### PR TITLE
Draw a dark gray border around color indicators in the time line.

### DIFF
--- a/common/lc_timelinewidget.cpp
+++ b/common/lc_timelinewidget.cpp
@@ -185,9 +185,9 @@ void lcTimelineWidget::Update(bool Clear, bool UpdateItems)
 				Image.fill(0);
 				float* Color = gColorList[ColorIndex].Value;
 				QPainter Painter(&Image);
-				Painter.setPen(Qt::NoPen);
+				Painter.setPen(Qt::darkGray);
 				Painter.setBrush(QColor::fromRgbF(Color[0], Color[1], Color[2]));
-				Painter.drawEllipse(QPoint(Size / 2, Size / 2), Size / 2, Size / 2);
+				Painter.drawEllipse(0, 0, Size - 1, Size - 1);
 
 				mIcons[ColorIndex] = QIcon(QPixmap::fromImage(Image));
 			}


### PR DESCRIPTION
This makes white, yellow and other colors more visible. In particular,
white entries do not look like absent against a white window background.

Due to the border, the circle must now be smaller by one pixel.