### PR TITLE
Change stud logo without application restart

### DIFF
--- a/common/lc_application.cpp
+++ b/common/lc_application.cpp
@@ -347,7 +347,11 @@ bool lcApplication::Initialize(QList<QPair<QString, bool>>& LibraryPaths, bool& 
 		else if (Param == QLatin1String("-sl") || Param == QLatin1String("--stud-logo"))
 		{
 			ParseInteger(StudLogo);
-			lcSetProfileInt(LC_PROFILE_STUD_LOGO, StudLogo);
+			if (StudLogo != lcGetProfileInt(LC_PROFILE_STUD_LOGO))
+			{
+				lcSetProfileInt(LC_PROFILE_STUD_LOGO, StudLogo);
+				lcGetPiecesLibrary()->mReloadStudLogo = true;
+			}
 		}
 		else if (Param == QLatin1String("-obj") || Param == QLatin1String("--export-wavefront"))
 		{
@@ -703,7 +707,7 @@ void lcApplication::ShowPreferencesDialog()
 	lcSetProfileInt(LC_PROFILE_ANTIALIASING_SAMPLES, Options.AASamples);
 	lcSetProfileInt(LC_PROFILE_STUD_LOGO, Options.StudLogo);
 
-	if (LibraryChanged || ColorsChanged || AAChanged || StudLogoChanged)
+	if (LibraryChanged || ColorsChanged || AAChanged)
 		QMessageBox::information(gMainWindow, tr("LeoCAD"), tr("Some changes will only take effect the next time you start LeoCAD."));
 
 	if (Options.CategoriesModified)
@@ -741,6 +745,14 @@ void lcApplication::ShowPreferencesDialog()
 			gMouseShortcuts = Options.MouseShortcuts;
 			lcSaveDefaultMouseShortcuts();
 		}
+	}
+
+	if (StudLogoChanged) 
+	{
+		lcGetPiecesLibrary()->mReloadStudLogo = true;
+		QString ProjectName = lcGetProfileString(LC_PROFILE_RECENT_FILE1);
+		if (!ProjectName.isEmpty())
+			gMainWindow->OpenProject(ProjectName);
 	}
 
 	// TODO: printing preferences

--- a/common/lc_application.cpp
+++ b/common/lc_application.cpp
@@ -349,8 +349,7 @@ bool lcApplication::Initialize(QList<QPair<QString, bool>>& LibraryPaths, bool& 
 			ParseInteger(StudLogo);
 			if (StudLogo != lcGetProfileInt(LC_PROFILE_STUD_LOGO))
 			{
-				lcSetProfileInt(LC_PROFILE_STUD_LOGO, StudLogo);
-				lcGetPiecesLibrary()->mReloadStudLogo = true;
+				lcGetPiecesLibrary()->SetStudLogo(StudLogo);
 			}
 		}
 		else if (Param == QLatin1String("-obj") || Param == QLatin1String("--export-wavefront"))
@@ -749,7 +748,7 @@ void lcApplication::ShowPreferencesDialog()
 
 	if (StudLogoChanged) 
 	{
-		lcGetPiecesLibrary()->mReloadStudLogo = true;
+		lcGetPiecesLibrary()->SetStudLogo(Options.StudLogo);
 		QString ProjectName = lcGetProfileString(LC_PROFILE_RECENT_FILE1);
 		if (!ProjectName.isEmpty())
 			gMainWindow->OpenProject(ProjectName);

--- a/common/lc_library.h
+++ b/common/lc_library.h
@@ -45,6 +45,7 @@ public:
 		mState = lcPrimitiveState::NOT_LOADED;
 		mStud = Stud;
 		mSubFile = SubFile;
+		mHasLogoStud = false;
 	}
 
 	void SetZipFile(lcZipFileType ZipFileType, quint32 ZipFileIndex)
@@ -60,6 +61,7 @@ public:
 	lcPrimitiveState mState;
 	bool mStud;
 	bool mSubFile;
+	bool mHasLogoStud;
 	lcLibraryMeshData mMeshData;
 };
 
@@ -113,7 +115,7 @@ public:
 
 	bool LoadPrimitive(lcLibraryPrimitive* Primitive);
 
-    bool GetStudLogo(lcMemFile& PrimFile, int StudLogo, bool OpenStud = false);
+	bool GetStudLogo(lcMemFile& PrimFile, int StudLogo, bool OpenStud = false);
 
 	void SetOfficialPieces()
 	{
@@ -138,6 +140,7 @@ public:
 
 	QDir mLibraryDir;
 
+	bool mReloadStudLogo;
 	bool mBuffersDirty;
 	lcVertexBuffer mVertexBuffer;
 	lcIndexBuffer mIndexBuffer;

--- a/common/lc_library.h
+++ b/common/lc_library.h
@@ -45,7 +45,7 @@ public:
 		mState = lcPrimitiveState::NOT_LOADED;
 		mStud = Stud;
 		mSubFile = SubFile;
-		mHasLogoStud = false;
+		mReloadStudLogo = false;
 	}
 
 	void SetZipFile(lcZipFileType ZipFileType, quint32 ZipFileIndex)
@@ -61,7 +61,7 @@ public:
 	lcPrimitiveState mState;
 	bool mStud;
 	bool mSubFile;
-	bool mHasLogoStud;
+	bool mReloadStudLogo;
 	lcLibraryMeshData mMeshData;
 };
 
@@ -116,6 +116,8 @@ public:
 	bool LoadPrimitive(lcLibraryPrimitive* Primitive);
 
 	bool GetStudLogo(lcMemFile& PrimFile, int StudLogo, bool OpenStud = false);
