### PR TITLE
Determine file size only of regular files.

### DIFF
--- a/common/lc_file.cpp
+++ b/common/lc_file.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include "lc_file.h"
 
 // =============================================================================
@@ -210,14 +211,11 @@ void lcDiskFile::SetLength(size_t NewLength)
 
 size_t lcDiskFile::GetLength() const
 {
-	long Length, Current;
+	struct stat st;
+	if (fstat(fileno(mFile), &st) < 0 || !S_ISREG(st.st_mode))
+		return 0;
 
-	Current = ftell(mFile);
-	fseek(mFile, 0, SEEK_END);
-	Length = ftell(mFile);
-	fseek(mFile, Current, SEEK_SET);
-
-	return Length;
+	return st.st_size;
 }
 
 void lcDiskFile::Flush()


### PR DESCRIPTION
lcDiskfile::Open() uses fopen() to open a file. On Linux, this can open
a directory just fine (at least for reading). This is slightly problematic
when it is attempted to open the parts library $(sharedir)/library.bin
and the library is an unzipped directory hierarchy. It is first attempted
to open the path as a ZIP file. While opening the directory as a file is
successful, subsequent navigation in the open "file" fails.

Pretend that a directory is an empty file so that the ZIP file reader is
not tempted to navigate around in the "file" and so reports failure in a
deterministic manner.

We could have inserted the check for regular files in lcDiskFile::Open(),
but this burdens every file open request, which can happen thousands of
times when the parts library is extracted instead of in a ZIP file.