### PR TITLE
Update to improved render dialog

### DIFF
--- a/qt/lc_renderdialog.h
+++ b/qt/lc_renderdialog.h
@@ -22,6 +22,7 @@ public slots:
 
 protected slots:
 	void ReadStdErr();
+	void WriteStdLog(bool = false);
 
 protected:
 	QString GetOutputFileName() const;


### PR DESCRIPTION
While commit 477dc1c616 [Improve render dialog. Fixes #160] does add some improvements, it also took away the POV-Ray image render progress display  when `setPixmap(...)` was moved from `Update()` to `ShowResult()` which is only called at process completion or if there is an error. This improvement seems to target Linux but affects all platforms. The POV-Ray image render progress display will only show when the memory mapped file is in use, i.e. on Windows and macOS.

Also, the `readyReadStandardError()` signal does not seem to be consistently caught on Windows (I haven't tested macOS) so the new progress bar display does not consistently update when an image is being rendered. If this works as expected on Linux, the connect statement in `on_RenderButton_Clicked()` and the progress update in `ReadStdErr()` should be encased in a `#ifdef Q_OS_LINUX` macro. 

For Window and macOS, which uses the memory mapped file, it is much better to update the progress bar from `Update()` using `mImage.width() * mImage.height()` to set the progress bar _maximum_ and `Header->PixelsRead` to set the _value_.

Lastly, it could be good to write stdout/stderr to file giving users the ability to review the render details.

The updates mentioned above are captured in this PR. The screenshot below show these updates producing both a consistent progress bar update and the image render progress when using the memory mapped file.

![Screenshot - 19_03_2019 , 13_38_55](https://user-images.githubusercontent.com/13388970/54607383-8291ab80-4a4e-11e9-90aa-d92c957db546.png)

Cheers,