### PR TITLE
OSX is named macOS since last year

### DIFF
--- a/download.html
+++ b/download.html
@@ -36,9 +36,9 @@
         <p>LeoCAD is available directly from several distributions, so you may want to search for it in your package manager first. If you can't find it, you'll have to download the source code and compile your own binary.</p>
         <p>If you don't have the LDraw Parts Library installed you'll need to download it and extract the zip file to /usr/share/leocad.</p>
         <div class="buttons-unit downloads"><a href="https://github.com/leozide/leocad/releases" class="button">Latest LeoCAD Release</a></div>
-        <h2>OSX</h2>
+        <h2>macOS</h2>
         <p>Click the button below to download the latest version of the LeoCAD dmg package. Once the download is complete open the package and drag its contents to your Applications folder.</p>
-        <div class="buttons-unit downloads"><a href="https://github.com/leozide/leocad/releases/download/v17.07/LeoCAD-MacOSX-17.07-9781.dmg" class="button">Download LeoCAD for OSX</a></div>
+        <div class="buttons-unit downloads"><a href="https://github.com/leozide/leocad/releases/download/v17.07/LeoCAD-MacOSX-17.07-9781.dmg" class="button">Download LeoCAD for macOS</a></div>
         </div>
       </section>
 <!-- footer start -->


### PR DESCRIPTION
This updates the download page to use the correct name.