### PR TITLE
Moved recent files to "Open Recent" submenu (#216)

### DIFF
--- a/common/lc_mainwindow.cpp
+++ b/common/lc_mainwindow.cpp
@@ -419,6 +419,11 @@ void lcMainWindow::CreateMenus()
 	QMenu* FileMenu = menuBar()->addMenu(tr("&File"));
 	FileMenu->addAction(mActions[LC_FILE_NEW]);
 	FileMenu->addAction(mActions[LC_FILE_OPEN]);
+	QMenu* RecentMenu = FileMenu->addMenu(tr("Open Recent"));
+	RecentMenu->addAction(mActions[LC_FILE_RECENT1]);
+	RecentMenu->addAction(mActions[LC_FILE_RECENT2]);
+	RecentMenu->addAction(mActions[LC_FILE_RECENT3]);
+	RecentMenu->addAction(mActions[LC_FILE_RECENT4]);
 	FileMenu->addAction(mActions[LC_FILE_MERGE]);
 	FileMenu->addSeparator();
 	FileMenu->addAction(mActions[LC_FILE_SAVE]);
@@ -443,11 +448,6 @@ void lcMainWindow::CreateMenus()
 	FileMenu->addAction(mActions[LC_FILE_PRINT_PREVIEW]);
 //	FileMenu->addAction(mActions[LC_FILE_PRINT_BOM]);
 	FileMenu->addSeparator();
-	FileMenu->addAction(mActions[LC_FILE_RECENT1]);
-	FileMenu->addAction(mActions[LC_FILE_RECENT2]);
-	FileMenu->addAction(mActions[LC_FILE_RECENT3]);
-	FileMenu->addAction(mActions[LC_FILE_RECENT4]);
-	mActionFileRecentSeparator = FileMenu->addSeparator();
 	FileMenu->addAction(mActions[LC_FILE_EXIT]);
 
 	QMenu* EditMenu = menuBar()->addMenu(tr("&Edit"));
@@ -2076,8 +2076,6 @@ void lcMainWindow::UpdateRecentFiles()
 		else
 			Action->setVisible(false);
 	}
-
-	mActionFileRecentSeparator->setVisible(!mRecentFiles[0].isEmpty());
 }
 
 void lcMainWindow::UpdateShortcuts()

--- a/common/lc_mainwindow.h
+++ b/common/lc_mainwindow.h
@@ -373,8 +373,6 @@ protected:
 	lcSelectionMode mSelectionMode;
 	int mModelTabWidgetContextMenuIndex;
 
-	QAction* mActionFileRecentSeparator;
-
 	lcTabWidget* mModelTabWidget;
 	QToolBar* mStandardToolBar;
 	QToolBar* mToolsToolBar;


### PR DESCRIPTION
Partial implementation for #216. There is no mnemonic for the "Open Recent"
submenu, and the submenu is not hidden or disabled if there are no recent
files.