### PR TITLE
Draw gray bounds around more color indicators

### DIFF
--- a/qt/lc_qcolorlist.cpp
+++ b/qt/lc_qcolorlist.cpp
@@ -82,8 +82,12 @@ bool lcQColorList::event(QEvent *event)
 			lcColor* color = &gColorList[mCellColors[CellIdx]];
 			QRgb rgb = qRgb(color->Value[0] * 255, color->Value[1] * 255, color->Value[2] * 255);
 
-			QImage image(1, 1, QImage::Format_RGB888);
-			image.setPixel(0, 0, rgb);
+			QImage image(16, 16, QImage::Format_RGB888);
+			image.fill(rgb);
+			QPainter painter(&image);
+			painter.setPen(Qt::darkGray);
+			painter.drawRect(0, 0, image.width() - 1, image.height() - 1);
+			painter.end();
 
 			QByteArray ba;
 			QBuffer buffer(&ba);
@@ -91,7 +95,7 @@ bool lcQColorList::event(QEvent *event)
 			image.save(&buffer, "PNG");
 
 			int colorIndex = mCellColors[CellIdx];
-			const char* format = "<table><tr><td style=\"vertical-align:middle\"><img height=16 src=\"data:image/png;base64,%1\"></td><td>%2 (%3)</td></tr></table>";
+			const char* format = "<table><tr><td style=\"vertical-align:middle\"><img src=\"data:image/png;base64,%1\"/></td><td>%2 (%3)</td></tr></table>";
 			QString text = QString(format).arg(QString(buffer.data().toBase64()), gColorList[colorIndex].Name, QString::number(gColorList[colorIndex].Code));
 
 			QToolTip::showText(helpEvent->globalPos(), text);

--- a/qt/lc_qcolorpicker.cpp
+++ b/qt/lc_qcolorpicker.cpp
@@ -140,14 +140,15 @@ void lcQColorPicker::updateIcon()
 {
 	int iconSize = style()->pixelMetric(QStyle::PM_SmallIconSize);
 	QPixmap pix(iconSize, iconSize);
-	pix.fill(palette().button().color());
 
 	QPainter p(&pix);
 
 	lcColor* color = &gColorList[currentColorIndex];
-	QRgb rgb = qRgb(color->Value[0] * 255, color->Value[1] * 255, color->Value[2] * 255);
+	p.setPen(Qt::darkGray);
+	p.setBrush(QColor::fromRgbF(color->Value[0], color->Value[1], color->Value[2]));
+	p.drawRect(0, 0, pix.width() - 1, pix.height() - 1);
+	p.end();
 
-	p.fillRect(0, 0, pix.width(), pix.height(), rgb);
 	setIcon(QIcon(pix));
 }
 

--- a/qt/lc_qpropertiestree.cpp
+++ b/qt/lc_qpropertiestree.cpp
@@ -499,11 +499,11 @@ void lcQPropertiesTree::updateColorEditor(QPushButton *editor, int value) const
 	img.fill(0);
 
 	lcColor* color = &gColorList[value];
-	QRgb rgb = qRgb(color->Value[0] * 255, color->Value[1] * 255, color->Value[2] * 255);
-	QBrush b(rgb);
 	QPainter painter(&img);
 	painter.setCompositionMode(QPainter::CompositionMode_Source);
-	painter.fillRect(0, 0, img.width(), img.height(), b);
+	painter.setPen(Qt::darkGray);
+	painter.setBrush(QColor::fromRgbF(color->Value[0], color->Value[1], color->Value[2]));
+	painter.drawRect(0, 0, img.width() - 1, img.height() - 1);
 	painter.end();
 
 	editor->setStyleSheet("Text-align:left");
@@ -909,11 +909,11 @@ void lcQPropertiesTree::SetPiece(const lcArray<lcObject*>& Selection, lcObject* 
 	img.fill(0);
 
 	lcColor* color = &gColorList[ColorIndex];
-	QRgb rgb = qRgb(color->Value[0] * 255, color->Value[1] * 255, color->Value[2] * 255);
-	QBrush b(rgb);
 	QPainter painter(&img);
 	painter.setCompositionMode(QPainter::CompositionMode_Source);
-	painter.fillRect(0, 0, img.width(), img.height(), b);
+	painter.setPen(Qt::darkGray);
+	painter.setBrush(QColor::fromRgbF(color->Value[0], color->Value[1], color->Value[2]));
+	painter.drawRect(0, 0, img.width() - 1, img.height() - 1);
 	painter.end();
 
 	partColor->setIcon(1, QIcon(QPixmap::fromImage(img)));


### PR DESCRIPTION
There are color indicators in the piece properties and the minifig wizard. Draw bounds to delineate the color from the background to make it more visible if they are very similar.