### PR TITLE
Generate and upload an AppImage on each Travis CI run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ script:
   - qmake PREFIX=/usr -r
   - make -j4
   - sudo apt-get -y install checkinstall
+  - rm ../*.spec # Otherwise the next line fails
   - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
   - mkdir appdir ; cd appdir
   - dpkg -x ../app_1-1_amd64.deb . ; find .

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,20 @@ install:
     fi
 
 script:
-  - qmake -v
-  - qmake -r
-  - make
+  - qmake PREFIX=/usr -v
+  - qmake PREFIX=/usr -r
+  - make -j4
+  - sudo apt-get -y install checkinstall
+  - sudo checkinstall --pkgname=app --pkgversion="1" --backup=no --fstrans=no --default --deldoc 
+  - mkdir appdir ; cd appdir
+  - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - cp ../qt/leocad.desktop .
+  - cp ../resources/leocad.png .
+  - cd .. 
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage 
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/leocad -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/leocad -appimage 
+  - curl --upload-file ./LeoCAD-*.AppImage https://transfer.sh/LeoCAD-git.$(git rev-parse --short HEAD).qt$QT_BASE-x86_64.AppImage 
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
   - qmake PREFIX=/usr -r
   - make -j4
   - sudo apt-get -y install checkinstall
-  - sudo checkinstall --pkgname=app --pkgversion="1" --backup=no --fstrans=no --default --deldoc 
+  - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
   - mkdir appdir ; cd appdir
   - dpkg -x ../app_1-1_amd64.deb . ; find .
   - cp ../qt/leocad.desktop .

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
   - qmake PREFIX=/usr -r
   - make -j4
   - sudo apt-get -y install checkinstall
-  - rm ../*.spec # Otherwise the next line fails
+  - rm ./*.spec # Otherwise the next line fails
   - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
   - mkdir appdir ; cd appdir
   - dpkg -x ../app_1-1_amd64.deb . ; find .

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ script:
   - mkdir appdir ; cd appdir
   - dpkg -x ../app_1-1_amd64.deb . ; find .
   - cp ../qt/leocad.desktop .
+  - sed -i -e 's|\.svg||g' leocad.desktop # Workaround
   - cp ../resources/leocad.png .
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ script:
   - qmake PREFIX=/usr -v
   - qmake PREFIX=/usr -r
   - make -j4
+  - if [ "$TRAVIS_OS_NAME" != "linux" ] ; then exit 0 ; fi
   - sudo apt-get -y install checkinstall
   - rm ./*.spec # Otherwise the next line fails
   - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 


### PR DESCRIPTION
This PR, when merged, will generate and upload an [AppImage](http://appimage.org/) on each Travis CI run. __The download URL can be seen toward the end of each Travis CI build log.__

Providing an AppImage would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed
- Optional(!) desktop integration with `appimaged`
- Binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can GPG2-sign your AppImages (inside the file)

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.