### PR TITLE
Appveyor support added

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
- matrix:
-  - name: win32
-    platform: amd64_x86
-    qt: 5.6\msvc2015
+ environment:
+   matrix:
+    - name: win32
+      platform: amd64_x86
+      qt: 5.6\msvc2015
  
  init:
   - set PATH=C:\Qt\%qt%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,5 +9,6 @@
   - call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %platform%
  
  install:
+  - qmake -v
   - qmake
-  - %make%
+  - nmake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,9 @@
  
  init:
   - set PATH=C:\Qt\%qt%\bin;%PATH%
-  - call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %platform%
+  - call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
  
  install:
   - qmake -v
   - qmake
-  - nmake /k
+  - nmake /NOLOG

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@
  
  init:
   - set PATH=C:\Qt\%qt%\bin;%PATH%
+  - call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %platform%
  
  install:
   - qmake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
- version: 0.80.{build}
+ version: 17.02.{build}
  
  environment:
    matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+ matrix:
+  - name: win32
+    platform: amd64_x86
+    qt: 5.6\msvc2015
+ 
+ init:
+  - set PATH=C:\Qt\%qt%\bin;%PATH%
+ 
+ install:
+  - qmake
+  - nmake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
    matrix:
     - name: win32
       platform: amd64_x86
-      qt: 5.6\msvc2015
+      qt: 5.7\msvc2015
  
  init:
   - set PATH=C:\Qt\%qt%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+ version: 0.80.{build}
+ 
  environment:
    matrix:
     - name: win32
@@ -11,4 +13,4 @@
  install:
   - qmake -v
   - qmake
-  - nmake /NOLOG
+  - nmake /NOLOGO

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,4 +11,4 @@
  install:
   - qmake -v
   - qmake
-  - nmake
+  - nmake /k

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,4 +9,4 @@
  
  install:
   - qmake
-  - nmake
+  - %make%

--- a/leocad.pro
+++ b/leocad.pro
@@ -9,7 +9,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 INCLUDEPATH += qt common
 CONFIG += precompile_header incremental c++11
 win32 { 
-	PRECOMPILED_HEADER = lc_global.h
+	PRECOMPILED_HEADER = common/lc_global.h
 	QMAKE_CXXFLAGS_WARN_ON += -wd4100
 	DEFINES += _CRT_SECURE_NO_WARNINGS _CRT_SECURE_NO_DEPRECATE=1 _CRT_NONSTDC_NO_WARNINGS=1
 	greaterThan(QT_MAJOR_VERSION, 4) {


### PR DESCRIPTION
I had to add directory name to lc_global.h in leocad.pro

Still get link error on appveyor:

qtmain.obj : error LNK2019: unresolved external symbol __imp__MessageBoxW@16 referenced in function "long __stdcall lcSehHandler(struct _EXCEPTION_POINTERS *)" (?lcSehHandler@@YGJPAU_EXCEPTION_POINTERS@@@Z)