### PR TITLE
Allow building without Qt gamepad module

### DIFF
--- a/common/lc_mainwindow.cpp
+++ b/common/lc_mainwindow.cpp
@@ -24,8 +24,6 @@
 #include "lc_colors.h"
 #include <functional>
 
-#define LC_ENABLE_GAMEPAD (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
-
 #if LC_ENABLE_GAMEPAD
 #include <QtGamepad/QGamepad>
 #endif

--- a/leocad.pro
+++ b/leocad.pro
@@ -8,7 +8,10 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 
 equals(QT_MAJOR_VERSION, 5) {
     greaterThan(QT_MINOR_VERSION, 11) {
-		QT += gamepad
+		qtHaveModule(gamepad) {
+			QT += gamepad
+			DEFINES += LC_ENABLE_GAMEPAD
+		}
 	}
 }
 


### PR DESCRIPTION
Hi. It's a simple fix for systems where the Qt gamepad module is not installed. Didn't test it *with* this module installed. I don't know Qt history, maybe the version check can be now removed.