+
+	void SetStudLogo(int StudLogo);
 
 	void SetOfficialPieces()
 	{

--- a/common/lc_meshloader.cpp
+++ b/common/lc_meshloader.cpp
@@ -1623,6 +1623,19 @@ bool lcMeshLoader::ReadMeshData(lcFile& File, const lcMatrix44& CurrentTransform
 
 			if (Primitive)
 			{
+				if (Primitive->mStud  &&
+				   (mMeshData.mHasLogoStud = Primitive->mHasLogoStud =
+				   (!strcmp(Primitive->mName,"stud2.dat") ||
+					!strcmp(Primitive->mName,"stud.dat"))))
+				{
+					if (Primitive->mState == lcPrimitiveState::LOADED &&
+						Primitive->mHasLogoStud && Library->mReloadStudLogo)
+					{
+						Primitive->mState = lcPrimitiveState::NOT_LOADED;
+						Primitive->mMeshData.RemoveAll();
+					}
+				}
+
 				if (Primitive->mState != lcPrimitiveState::LOADED && !Library->LoadPrimitive(Primitive))
 					break;
 

--- a/common/lc_meshloader.cpp
+++ b/common/lc_meshloader.cpp
@@ -1624,23 +1624,21 @@ bool lcMeshLoader::ReadMeshData(lcFile& File, const lcMatrix44& CurrentTransform
 			if (Primitive)
 			{
 				if (Primitive->mStud  &&
-				   (mMeshData.mHasLogoStud = Primitive->mHasLogoStud =
-				   (!strcmp(Primitive->mName,"stud2.dat") ||
-					!strcmp(Primitive->mName,"stud.dat"))))
+					Primitive->mReloadStudLogo &&
+					Primitive->mState == lcPrimitiveState::LOADED )
 				{
-					if (Primitive->mState == lcPrimitiveState::LOADED &&
-						Primitive->mHasLogoStud && Library->mReloadStudLogo)
-					{
-						Primitive->mState = lcPrimitiveState::NOT_LOADED;
-						Primitive->mMeshData.RemoveAll();
-					}
+					Primitive->mMeshData.RemoveAll();
+					Primitive->mState = lcPrimitiveState::NOT_LOADED;
 				}
 
 				if (Primitive->mState != lcPrimitiveState::LOADED && !Library->LoadPrimitive(Primitive))
 					break;
 
 				if (Primitive->mStud)
+				{
+					mMeshData.mHasLogoStud = !strcmp(Primitive->mName,"stud2.dat") || !strcmp(Primitive->mName,"stud.dat");
 					mMeshData.AddMeshDataNoDuplicateCheck(Primitive->mMeshData, IncludeTransform, ColorCode, Mirror ^ InvertNext, InvertNext, TextureMap, MeshDataType);
+				}
 				else if (!Primitive->mSubFile)
 				{
 					if (mOptimize)

--- a/common/lc_meshloader.h
+++ b/common/lc_meshloader.h
@@ -97,6 +97,7 @@ public:
 	lcLibraryMeshData()
 	{
 		mHasTextures = false;
+		mHasLogoStud = false;
 
 		for (int MeshDataIdx = 0; MeshDataIdx < LC_NUM_MESHDATA_TYPES; MeshDataIdx++)
 			mVertices[MeshDataIdx].SetGrow(1024);
@@ -117,6 +118,17 @@ public:
 		return true;
 	}
 
+	void RemoveAll()
+	{
+		for (int MeshDataIdx = 0; MeshDataIdx < LC_NUM_MESHDATA_TYPES; MeshDataIdx++)
+			mVertices[MeshDataIdx].RemoveAll();
+
+		for (int MeshDataIdx = 0; MeshDataIdx < LC_NUM_MESHDATA_TYPES; MeshDataIdx++)
+			mSections[MeshDataIdx].RemoveAll();
+
+		mHasTextures = false;
+	}
+
 	lcMesh* CreateMesh();
 	lcLibraryMeshSection* AddSection(lcMeshDataType MeshDataType, lcMeshPrimitiveType PrimitiveType, quint32 ColorCode, lcTexture* Texture);
 	quint32 AddVertex(lcMeshDataType MeshDataType, const lcVector3& Position, bool Optimize);
@@ -135,6 +147,7 @@ public:
 	lcArray<lcLibraryMeshSection*> mSections[LC_NUM_MESHDATA_TYPES];
 	lcArray<lcLibraryMeshVertex> mVertices[LC_NUM_MESHDATA_TYPES];
 	bool mHasTextures;
+	bool mHasLogoStud;
 };
 
 class lcMeshLoader

--- a/common/pieceinf.cpp
+++ b/common/pieceinf.cpp
@@ -25,6 +25,7 @@ PieceInfo::PieceInfo()
 	mModel = nullptr;
 	mProject = nullptr;
 	mSynthInfo = nullptr;
+	mHasLogoStud = false;
 }
 
 PieceInfo::~PieceInfo()

--- a/common/pieceinf.h
+++ b/common/pieceinf.h
@@ -169,6 +169,7 @@ public:
 	lcPieceInfoState mState;
 	int mFolderType;
 	int mFolderIndex;
+	bool mHasLogoStud;
 
 protected:
 	void ReleaseMesh();

--- a/common/project.cpp
+++ b/common/project.cpp
@@ -453,6 +453,8 @@ bool Project::Load(const QString& FileName)
 		Model->UpdatePieceInfo(UpdatedModels);
 	}
 
+	lcGetPiecesLibrary()->mReloadStudLogo = false;
+
 	mModified = false;
 
 	return true;


### PR DESCRIPTION
I found having to restart after changing the logo a bit annoying. This patch automatically updates the stud primitive mesh data and reloads the current project when a stud logo change is detected. 