### PR TITLE
Some improvements

### DIFF
--- a/common/lc_mainwindow.cpp
+++ b/common/lc_mainwindow.cpp
@@ -31,6 +31,26 @@
 lcMainWindow* gMainWindow;
 #define LC_TAB_LAYOUT_VERSION 0x0001
 
+void lcTabBar::mouseReleaseEvent(QMouseEvent *event)
+{
+	if (event->type() == QEvent::MouseButtonRelease && event->button() == Qt::MidButton)
+		tabCloseRequested(tabAt(event->pos()));
+	else
+		QTabBar::mouseReleaseEvent(event);
+}
+
+lcTabWidget::lcTabWidget()
+	: QTabWidget()
+{
+	setTabBar(new lcTabBar());
+}
+
+lcTabWidget::~lcTabWidget()
+{
+	if (tabBar())
+		delete tabBar();
+}
+
 void lcModelTabWidget::ResetLayout()
 {
 	QLayout* TabLayout = layout();

--- a/common/lc_mainwindow.h
+++ b/common/lc_mainwindow.h
@@ -30,18 +30,24 @@ struct lcSearchOptions
 	char Name[256];
 };
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
-typedef QTabWidget lcTabWidget;
-#else
+class lcTabBar : public QTabBar
+{
+protected:
+	void mouseReleaseEvent(QMouseEvent *event);
+};
+
 class lcTabWidget : public QTabWidget
 {
 public:
+	lcTabWidget();
+	~lcTabWidget();
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
 	QTabBar* tabBar()
 	{
 		return QTabWidget::tabBar();
 	}
-};
 #endif
+};
 
 class lcModelTabWidget : public QWidget
 {

--- a/common/lc_mesh.cpp
+++ b/common/lc_mesh.cpp
@@ -176,7 +176,7 @@ void lcMesh::CreateBox()
 }
 
 template<typename IndexType>
-bool lcMesh::MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDistance)
+bool lcMesh::MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDistance, lcVector3& Intersection)
 {
 	float Distance;
 	if (!lcBoundingBoxRayIntersectDistance(mBoundingBox.Min, mBoundingBox.Max, Start, End, &Distance, nullptr) || (Distance >= MinDistance))
@@ -184,7 +184,7 @@ bool lcMesh::MinIntersectDist(const lcVector3& Start, const lcVector3& End, floa
 
 	lcVertex* Verts = (lcVertex*)mVertexData;
 	bool Hit = false;
-	lcVector3 Intersection;
+	lcVector3 TriangleIntersection;
 
 	for (int SectionIdx = 0; SectionIdx < mLods[LC_MESH_LOD_HIGH].NumSections; SectionIdx++)
 	{
@@ -201,20 +201,23 @@ bool lcMesh::MinIntersectDist(const lcVector3& Start, const lcVector3& End, floa
 			const lcVector3& v2 = Verts[Indices[Idx + 1]].Position;
 			const lcVector3& v3 = Verts[Indices[Idx + 2]].Position;
 
-			if (lcLineTriangleMinIntersection(v1, v2, v3, Start, End, &MinDistance, &Intersection))
+			if (lcLineTriangleMinIntersection(v1, v2, v3, Start, End, &MinDistance, &TriangleIntersection))
+			{
+				Intersection = TriangleIntersection;
 				Hit = true;
+			}
 		}
 	}
 
 	return Hit;
 }
 
-bool lcMesh::MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDist)
+bool lcMesh::MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDist, lcVector3& Intersection)
 {
 	if (mIndexType == GL_UNSIGNED_SHORT)
-		return MinIntersectDist<GLushort>(Start, End, MinDist);
+		return MinIntersectDist<GLushort>(Start, End, MinDist, Intersection);
 	else
-		return MinIntersectDist<GLuint>(Start, End, MinDist);
+		return MinIntersectDist<GLuint>(Start, End, MinDist, Intersection);
 }
 
 template<typename IndexType>

--- a/common/lc_mesh.h
+++ b/common/lc_mesh.h
@@ -71,8 +71,8 @@ public:
 	void ExportWavefrontIndices(lcFile& File, int DefaultColorIndex, int VertexOffset);
 
 	template<typename IndexType>
-	bool MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDist);
-	bool MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDist);
+	bool MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDist, lcVector3& Intersection);
+	bool MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDist, lcVector3& Intersection);
 
 	template<typename IndexType>
 	bool IntersectsPlanes(const lcVector4 Planes[6]);

--- a/common/lc_model.cpp
+++ b/common/lc_model.cpp
@@ -1453,7 +1453,7 @@ void lcModel::BoxTest(lcObjectBoxTest& ObjectBoxTest) const
 			Light->BoxTest(ObjectBoxTest);
 }
 
