### PR TITLE
When copying the camera position, also copy the ortho state.

### DIFF
--- a/common/camera.cpp
+++ b/common/camera.cpp
@@ -473,6 +473,7 @@ void lcCamera::CopyPosition(const lcCamera* camera)
 	mPosition = camera->mPosition;
 	mTargetPosition = camera->mTargetPosition;
 	mUpVector = camera->mUpVector;
+	mState |= (camera->mState&LC_CAMERA_ORTHO);
 }
 
 void lcCamera::DrawInterface(lcContext* Context) const


### PR DESCRIPTION
Without this, the camera/viewpoint will reset to perspective when you least expect it. For example, when calling SaveStepImages, using the --image command line.

Maybe this isn't the right way to fix, but it seems reasonable to copy this when copying the camera?