### PR TITLE
Fix two issues with pivot points

### DIFF
--- a/common/piece.cpp
+++ b/common/piece.cpp
@@ -44,7 +44,9 @@ lcPiece::lcPiece(const lcPiece& Other)
 	mStepHide = Other.mStepHide;
 	mGroup = Other.mGroup;
 	mFileLine = -1;
+
 	mPivotMatrix = Other.mPivotMatrix;
+	mState |= ( Other.mState & LC_PIECE_PIVOT_POINT_VALID );
 
 	mPositionKeys = Other.mPositionKeys;
 	mRotationKeys = Other.mRotationKeys;

--- a/common/piece.h
+++ b/common/piece.h
@@ -535,6 +535,7 @@ public:
 	void ResetPivotPoint()
 	{
 		mState &= ~LC_PIECE_PIVOT_POINT_VALID;
+		mPivotMatrix = lcMatrix44Identity();
 	}
 
 public:


### PR DESCRIPTION
This pull request fixes two small bugs related to pivot points:

- `ResetPivotPoint()` now truely resets the pivot point (and not only invalidates it).
- The copy constructor of `lcPiece` now also copies the state of the pivot point. Thus, duplicating pieces also duplicates the pivot points.