-bool lcModel::SubModelMinIntersectDist(const lcVector3& WorldStart, const lcVector3& WorldEnd, float& MinDistance) const
+bool lcModel::SubModelMinIntersectDist(const lcVector3& WorldStart, const lcVector3& WorldEnd, float& MinDistance, lcVector3& Intersection) const
 {
 	bool MinIntersect = false;
 
@@ -1463,7 +1463,7 @@ bool lcModel::SubModelMinIntersectDist(const lcVector3& WorldStart, const lcVect
 		lcVector3 Start = lcMul31(WorldStart, InverseWorldMatrix);
 		lcVector3 End = lcMul31(WorldEnd, InverseWorldMatrix);
 
-		if (Piece->IsVisibleInSubModel() && Piece->mPieceInfo->MinIntersectDist(Start, End, MinDistance)) // todo: this should check for piece->mMesh first
+		if (Piece->IsVisibleInSubModel() && Piece->mPieceInfo->MinIntersectDist(Start, End, MinDistance, Intersection)) // todo: this should check for piece->mMesh first
 			MinIntersect = true;
 	}
 

--- a/common/lc_model.h
+++ b/common/lc_model.h
@@ -240,7 +240,7 @@ public:
 
 	void RayTest(lcObjectRayTest& ObjectRayTest) const;
 	void BoxTest(lcObjectBoxTest& ObjectBoxTest) const;
-	bool SubModelMinIntersectDist(const lcVector3& WorldStart, const lcVector3& WorldEnd, float& MinDistance) const;
+	bool SubModelMinIntersectDist(const lcVector3& WorldStart, const lcVector3& WorldEnd, float& MinDistance, lcVector3& Intersection) const;
 	bool SubModelBoxTest(const lcVector4 Planes[6]) const;
 
 	bool AnyPiecesSelected() const;

--- a/common/object.h
+++ b/common/object.h
@@ -24,6 +24,7 @@ struct lcObjectSection
 {
 	lcObject* Object;
 	quint32 Section;
+	lcVector3 Intersection;
 };
 
 struct lcObjectRayTest

--- a/common/piece.cpp
+++ b/common/piece.cpp
@@ -722,6 +722,14 @@ void lcPiece::MoveSelected(lcStep Step, bool AddKey, const lcVector3& Distance)
 			lcMatrix44& Transform = mControlPoints[ControlPointIndex].Transform;
 
 			Transform.SetTranslation(Transform.GetTranslation() + lcMul(Distance, InverseWorldMatrix));
+
+			lcVector3 OldCenterPosition = mModelWorld.GetTranslation();
+			lcVector3 ControlPointsCenter = OldCenterPosition + mControlPoints[0].Transform.GetTranslation();
+			for (int c = 1; c < mControlPoints.GetSize(); c++)
+				ControlPointsCenter += (mControlPoints[c].Transform.GetTranslation() - mControlPoints[c-1].Transform.GetTranslation()) / 2;
+			for (int c = 0; c < mControlPoints.GetSize(); c++)
+				mControlPoints[c].Transform.SetTranslation(mControlPoints[c].Transform.GetTranslation() - ControlPointsCenter + OldCenterPosition);
+			this->SetPosition(ControlPointsCenter, Step, AddKey);
 		}
 
 		UpdateMesh();

--- a/common/piece.cpp
+++ b/common/piece.cpp
@@ -469,13 +469,13 @@ void lcPiece::RayTest(lcObjectRayTest& ObjectRayTest) const
 
 	if (mMesh)
 	{
-		if (mMesh->MinIntersectDist(Start, End, ObjectRayTest.Distance))
+		if (mMesh->MinIntersectDist(Start, End, ObjectRayTest.Distance, ObjectRayTest.ObjectSection.Intersection))
 		{
 			ObjectRayTest.ObjectSection.Object = const_cast<lcPiece*>(this);
 			ObjectRayTest.ObjectSection.Section = LC_PIECE_SECTION_POSITION;
 		}
 	}
-	else if (mPieceInfo->MinIntersectDist(Start, End, ObjectRayTest.Distance))
+	else if (mPieceInfo->MinIntersectDist(Start, End, ObjectRayTest.Distance, ObjectRayTest.ObjectSection.Intersection))
 	{
 		ObjectRayTest.ObjectSection.Object = const_cast<lcPiece*>(this);
 		ObjectRayTest.ObjectSection.Section = LC_PIECE_SECTION_POSITION;
@@ -493,12 +493,14 @@ void lcPiece::RayTest(lcObjectRayTest& ObjectRayTest) const
 			lcVector3 PointEnd = lcMul31(End, InverseTransform);
 
 			float Distance;
-			if (!lcBoundingBoxRayIntersectDistance(Min, Max, PointStart, PointEnd, &Distance, nullptr) || (Distance >= ObjectRayTest.Distance))
+			lcVector3 Intersection;
+			if (!lcBoundingBoxRayIntersectDistance(Min, Max, PointStart, PointEnd, &Distance, &Intersection) || (Distance >= ObjectRayTest.Distance))
 				continue;
 
 			ObjectRayTest.ObjectSection.Object = const_cast<lcPiece*>(this);
 			ObjectRayTest.ObjectSection.Section = LC_PIECE_SECTION_CONTROL_POINT_1 + ControlPointIdx;
 			ObjectRayTest.Distance = Distance;
+			ObjectRayTest.ObjectSection.Intersection = Intersection;
 		}
 	}
 }

