### PR TITLE
Fix regular file check again.

### DIFF
--- a/common/lc_file.cpp
+++ b/common/lc_file.cpp
@@ -212,7 +212,7 @@ void lcDiskFile::SetLength(size_t NewLength)
 size_t lcDiskFile::GetLength() const
 {
 	struct stat st;
-	if (fstat(fileno(mFile), &st) < 0 || (st.st_mode & S_IFMT) == S_IFREG)
+	if (fstat(fileno(mFile), &st) < 0 || (st.st_mode & S_IFMT) != S_IFREG)
 		return 0;
 
 	return st.st_size;


### PR DESCRIPTION
The previous Windows fix accidentally reverted the logic of the check for
a regular file. As a consequence, ZIP files are not recognized anymore.