--- a/common/pieceinf.cpp
+++ b/common/pieceinf.cpp
@@ -194,7 +194,7 @@ void PieceInfo::Unload()
 	}
 }
 
-bool PieceInfo::MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDistance) const
+bool PieceInfo::MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDistance, lcVector3& Intersection) const
 {
 	bool Intersect = false;
 
@@ -208,17 +208,17 @@ bool PieceInfo::MinIntersectDist(const lcVector3& Start, const lcVector3& End, f
 			return true;
 
 		if (mFlags & LC_PIECE_MODEL)
-			Intersect |= mModel->SubModelMinIntersectDist(Start, End, MinDistance);
+			Intersect |= mModel->SubModelMinIntersectDist(Start, End, MinDistance, Intersection);
 		else if (mFlags & LC_PIECE_PROJECT)
 		{
 			lcModel* Model = mProject->GetMainModel();
 			if (Model)
-				Intersect |= Model->SubModelMinIntersectDist(Start, End, MinDistance);
+				Intersect |= Model->SubModelMinIntersectDist(Start, End, MinDistance, Intersection);
 		}
 	}
 
 	if (mMesh)
-		Intersect = mMesh->MinIntersectDist(Start, End, MinDistance);
+		Intersect = mMesh->MinIntersectDist(Start, End, MinDistance, Intersection);
 
 	return Intersect;
 }

--- a/common/pieceinf.h
+++ b/common/pieceinf.h
@@ -145,7 +145,7 @@ public:
 	void CreateProject(Project* Project, const char* PieceName);
 	bool GetPieceWorldMatrix(lcPiece* Piece, lcMatrix44& WorldMatrix) const;
 	bool IncludesModel(const lcModel* Model) const;
-	bool MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDistance) const;
+	bool MinIntersectDist(const lcVector3& Start, const lcVector3& End, float& MinDistance, lcVector3& Intersection) const;
 	bool BoxTest(const lcMatrix44& WorldMatrix, const lcVector4 Planes[6]) const;
 	void GetPartsList(int DefaultColorIndex, bool IncludeSubmodels, lcPartsList& PartsList) const;
 	void GetModelParts(const lcMatrix44& WorldMatrix, int DefaultColorIndex, lcArray<lcModelPartsEntry>& ModelParts) const;

--- a/common/view.cpp
+++ b/common/view.cpp
@@ -563,12 +563,14 @@ lcVector3 View::GetMoveDirection(const lcVector3& Direction) const
 
 lcMatrix44 View::GetPieceInsertPosition(bool IgnoreSelected, PieceInfo* Info) const
 {
-	lcPiece* HitPiece = (lcPiece*)FindObjectUnderPointer(true, IgnoreSelected).Object;
+	lcObjectSection ObjectSection = FindObjectUnderPointer(true, IgnoreSelected);
+	lcPiece* HitPiece = (lcPiece*)ObjectSection.Object;
 	lcModel* ActiveModel = GetActiveModel();
 
 	if (HitPiece)
 	{
-		lcVector3 Position(0, 0, HitPiece->GetBoundingBox().Max.z - Info->GetBoundingBox().Min.z);
+		lcVector3 Position(ObjectSection.Intersection);
+		Position.z += -Info->GetBoundingBox().Min.z;
 
 		if (gMainWindow->GetRelativeTransform())
 			Position = lcMul31(ActiveModel->SnapPosition(Position), HitPiece->mModelWorld);


### PR DESCRIPTION
- using middle mouse button to close tabs is a well known feature from browsers

- placing pieces uses the intersection point, it was known before but unused

This improves placing pieces on each other significantly since you can slide them around, while sitll using the grid

- last but not least i made the center/focus point of synth parts to stay in the center of its control points

This improves handling, since the focus point is not offcarried and you struggle to pan and orbit around the item, if you once moved the control points.

Before:
![image](https://user-images.githubusercontent.com/4201214/54525012-8f8d9c80-4973-11e9-9704-6692e5b3ada2.png)

After:
![image](https://user-images.githubusercontent.com/4201214/54524918-5ce3a400-4973-11e9-81c9-9c4d66dbb292.png)
