### PR TITLE
Synthesis of Technic Universal Joints

### DIFF
--- a/common/lc_model.cpp
+++ b/common/lc_model.cpp
@@ -684,6 +684,7 @@ void lcModel::LoadLDraw(QIODevice& Device, Project* Project)
 				Piece->SetPieceInfo(Info, PartId, false);
 				Piece->Initialize(Transform, CurrentStep);
 				Piece->SetColorCode(ColorCode);
+				Piece->VerifyControlPoints(ControlPoints);
 				Piece->SetControlPoints(ControlPoints);
 				AddPiece(Piece);
 				Piece = nullptr;

--- a/common/lc_synth.cpp
+++ b/common/lc_synth.cpp
@@ -17,6 +17,36 @@ protected:
 	void CalculateSections(const lcArray<lcPieceControlPoint>& ControlPoints, lcArray<lcMatrix44>& Sections, SectionCallbackFunc SectionCallback) const override;
 };
 
+class lcSynthInfoFlexibleHose : public lcSynthInfoCurved
+{
+public:
+	lcSynthInfoFlexibleHose(float Length, int NumSections, PieceInfo* Info);
+};
+
+class lcSynthInfoFlexSystemHose : public lcSynthInfoCurved
+{
+public:
+	lcSynthInfoFlexSystemHose(float Length, int NumSections, PieceInfo* Info);
+};
+
+class lcSynthInfoRibbedHose : public lcSynthInfoCurved
+{
+public:
+	lcSynthInfoRibbedHose(float Length, int NumSections, PieceInfo* Info);
+};
+
+class lcSynthInfoFlexibleAxle : public lcSynthInfoCurved
+{
+public:
+	lcSynthInfoFlexibleAxle(float Length, int NumSections, PieceInfo* Info);
+};
+
+class lcSynthInfoBraidedString : public lcSynthInfoCurved
+{
+public:
+	lcSynthInfoBraidedString(float Length, int NumSections, PieceInfo* Info);
+};
+
 class lcSynthInfoStraight : public lcSynthInfo
 {
 public:
@@ -26,6 +56,18 @@ protected:
 	void CalculateSections(const lcArray<lcPieceControlPoint>& ControlPoints, lcArray<lcMatrix44>& Sections, SectionCallbackFunc SectionCallback) const override;
 };
 
+class lcSynthInfoShockAbsorber : public lcSynthInfoStraight
+{
+public:
+	lcSynthInfoShockAbsorber(float Length, PieceInfo* Info);
+};
+
+class lcSynthInfoActuator : public lcSynthInfoStraight
+{
+public:
+	lcSynthInfoActuator(float Length, PieceInfo* Info);
+};
+
 void lcSynthInit()
 {
 	lcPiecesLibrary* Library = lcGetPiecesLibrary();
@@ -33,14 +75,13 @@ void lcSynthInit()
 	static const struct
 	{
 		char PartID[16];
-		lcSynthType Type;
 		float Length;
 		int NumSections;
 	}
 	FlexibleHoses[] =
 	{
-		{ "73590a.dat",   lcSynthType::HOSE_FLEXIBLE,    140.0f,   51 }, // Hose Flexible  8.5L without Tabs
-		{ "73590b.dat",   lcSynthType::HOSE_FLEXIBLE,    140.0f,   51 }, // Hose Flexible  8.5L with Tabs
+		{ "73590a.dat",   140.0f,   51 }, // Hose Flexible  8.5L without Tabs
+		{ "73590b.dat",   140.0f,   51 }, // Hose Flexible  8.5L with Tabs
 	};
 
 	for (const auto& HoseInfo: FlexibleHoses)
@@ -48,51 +89,50 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(HoseInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoCurved(HoseInfo.Type, HoseInfo.Length, HoseInfo.NumSections, Info));
+			Info->SetSynthInfo(new lcSynthInfoFlexibleHose(HoseInfo.Length, HoseInfo.NumSections, Info));
 	}
 
 	static const struct
 	{
 		char PartID[16];
-		lcSynthType Type;
 		float Length;
 		int NumSections;
 	}
 	FlexSystemHoses[] =
 	{
-		{ "76263.dat",    lcSynthType::FLEX_SYSTEM_HOSE,   60.0f,  29 }, // Technic Flex-System Hose  3L (60LDU)
-		{ "76250.dat",    lcSynthType::FLEX_SYSTEM_HOSE,   80.0f,  39 }, // Technic Flex-System Hose  4L (80LDU)
-		{ "76307.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  100.0f,  49 }, // Technic Flex-System Hose  5L (100LDU)
-		{ "76279.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  120.0f,  59 }, // Technic Flex-System Hose  6L (120LDU)
-		{ "76289.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  140.0f,  69 }, // Technic Flex-System Hose  7L (140LDU)
-		{ "76260.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  160.0f,  79 }, // Technic Flex-System Hose  8L (160LDU)
-		{ "76324.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  180.0f,  89 }, // Technic Flex-System Hose  9L (180LDU)
-		{ "76348.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  200.0f,  99 }, // Technic Flex-System Hose 10L (200LDU)
-		{ "71505.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  220.0f, 109 }, // Technic Flex-System Hose 11L (220LDU)
-		{ "71175.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  240.0f, 119 }, // Technic Flex-System Hose 12L (240LDU)
-		{ "71551.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  260.0f, 129 }, // Technic Flex-System Hose 13L (260LDU)
-		{ "71177.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  280.0f, 139 }, // Technic Flex-System Hose 14L (280LDU)
-		{ "71194.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  300.0f, 149 }, // Technic Flex-System Hose 15L (300LDU)
-		{ "71192.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  320.0f, 159 }, // Technic Flex-System Hose 16L (320LDU)
-		{ "76270.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  340.0f, 169 }, // Technic Flex-System Hose 17L (340LDU)
-		{ "71582.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  360.0f, 179 }, // Technic Flex-System Hose 18L (360LDU)
-		{ "22463.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  380.0f, 189 }, // Technic Flex-System Hose 19L (380LDU)
-		{ "76276.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  400.0f, 199 }, // Technic Flex-System Hose 20L (400LDU)
-		{ "70978.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  420.0f, 209 }, // Technic Flex-System Hose 21L (420LDU)
-		{ "76252.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  440.0f, 219 }, // Technic Flex-System Hose 22L (440LDU)
-		{ "76254.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  460.0f, 229 }, // Technic Flex-System Hose 23L (460LDU)
-		{ "76277.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  480.0f, 239 }, // Technic Flex-System Hose 24L (480LDU)
-		{ "53475.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  520.0f, 259 }, // Technic Flex-System Hose 26L (520LDU)
-		{ "76280.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  560.0f, 279 }, // Technic Flex-System Hose 28L (560LDU)
-		{ "76389.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  580.0f, 289 }, // Technic Flex-System Hose 29L (580LDU)
-		{ "76282.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  600.0f, 299 }, // Technic Flex-System Hose 30L (600LDU)
-		{ "76283.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  620.0f, 309 }, // Technic Flex-System Hose 31L (620LDU)
-		{ "57274.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  640.0f, 319 }, // Technic Flex-System Hose 32L (640LDU)
-		{ "42688.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  660.0f, 329 }, // Technic Flex-System Hose 33L (660LDU)
-		{ "22461.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  680.0f, 339 }, // Technic Flex-System Hose 34L (680LDU)
-		{ "46305.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  800.0f, 399 }, // Technic Flex-System Hose 40L (800LDU)
-		{ "76281.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  900.0f, 449 }, // Technic Flex-System Hose 45L (900LDU)
-		{ "22296.dat",    lcSynthType::FLEX_SYSTEM_HOSE, 1060.0f, 529 }, // Technic Flex-System Hose 53L (1060LDU)
+		{ "76263.dat",      60.0f,  29 }, // Technic Flex-System Hose  3L (60LDU)
+		{ "76250.dat",      80.0f,  39 }, // Technic Flex-System Hose  4L (80LDU)
+		{ "76307.dat",     100.0f,  49 }, // Technic Flex-System Hose  5L (100LDU)
+		{ "76279.dat",     120.0f,  59 }, // Technic Flex-System Hose  6L (120LDU)
+		{ "76289.dat",     140.0f,  69 }, // Technic Flex-System Hose  7L (140LDU)
+		{ "76260.dat",     160.0f,  79 }, // Technic Flex-System Hose  8L (160LDU)
+		{ "76324.dat",     180.0f,  89 }, // Technic Flex-System Hose  9L (180LDU)
+		{ "76348.dat",     200.0f,  99 }, // Technic Flex-System Hose 10L (200LDU)
+		{ "71505.dat",     220.0f, 109 }, // Technic Flex-System Hose 11L (220LDU)
+		{ "71175.dat",     240.0f, 119 }, // Technic Flex-System Hose 12L (240LDU)
+		{ "71551.dat",     260.0f, 129 }, // Technic Flex-System Hose 13L (260LDU)
+		{ "71177.dat",     280.0f, 139 }, // Technic Flex-System Hose 14L (280LDU)
+		{ "71194.dat",     300.0f, 149 }, // Technic Flex-System Hose 15L (300LDU)
+		{ "71192.dat",     320.0f, 159 }, // Technic Flex-System Hose 16L (320LDU)
+		{ "76270.dat",     340.0f, 169 }, // Technic Flex-System Hose 17L (340LDU)
+		{ "71582.dat",     360.0f, 179 }, // Technic Flex-System Hose 18L (360LDU)
+		{ "22463.dat",     380.0f, 189 }, // Technic Flex-System Hose 19L (380LDU)
+		{ "76276.dat",     400.0f, 199 }, // Technic Flex-System Hose 20L (400LDU)
+		{ "70978.dat",     420.0f, 209 }, // Technic Flex-System Hose 21L (420LDU)
+		{ "76252.dat",     440.0f, 219 }, // Technic Flex-System Hose 22L (440LDU)
+		{ "76254.dat",     460.0f, 229 }, // Technic Flex-System Hose 23L (460LDU)
+		{ "76277.dat",     480.0f, 239 }, // Technic Flex-System Hose 24L (480LDU)
+		{ "53475.dat",     520.0f, 259 }, // Technic Flex-System Hose 26L (520LDU)
+		{ "76280.dat",     560.0f, 279 }, // Technic Flex-System Hose 28L (560LDU)
+		{ "76389.dat",     580.0f, 289 }, // Technic Flex-System Hose 29L (580LDU)
+		{ "76282.dat",     600.0f, 299 }, // Technic Flex-System Hose 30L (600LDU)
+		{ "76283.dat",     620.0f, 309 }, // Technic Flex-System Hose 31L (620LDU)
+		{ "57274.dat",     640.0f, 319 }, // Technic Flex-System Hose 32L (640LDU)
+		{ "42688.dat",     660.0f, 329 }, // Technic Flex-System Hose 33L (660LDU)
+		{ "22461.dat",     680.0f, 339 }, // Technic Flex-System Hose 34L (680LDU)
+		{ "46305.dat",     800.0f, 399 }, // Technic Flex-System Hose 40L (800LDU)
+		{ "76281.dat",     900.0f, 449 }, // Technic Flex-System Hose 45L (900LDU)
+		{ "22296.dat",    1060.0f, 529 }, // Technic Flex-System Hose 53L (1060LDU)
 	};
 
 	for (const auto& HoseInfo: FlexSystemHoses)
@@ -100,37 +140,36 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(HoseInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoCurved(HoseInfo.Type, HoseInfo.Length, HoseInfo.NumSections, Info));
+			Info->SetSynthInfo(new lcSynthInfoFlexSystemHose(HoseInfo.Length, HoseInfo.NumSections, Info));
 	}
 
 	static const struct
 	{
 		char PartID[16];
-		lcSynthType Type;
 		float Length;
 		int NumSections;
 	}
 	RibbedHoses[] =
 	{
-		{ "72504.dat",    lcSynthType::RIBBED_HOSE,       31.25f,   4 }, // Technic Ribbed Hose  2L
-		{ "72706.dat",    lcSynthType::RIBBED_HOSE,       50.00f,   7 }, // Technic Ribbed Hose  3L
-		{ "71952.dat",    lcSynthType::RIBBED_HOSE,       75.00f,  11 }, // Technic Ribbed Hose  4L
-		{ "72853.dat",    lcSynthType::RIBBED_HOSE,       93.75f,  14 }, // Technic Ribbed Hose  5L
-		{ "71944.dat",    lcSynthType::RIBBED_HOSE,      112.50f,  17 }, // Technic Ribbed Hose  6L
-		{ "57719.dat",    lcSynthType::RIBBED_HOSE,      131.25f,  20 }, // Technic Ribbed Hose  7L
-		{ "71951.dat",    lcSynthType::RIBBED_HOSE,      150.00f,  23 }, // Technic Ribbed Hose  8L
-		{ "71917.dat",    lcSynthType::RIBBED_HOSE,      175.00f,  27 }, // Technic Ribbed Hose  9L
-		{ "71949.dat",    lcSynthType::RIBBED_HOSE,      193.75f,  30 }, // Technic Ribbed Hose 10L
-		{ "71986.dat",    lcSynthType::RIBBED_HOSE,      212.50f,  33 }, // Technic Ribbed Hose 11L
-		{ "71819.dat",    lcSynthType::RIBBED_HOSE,      231.25f,  36 }, // Technic Ribbed Hose 12L
-		{ "71923.dat",    lcSynthType::RIBBED_HOSE,      275.00f,  43 }, // Technic Ribbed Hose 14L
-		{ "71946.dat",    lcSynthType::RIBBED_HOSE,      293.75f,  46 }, // Technic Ribbed Hose 15L
-		{ "71947.dat",    lcSynthType::RIBBED_HOSE,      312.50f,  49 }, // Technic Ribbed Hose 16L
-		{ "22900.dat",    lcSynthType::RIBBED_HOSE,      331.25f,  52 }, // Technic Ribbed Hose 17L
-		{ "72039.dat",    lcSynthType::RIBBED_HOSE,      350.00f,  55 }, // Technic Ribbed Hose 18L
-		{ "43675.dat",    lcSynthType::RIBBED_HOSE,      375.00f,  58 }, // Technic Ribbed Hose 19L
-		{ "23397.dat",    lcSynthType::RIBBED_HOSE,      468.75f,  74 }, // Technic Ribbed Hose 24L
-		{ "33763.dat",    lcSynthType::RIBBED_HOSE,      512.50f,  81 }, // Technic Ribbed Hose 26L
+		{ "72504.dat",     31.25f,   4 }, // Technic Ribbed Hose  2L
+		{ "72706.dat",     50.00f,   7 }, // Technic Ribbed Hose  3L
+		{ "71952.dat",     75.00f,  11 }, // Technic Ribbed Hose  4L
+		{ "72853.dat",     93.75f,  14 }, // Technic Ribbed Hose  5L
+		{ "71944.dat",    112.50f,  17 }, // Technic Ribbed Hose  6L
+		{ "57719.dat",    131.25f,  20 }, // Technic Ribbed Hose  7L
+		{ "71951.dat",    150.00f,  23 }, // Technic Ribbed Hose  8L
+		{ "71917.dat",    175.00f,  27 }, // Technic Ribbed Hose  9L
+		{ "71949.dat",    193.75f,  30 }, // Technic Ribbed Hose 10L
+		{ "71986.dat",    212.50f,  33 }, // Technic Ribbed Hose 11L
+		{ "71819.dat",    231.25f,  36 }, // Technic Ribbed Hose 12L
+		{ "71923.dat",    275.00f,  43 }, // Technic Ribbed Hose 14L
+		{ "71946.dat",    293.75f,  46 }, // Technic Ribbed Hose 15L
+		{ "71947.dat",    312.50f,  49 }, // Technic Ribbed Hose 16L
+		{ "22900.dat",    331.25f,  52 }, // Technic Ribbed Hose 17L
+		{ "72039.dat",    350.00f,  55 }, // Technic Ribbed Hose 18L
+		{ "43675.dat",    375.00f,  58 }, // Technic Ribbed Hose 19L
+		{ "23397.dat",    468.75f,  74 }, // Technic Ribbed Hose 24L
+		{ "33763.dat",    512.50f,  81 }, // Technic Ribbed Hose 26L
 	};
 
 	for (const auto& HoseInfo: RibbedHoses)
@@ -138,25 +177,24 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(HoseInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoCurved(HoseInfo.Type, HoseInfo.Length, HoseInfo.NumSections, Info));
+			Info->SetSynthInfo(new lcSynthInfoRibbedHose(HoseInfo.Length, HoseInfo.NumSections, Info));
 	}
 
 	static const struct
 	{
 		char PartID[16];
-		lcSynthType Type;
 		float Length;
 		int NumSections;
 	}
 	FlexibleAxles[] =
 	{
-		{ "32580.dat",    lcSynthType::FLEXIBLE_AXLE,  120.00f,  15 }, // Technic Axle Flexible  7
-		{ "32199.dat",    lcSynthType::FLEXIBLE_AXLE,  200.00f,  35 }, // Technic Axle Flexible 11
-		{ "55709.dat",    lcSynthType::FLEXIBLE_AXLE,  200.00f,  35 }, // Technic Axle Flexible 11
-		{ "32200.dat",    lcSynthType::FLEXIBLE_AXLE,  220.00f,  40 }, // Technic Axle Flexible 12
-		{ "32201.dat",    lcSynthType::FLEXIBLE_AXLE,  260.00f,  50 }, // Technic Axle Flexible 14
-		{ "32202.dat",    lcSynthType::FLEXIBLE_AXLE,  300.00f,  60 }, // Technic Axle Flexible 16
-		{ "32235.dat",    lcSynthType::FLEXIBLE_AXLE,  360.00f,  75 }, // Technic Axle Flexible 19
+		{ "32580.dat",    120.00f,  15 }, // Technic Axle Flexible  7
+		{ "32199.dat",    200.00f,  35 }, // Technic Axle Flexible 11
+		{ "55709.dat",    200.00f,  35 }, // Technic Axle Flexible 11
+		{ "32200.dat",    220.00f,  40 }, // Technic Axle Flexible 12
+		{ "32201.dat",    260.00f,  50 }, // Technic Axle Flexible 14
+		{ "32202.dat",    300.00f,  60 }, // Technic Axle Flexible 16
+		{ "32235.dat",    360.00f,  75 }, // Technic Axle Flexible 19
 	};
 
 	for (const auto& AxleInfo: FlexibleAxles)
@@ -164,21 +202,20 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(AxleInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoCurved(AxleInfo.Type, AxleInfo.Length, AxleInfo.NumSections, Info));
+			Info->SetSynthInfo(new lcSynthInfoFlexibleAxle(AxleInfo.Length, AxleInfo.NumSections, Info));
 	}
 
 	static const struct
 	{
 		char PartID[16];
-		lcSynthType Type;
 		float Length;
 		int NumSections;
 	}
 	BraidedStrings[] =
 	{
-		{ "76384.dat",    lcSynthType::STRING_BRAIDED, 200.00f,  46 }, // String Braided 11L with End Studs
-		{ "75924.dat",    lcSynthType::STRING_BRAIDED, 400.00f,  96 }, // String Braided 21L with End Studs
-		{ "572C02.dat",   lcSynthType::STRING_BRAIDED, 800.00f, 196 }, // String Braided 41L with End Studs
+		{ "76384.dat",    200.00f,  46 }, // String Braided 11L with End Studs
+		{ "75924.dat",    400.00f,  96 }, // String Braided 21L with End Studs
+		{ "572C02.dat",   800.00f, 196 }, // String Braided 41L with End Studs
 	};
 
 	for (const auto& StringInfo: BraidedStrings)
@@ -186,21 +223,20 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(StringInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoCurved(StringInfo.Type, StringInfo.Length, StringInfo.NumSections, Info));
+			Info->SetSynthInfo(new lcSynthInfoBraidedString(StringInfo.Length, StringInfo.NumSections, Info));
 	}
 
 	static const struct
 	{
 		char PartID[16];
-		lcSynthType Type;
 		float Length;
 	}
 	ShockAbsorbers[] =
 	{
-		{ "73129.dat",    lcSynthType::SHOCK_ABSORBER, 110.00f }, // Technic Shock Absorber 6.5L
-		{ "41838.dat",    lcSynthType::SHOCK_ABSORBER, 110.00f }, // Technic Shock Absorber 6.5L Soft
-		{ "76138.dat",    lcSynthType::SHOCK_ABSORBER, 110.00f }, // Technic Shock Absorber 6.5L Stiff
-		{ "76537.dat",    lcSynthType::SHOCK_ABSORBER, 110.00f }, // Technic Shock Absorber 6.5L Extra Stiff
+		{ "73129.dat",    110.00f }, // Technic Shock Absorber 6.5L
+		{ "41838.dat",    110.00f }, // Technic Shock Absorber 6.5L Soft
+		{ "76138.dat",    110.00f }, // Technic Shock Absorber 6.5L Stiff
+		{ "76537.dat",    110.00f }, // Technic Shock Absorber 6.5L Extra Stiff
 	};
 
 	for (const auto& AbsorberInfo: ShockAbsorbers)
@@ -208,19 +244,18 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(AbsorberInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoStraight(AbsorberInfo.Type, AbsorberInfo.Length, Info));
+			Info->SetSynthInfo(new lcSynthInfoShockAbsorber(AbsorberInfo.Length, Info));
 	}
 
 	static const struct
 	{
 		char PartID[16];
-		lcSynthType Type;
 		float Length;
 	}
 	Actuators[] =
 	{
-		{ "61927C01.dat", lcSynthType::ACTUATOR,       270.00f }, // Technic Power Functions Linear Actuator (Extended)
-		{ "61927.dat",    lcSynthType::ACTUATOR,       170.00f }  // Technic Power Functions Linear Actuator (Contracted)
+		{ "61927C01.dat", 270.00f }, // Technic Power Functions Linear Actuator (Extended)
+		{ "61927.dat",    170.00f }  // Technic Power Functions Linear Actuator (Contracted)
 	};
 
 	for (const auto& ActuatorInfo: Actuators)
@@ -228,7 +263,7 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(ActuatorInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoStraight(ActuatorInfo.Type, ActuatorInfo.Length, Info));
+			Info->SetSynthInfo(new lcSynthInfoActuator(ActuatorInfo.Length, Info));
 	}
 
 //	"758C01" // Hose Flexible  12L
@@ -315,8 +350,43 @@ lcSynthInfoCurved::lcSynthInfoCurved(lcSynthType Type, float Length, int NumSect
 	mCurve = true;
 }
 
+lcSynthInfoFlexibleHose::lcSynthInfoFlexibleHose(float Length, int NumSections, PieceInfo* Info)
+	: lcSynthInfoCurved(lcSynthType::HOSE_FLEXIBLE, Length, NumSections, Info)
+{
+}
+
+lcSynthInfoFlexSystemHose::lcSynthInfoFlexSystemHose(float Length, int NumSections, PieceInfo* Info)
+	: lcSynthInfoCurved(lcSynthType::FLEX_SYSTEM_HOSE, Length, NumSections, Info)
+{
+}
+
+lcSynthInfoRibbedHose::lcSynthInfoRibbedHose(float Length, int NumSections, PieceInfo* Info)
+	: lcSynthInfoCurved(lcSynthType::RIBBED_HOSE, Length, NumSections, Info)
+{
+}
+
+lcSynthInfoFlexibleAxle::lcSynthInfoFlexibleAxle(float Length, int NumSections, PieceInfo* Info)
+	: lcSynthInfoCurved(lcSynthType::FLEXIBLE_AXLE, Length, NumSections, Info)
+{
+}
+
+lcSynthInfoBraidedString::lcSynthInfoBraidedString(float Length, int NumSections, PieceInfo* Info)
+	: lcSynthInfoCurved(lcSynthType::STRING_BRAIDED, Length, NumSections, Info)
+{
+}
+
 lcSynthInfoStraight::lcSynthInfoStraight(lcSynthType Type, float Length, PieceInfo* Info)
 	: lcSynthInfo(Type, Length, 1, Info)
+{
+}
+
+lcSynthInfoShockAbsorber::lcSynthInfoShockAbsorber(float Length, PieceInfo* Info)
+	: lcSynthInfoStraight(lcSynthType::SHOCK_ABSORBER, Length, Info)
+{
+}
+
+lcSynthInfoActuator::lcSynthInfoActuator(float Length, PieceInfo* Info)
+	: lcSynthInfoStraight(lcSynthType::ACTUATOR, Length, Info)
 {
 }
 

--- a/common/lc_synth.cpp
+++ b/common/lc_synth.cpp
@@ -10,7 +10,7 @@
 class lcSynthInfoCurved : public lcSynthInfo
 {
 public:
-	lcSynthInfoCurved(lcSynthType Type, float Length, int NumSections, PieceInfo* Info);
+	lcSynthInfoCurved(lcSynthType Type, float Length, int NumSections);
 
 protected:
 	float GetSectionTwist(const lcMatrix44& StartTransform, const lcMatrix44& EndTransform) const;
@@ -24,12 +24,14 @@ public:
 
 protected:
 	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
+
+	PieceInfo* mPieceInfo;
 };
 
 class lcSynthInfoFlexSystemHose : public lcSynthInfoCurved
 {
 public:
-	lcSynthInfoFlexSystemHose(float Length, int NumSections, PieceInfo* Info);
+	lcSynthInfoFlexSystemHose(float Length, int NumSections);
 
 protected:
 	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
@@ -38,7 +40,7 @@ protected:
 class lcSynthInfoRibbedHose : public lcSynthInfoCurved
 {
 public:
-	lcSynthInfoRibbedHose(float Length, int NumSections, PieceInfo* Info);
+	lcSynthInfoRibbedHose(float Length, int NumSections);
 
 protected:
 	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
@@ -47,7 +49,7 @@ protected:
 class lcSynthInfoFlexibleAxle : public lcSynthInfoCurved
 {
 public:
-	lcSynthInfoFlexibleAxle(float Length, int NumSections, PieceInfo* Info);
+	lcSynthInfoFlexibleAxle(float Length, int NumSections);
 
 protected:
 	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
@@ -56,7 +58,7 @@ protected:
 class lcSynthInfoBraidedString : public lcSynthInfoCurved
 {
 public:
-	lcSynthInfoBraidedString(float Length, int NumSections, PieceInfo* Info);
+	lcSynthInfoBraidedString(float Length, int NumSections);
 
 protected:
 	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
@@ -65,7 +67,7 @@ protected:
 class lcSynthInfoStraight : public lcSynthInfo
 {
 public:
-	lcSynthInfoStraight(lcSynthType Type, float Length, PieceInfo* Info);
+	lcSynthInfoStraight(lcSynthType Type, float Length);
 
 protected:
 	void CalculateSections(const lcArray<lcPieceControlPoint>& ControlPoints, lcArray<lcMatrix44>& Sections, SectionCallbackFunc SectionCallback) const override;
@@ -78,12 +80,14 @@ public:
 
 protected:
 	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
+
+	PieceInfo* mPieceInfo;
 };
 
 class lcSynthInfoActuator : public lcSynthInfoStraight
 {
 public:
-	lcSynthInfoActuator(float Length, PieceInfo* Info);
+	explicit lcSynthInfoActuator(float Length);
 
 protected:
 	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
@@ -161,7 +165,7 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(HoseInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoFlexSystemHose(HoseInfo.Length, HoseInfo.NumSections, Info));
+			Info->SetSynthInfo(new lcSynthInfoFlexSystemHose(HoseInfo.Length, HoseInfo.NumSections));
 	}
 
 	static const struct
@@ -198,7 +202,7 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(HoseInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoRibbedHose(HoseInfo.Length, HoseInfo.NumSections, Info));
+			Info->SetSynthInfo(new lcSynthInfoRibbedHose(HoseInfo.Length, HoseInfo.NumSections));
 	}
 
 	static const struct
@@ -223,7 +227,7 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(AxleInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoFlexibleAxle(AxleInfo.Length, AxleInfo.NumSections, Info));
+			Info->SetSynthInfo(new lcSynthInfoFlexibleAxle(AxleInfo.Length, AxleInfo.NumSections));
 	}
 
 	static const struct
@@ -244,7 +248,7 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(StringInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoBraidedString(StringInfo.Length, StringInfo.NumSections, Info));
+			Info->SetSynthInfo(new lcSynthInfoBraidedString(StringInfo.Length, StringInfo.NumSections));
 	}
 
 	static const struct
@@ -284,14 +288,14 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(ActuatorInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoActuator(ActuatorInfo.Length, Info));
+			Info->SetSynthInfo(new lcSynthInfoActuator(ActuatorInfo.Length));
 	}
 
 //	"758C01" // Hose Flexible  12L
 }
 
-lcSynthInfo::lcSynthInfo(lcSynthType Type, float Length, int NumSections, PieceInfo* Info)
-	: mPieceInfo(Info), mType(Type), mLength(Length), mNumSections(NumSections)
+lcSynthInfo::lcSynthInfo(lcSynthType Type, float Length, int NumSections)
+	: mType(Type), mLength(Length), mNumSections(NumSections)
 {
 	float EdgeSectionLength = 0.0f;
 	float MidSectionLength = 0.0f;
@@ -365,49 +369,49 @@ lcSynthInfo::lcSynthInfo(lcSynthType Type, float Length, int NumSections, PieceI
 	mEnd.Length = EdgeSectionLength;
 }
 
-lcSynthInfoCurved::lcSynthInfoCurved(lcSynthType Type, float Length, int NumSections, PieceInfo* Info)
-	: lcSynthInfo(Type, Length, NumSections, Info)
+lcSynthInfoCurved::lcSynthInfoCurved(lcSynthType Type, float Length, int NumSections)
+	: lcSynthInfo(Type, Length, NumSections)
 {
 	mCurve = true;
 }
 
 lcSynthInfoFlexibleHose::lcSynthInfoFlexibleHose(float Length, int NumSections, PieceInfo* Info)
-	: lcSynthInfoCurved(lcSynthType::HOSE_FLEXIBLE, Length, NumSections, Info)
+	: lcSynthInfoCurved(lcSynthType::HOSE_FLEXIBLE, Length, NumSections), mPieceInfo(Info)
 {
 }
 
-lcSynthInfoFlexSystemHose::lcSynthInfoFlexSystemHose(float Length, int NumSections, PieceInfo* Info)
-	: lcSynthInfoCurved(lcSynthType::FLEX_SYSTEM_HOSE, Length, NumSections, Info)
+lcSynthInfoFlexSystemHose::lcSynthInfoFlexSystemHose(float Length, int NumSections)
+	: lcSynthInfoCurved(lcSynthType::FLEX_SYSTEM_HOSE, Length, NumSections)
 {
 }
 
-lcSynthInfoRibbedHose::lcSynthInfoRibbedHose(float Length, int NumSections, PieceInfo* Info)
-	: lcSynthInfoCurved(lcSynthType::RIBBED_HOSE, Length, NumSections, Info)
+lcSynthInfoRibbedHose::lcSynthInfoRibbedHose(float Length, int NumSections)
+	: lcSynthInfoCurved(lcSynthType::RIBBED_HOSE, Length, NumSections)
 {
 }
 
-lcSynthInfoFlexibleAxle::lcSynthInfoFlexibleAxle(float Length, int NumSections, PieceInfo* Info)
-	: lcSynthInfoCurved(lcSynthType::FLEXIBLE_AXLE, Length, NumSections, Info)
+lcSynthInfoFlexibleAxle::lcSynthInfoFlexibleAxle(float Length, int NumSections)
+	: lcSynthInfoCurved(lcSynthType::FLEXIBLE_AXLE, Length, NumSections)
 {
 }
 
-lcSynthInfoBraidedString::lcSynthInfoBraidedString(float Length, int NumSections, PieceInfo* Info)
-	: lcSynthInfoCurved(lcSynthType::STRING_BRAIDED, Length, NumSections, Info)
+lcSynthInfoBraidedString::lcSynthInfoBraidedString(float Length, int NumSections)
+	: lcSynthInfoCurved(lcSynthType::STRING_BRAIDED, Length, NumSections)
 {
 }
 
-lcSynthInfoStraight::lcSynthInfoStraight(lcSynthType Type, float Length, PieceInfo* Info)
-	: lcSynthInfo(Type, Length, 1, Info)
+lcSynthInfoStraight::lcSynthInfoStraight(lcSynthType Type, float Length)
+	: lcSynthInfo(Type, Length, 1)
 {
 }
 
 lcSynthInfoShockAbsorber::lcSynthInfoShockAbsorber(float Length, PieceInfo* Info)
-	: lcSynthInfoStraight(lcSynthType::SHOCK_ABSORBER, Length, Info)
+	: lcSynthInfoStraight(lcSynthType::SHOCK_ABSORBER, Length), mPieceInfo(Info)
 {
 }
 
-lcSynthInfoActuator::lcSynthInfoActuator(float Length, PieceInfo* Info)
-	: lcSynthInfoStraight(lcSynthType::ACTUATOR, Length, Info)
+lcSynthInfoActuator::lcSynthInfoActuator(float Length)
+	: lcSynthInfoStraight(lcSynthType::ACTUATOR, Length)
 {
 }
 

--- a/common/lc_synth.cpp
+++ b/common/lc_synth.cpp
@@ -13,6 +13,7 @@ public:
 	lcSynthInfoCurved(float Length, float DefaultScale, int NumSections, bool RigidEdges);
 
 	void GetDefaultControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const override;
+	void VerifyControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const override;
 
 protected:
 	float GetSectionTwist(const lcMatrix44& StartTransform, const lcMatrix44& EndTransform) const;
@@ -87,6 +88,8 @@ class lcSynthInfoStraight : public lcSynthInfo
 {
 public:
 	explicit lcSynthInfoStraight(float Length);
+
+	void VerifyControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const override;
 
 protected:
 	void CalculateSections(const lcArray<lcPieceControlPoint>& ControlPoints, lcArray<lcMatrix44>& Sections, SectionCallbackFunc SectionCallback) const override;
@@ -407,12 +410,26 @@ void lcSynthInfoCurved::GetDefaultControlPoints(lcArray<lcPieceControlPoint>& Co
 	ControlPoints[1].Scale = Scale;
 }
 
+void lcSynthInfoCurved::VerifyControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const
+{
+	if (ControlPoints.GetSize() < 2)
+		GetDefaultControlPoints(ControlPoints);
+}
+
 void lcSynthInfoFlexSystemHose::GetDefaultControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const
 {
 	lcSynthInfoCurved::GetDefaultControlPoints(ControlPoints);
 
 	ControlPoints[0].Transform = lcMatrix44Translation(lcVector3(0.0f, 0.0f, -mLength));
 	ControlPoints[1].Transform = lcMatrix44Translation(lcVector3(0.0f, 0.0f, 0.0f));
+}
+
+void lcSynthInfoStraight::VerifyControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const
+{
+	if (ControlPoints.GetSize() < 2)
+		GetDefaultControlPoints(ControlPoints);
+	else
+		ControlPoints.SetSize(2);
 }
 
 void lcSynthInfoShockAbsorber::GetDefaultControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const

--- a/common/lc_synth.cpp
+++ b/common/lc_synth.cpp
@@ -76,12 +76,12 @@ protected:
 class lcSynthInfoShockAbsorber : public lcSynthInfoStraight
 {
 public:
-	lcSynthInfoShockAbsorber(float Length, PieceInfo* Info);
+	explicit lcSynthInfoShockAbsorber(const char* SpringPart);
 
 protected:
 	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
 
-	PieceInfo* mPieceInfo;
+	const char* mSpringPart;
 };
 
 class lcSynthInfoActuator : public lcSynthInfoStraight
@@ -254,14 +254,14 @@ void lcSynthInit()
 	static const struct
 	{
 		char PartID[16];
-		float Length;
+		char SpringPart[16];
 	}
 	ShockAbsorbers[] =
 	{
-		{ "73129.dat",    110.00f }, // Technic Shock Absorber 6.5L
-		{ "41838.dat",    110.00f }, // Technic Shock Absorber 6.5L Soft
-		{ "76138.dat",    110.00f }, // Technic Shock Absorber 6.5L Stiff
-		{ "76537.dat",    110.00f }, // Technic Shock Absorber 6.5L Extra Stiff
+		{ "73129.dat", "70038.dat" }, // Technic Shock Absorber 6.5L
+		{ "41838.dat", "41837.dat" }, // Technic Shock Absorber 6.5L Soft
+		{ "76138.dat", "71953.dat" }, // Technic Shock Absorber 6.5L Stiff
+		{ "76537.dat", "22977.dat" }, // Technic Shock Absorber 6.5L Extra Stiff
 	};
 
 	for (const auto& AbsorberInfo: ShockAbsorbers)
@@ -269,7 +269,7 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(AbsorberInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoShockAbsorber(AbsorberInfo.Length, Info));
+			Info->SetSynthInfo(new lcSynthInfoShockAbsorber(AbsorberInfo.SpringPart));
 	}
 
 	static const struct
@@ -405,8 +405,8 @@ lcSynthInfoStraight::lcSynthInfoStraight(lcSynthType Type, float Length)
 {
 }
 
-lcSynthInfoShockAbsorber::lcSynthInfoShockAbsorber(float Length, PieceInfo* Info)
-	: lcSynthInfoStraight(lcSynthType::SHOCK_ABSORBER, Length), mPieceInfo(Info)
+lcSynthInfoShockAbsorber::lcSynthInfoShockAbsorber(const char* SpringPart)
+	: lcSynthInfoStraight(lcSynthType::SHOCK_ABSORBER, 110.00f), mSpringPart(SpringPart)
 {
 }
 
@@ -1179,21 +1179,9 @@ void lcSynthInfoShockAbsorber::AddParts(lcMemFile& File, lcLibraryMeshData&, con
 
 	float Distance = Sections[0].GetTranslation().y - Sections[1].GetTranslation().y;
 	float Scale = (Distance - 66.0f) / 44.0f;
-	const char* SpringPart;
-
-	if (!qstricmp(mPieceInfo->mFileName, "73129.dat"))
-		SpringPart = "70038";
-	else if (!qstricmp(mPieceInfo->mFileName, "41838.dat"))
-		SpringPart = "41837";
-	else if (!qstricmp(mPieceInfo->mFileName, "76138.dat"))
-		SpringPart = "71953";
-	else if (!qstricmp(mPieceInfo->mFileName, "76537.dat"))
-		SpringPart = "22977";
-	else
-		return;
 
 	Offset = Sections[0].GetTranslation();
-	sprintf(Line, "1 494 %f %f %f 1 0 0 0 %f 0 0 0 1 %s.dat\n", Offset[0], Offset[1] - 10 - 44.0f * Scale, Offset[2], Scale, SpringPart);
+	sprintf(Line, "1 494 %f %f %f 1 0 0 0 %f 0 0 0 1 %s\n", Offset[0], Offset[1] - 10 - 44.0f * Scale, Offset[2], Scale, mSpringPart);
 	File.WriteBuffer(Line, strlen(Line));
 }
 

--- a/common/lc_synth.cpp
+++ b/common/lc_synth.cpp
@@ -21,30 +21,45 @@ class lcSynthInfoFlexibleHose : public lcSynthInfoCurved
 {
 public:
 	lcSynthInfoFlexibleHose(float Length, int NumSections, PieceInfo* Info);
+
+protected:
+	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
 };
 
 class lcSynthInfoFlexSystemHose : public lcSynthInfoCurved
 {
 public:
 	lcSynthInfoFlexSystemHose(float Length, int NumSections, PieceInfo* Info);
+
+protected:
+	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
 };
 
 class lcSynthInfoRibbedHose : public lcSynthInfoCurved
 {
 public:
 	lcSynthInfoRibbedHose(float Length, int NumSections, PieceInfo* Info);
+
+protected:
+	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
 };
 
 class lcSynthInfoFlexibleAxle : public lcSynthInfoCurved
 {
 public:
 	lcSynthInfoFlexibleAxle(float Length, int NumSections, PieceInfo* Info);
+
+protected:
+	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
 };
 
 class lcSynthInfoBraidedString : public lcSynthInfoCurved
 {
 public:
 	lcSynthInfoBraidedString(float Length, int NumSections, PieceInfo* Info);
+
+protected:
+	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
 };
 
 class lcSynthInfoStraight : public lcSynthInfo
@@ -60,12 +75,18 @@ class lcSynthInfoShockAbsorber : public lcSynthInfoStraight
 {
 public:
 	lcSynthInfoShockAbsorber(float Length, PieceInfo* Info);
+
+protected:
+	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
 };
 
 class lcSynthInfoActuator : public lcSynthInfoStraight
 {
 public:
 	lcSynthInfoActuator(float Length, PieceInfo* Info);
+
+protected:
+	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
 };
 
 void lcSynthInit()
@@ -663,7 +684,7 @@ void lcSynthInfoStraight::CalculateSections(const lcArray<lcPieceControlPoint>& 
 	}
 }
 
-void lcSynthInfo::AddHoseFlexibleParts(lcMemFile& File, const lcArray<lcMatrix44>& Sections) const
+void lcSynthInfoFlexibleHose::AddParts(lcMemFile& File, lcLibraryMeshData&, const lcArray<lcMatrix44>& Sections) const
 {
 	char Line[256];
 	const int NumEdgeParts = 2;
@@ -731,7 +752,7 @@ void lcSynthInfo::AddHoseFlexibleParts(lcMemFile& File, const lcArray<lcMatrix44
 	}
 }
 
-void lcSynthInfo::AddFlexHoseParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const
+void lcSynthInfoFlexSystemHose::AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const
 {
 	char Line[256];
 
@@ -839,7 +860,7 @@ void lcSynthInfo::AddFlexHoseParts(lcMemFile& File, lcLibraryMeshData& MeshData,
 	AddSectionVertices(InsideSectionVertices, LC_ARRAY_COUNT(InsideSectionVertices));
 }
 
-void lcSynthInfo::AddRibbedHoseParts(lcMemFile& File, const lcArray<lcMatrix44>& Sections) const
+void lcSynthInfoRibbedHose::AddParts(lcMemFile& File, lcLibraryMeshData&, const lcArray<lcMatrix44>& Sections) const
 {
 	char Line[256];
 
@@ -876,7 +897,7 @@ void lcSynthInfo::AddRibbedHoseParts(lcMemFile& File, const lcArray<lcMatrix44>&
 	}
 }
 
-void lcSynthInfo::AddFlexibleAxleParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const
+void lcSynthInfoFlexibleAxle::AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const
 {
 	char Line[256];
 	const int NumEdgeParts = 6;
@@ -1006,12 +1027,15 @@ void lcSynthInfo::AddFlexibleAxleParts(lcMemFile& File, lcLibraryMeshData& MeshD
 	}
 }
 
-void lcSynthInfo::AddStringBraidedParts(lcMemFile& File, lcLibraryMeshData& MeshData, lcArray<lcMatrix44>& Sections) const
+void lcSynthInfoBraidedString::AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& SectionsIn) const
 {
+	lcArray<lcMatrix44> Sections;
+	Sections.SetSize(SectionsIn.GetSize());
+
 	for (int SectionIdx = 0; SectionIdx < Sections.GetSize(); SectionIdx++)
 	{
-		lcMatrix33 Transform(lcMul(lcMatrix33Scale(lcVector3(1.0f, -1.0f, 1.0f)), lcMatrix33(Sections[SectionIdx])));
-		lcVector3 Offset = Sections[SectionIdx].GetTranslation();
+		lcMatrix33 Transform(lcMul(lcMatrix33Scale(lcVector3(1.0f, -1.0f, 1.0f)), lcMatrix33(SectionsIn[SectionIdx])));
+		lcVector3 Offset = SectionsIn[SectionIdx].GetTranslation();
 		Sections[SectionIdx] = lcMatrix44(Transform, Offset);
 	}
 
@@ -1136,7 +1160,7 @@ void lcSynthInfo::AddStringBraidedParts(lcMemFile& File, lcLibraryMeshData& Mesh
 	}
 }
 
-void lcSynthInfo::AddShockAbsorberParts(lcMemFile& File, lcArray<lcMatrix44>& Sections) const
+void lcSynthInfoShockAbsorber::AddParts(lcMemFile& File, lcLibraryMeshData&, const lcArray<lcMatrix44>& Sections) const
 {
 	char Line[256];
 	lcVector3 Offset;
@@ -1169,7 +1193,7 @@ void lcSynthInfo::AddShockAbsorberParts(lcMemFile& File, lcArray<lcMatrix44>& Se
 	File.WriteBuffer(Line, strlen(Line));
 }
 
-void lcSynthInfo::AddActuatorParts(lcMemFile& File, lcArray<lcMatrix44>& Sections) const
+void lcSynthInfoActuator::AddParts(lcMemFile& File, lcLibraryMeshData&, const lcArray<lcMatrix44>& Sections) const
 {
 	char Line[256];
 	lcVector3 Offset;
@@ -1194,36 +1218,7 @@ lcMesh* lcSynthInfo::CreateMesh(const lcArray<lcPieceControlPoint>& ControlPoint
 	lcLibraryMeshData MeshData;
 	lcMemFile File; // todo: rewrite this to pass the parts directly
 
-	switch (mType)
-	{
-	case lcSynthType::HOSE_FLEXIBLE:
-		AddHoseFlexibleParts(File, Sections);
-		break;
-
-	case lcSynthType::FLEX_SYSTEM_HOSE:
-		AddFlexHoseParts(File, MeshData, Sections);
-		break;
-
-	case lcSynthType::RIBBED_HOSE:
-		AddRibbedHoseParts(File, Sections);
-		break;
-
-	case lcSynthType::FLEXIBLE_AXLE:
-		AddFlexibleAxleParts(File, MeshData, Sections);
-		break;
-
-	case lcSynthType::STRING_BRAIDED:
-		AddStringBraidedParts(File, MeshData, Sections);
-		break;
-
-	case lcSynthType::SHOCK_ABSORBER:
-		AddShockAbsorberParts(File, Sections);
-		break;
-
-	case lcSynthType::ACTUATOR:
-		AddActuatorParts(File, Sections);
-		break;
-	}
+	AddParts(File, MeshData, Sections);
 
 	File.WriteU8(0);
 

--- a/common/lc_synth.cpp
+++ b/common/lc_synth.cpp
@@ -10,7 +10,7 @@
 class lcSynthInfoCurved : public lcSynthInfo
 {
 public:
-	lcSynthInfoCurved(lcSynthType Type, float Length, float DefaultScale, int NumSections, bool RigidEdges);
+	lcSynthInfoCurved(float Length, float DefaultScale, int NumSections, bool RigidEdges);
 
 	void GetDefaultControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const override;
 
@@ -86,7 +86,7 @@ protected:
 class lcSynthInfoStraight : public lcSynthInfo
 {
 public:
-	lcSynthInfoStraight(lcSynthType Type, float Length);
+	explicit lcSynthInfoStraight(float Length);
 
 protected:
 	void CalculateSections(const lcArray<lcPieceControlPoint>& ControlPoints, lcArray<lcMatrix44>& Sections, SectionCallbackFunc SectionCallback) const override;
@@ -318,13 +318,13 @@ void lcSynthInit()
 //	"758C01" // Hose Flexible  12L
 }
 
-lcSynthInfo::lcSynthInfo(lcSynthType Type, float Length)
-	: mType(Type), mLength(Length)
+lcSynthInfo::lcSynthInfo(float Length)
+	: mLength(Length)
 {
 }
 
-lcSynthInfoCurved::lcSynthInfoCurved(lcSynthType Type, float Length, float DefaultScale, int NumSections, bool RigidEdges)
-	: lcSynthInfo(Type, Length), mNumSections(NumSections), mDefaultScale(DefaultScale), mRigidEdges(RigidEdges)
+lcSynthInfoCurved::lcSynthInfoCurved(float Length, float DefaultScale, int NumSections, bool RigidEdges)
+	: lcSynthInfo(Length), mNumSections(NumSections), mDefaultScale(DefaultScale), mRigidEdges(RigidEdges)
 {
 	mCurve = true;
 
@@ -333,7 +333,7 @@ lcSynthInfoCurved::lcSynthInfoCurved(lcSynthType Type, float Length, float Defau
 }
 
 lcSynthInfoFlexibleHose::lcSynthInfoFlexibleHose(float Length, int NumSections, const char* EdgePart2)
-	: lcSynthInfoCurved(lcSynthType::HOSE_FLEXIBLE, Length, 12.f, NumSections, true),
+	: lcSynthInfoCurved(Length, 12.f, NumSections, true),
 	mEdgePart2(EdgePart2)
 {
 	mStart.Length = 5.0f;
@@ -343,7 +343,7 @@ lcSynthInfoFlexibleHose::lcSynthInfoFlexibleHose(float Length, int NumSections, 
 }
 
 lcSynthInfoFlexSystemHose::lcSynthInfoFlexSystemHose(float Length, int NumSections)
-	: lcSynthInfoCurved(lcSynthType::FLEX_SYSTEM_HOSE, Length, 12.f, NumSections, true)
+	: lcSynthInfoCurved(Length, 12.f, NumSections, true)
 {
 	mStart.Transform = lcMatrix44Identity();
 	mEnd.Transform = lcMatrix44Identity();
@@ -353,7 +353,7 @@ lcSynthInfoFlexSystemHose::lcSynthInfoFlexSystemHose(float Length, int NumSectio
 }
 
 lcSynthInfoRibbedHose::lcSynthInfoRibbedHose(float Length, int NumSections)
-	: lcSynthInfoCurved(lcSynthType::RIBBED_HOSE, Length, 80.0f, NumSections, false)
+	: lcSynthInfoCurved(Length, 80.0f, NumSections, false)
 {
 	mStart.Length = 6.25f;
 	mMiddle.Length = 6.25f;
@@ -361,7 +361,7 @@ lcSynthInfoRibbedHose::lcSynthInfoRibbedHose(float Length, int NumSections)
 }
 
 lcSynthInfoFlexibleAxle::lcSynthInfoFlexibleAxle(float Length, int NumSections)
-	: lcSynthInfoCurved(lcSynthType::FLEXIBLE_AXLE, Length, 12.0f, NumSections, true)
+	: lcSynthInfoCurved(Length, 12.0f, NumSections, true)
 {
 	mStart.Length = 30.0f;
 	mMiddle.Length = 4.0f;
@@ -369,7 +369,7 @@ lcSynthInfoFlexibleAxle::lcSynthInfoFlexibleAxle(float Length, int NumSections)
 }
 
 lcSynthInfoBraidedString::lcSynthInfoBraidedString(float Length, int NumSections)
-	: lcSynthInfoCurved(lcSynthType::STRING_BRAIDED, Length, 12.0f, NumSections, true)
+	: lcSynthInfoCurved(Length, 12.0f, NumSections, true)
 {
 	mStart.Transform = lcMatrix44Identity();
 	mEnd.Transform = lcMatrix44Identity();
@@ -378,18 +378,18 @@ lcSynthInfoBraidedString::lcSynthInfoBraidedString(float Length, int NumSections
 	mEnd.Length = 8.0f;
 }
 
-lcSynthInfoStraight::lcSynthInfoStraight(lcSynthType Type, float Length)
-	: lcSynthInfo(Type, Length)
+lcSynthInfoStraight::lcSynthInfoStraight(float Length)
+	: lcSynthInfo(Length)
 {
 }
 
 lcSynthInfoShockAbsorber::lcSynthInfoShockAbsorber(const char* SpringPart)
-	: lcSynthInfoStraight(lcSynthType::SHOCK_ABSORBER, 110.00f), mSpringPart(SpringPart)
+	: lcSynthInfoStraight(110.00f), mSpringPart(SpringPart)
 {
 }
 
 lcSynthInfoActuator::lcSynthInfoActuator(float Length)
-	: lcSynthInfoStraight(lcSynthType::ACTUATOR, Length)
+	: lcSynthInfoStraight(Length)
 {
 }
 

--- a/common/lc_synth.cpp
+++ b/common/lc_synth.cpp
@@ -20,12 +20,12 @@ protected:
 class lcSynthInfoFlexibleHose : public lcSynthInfoCurved
 {
 public:
-	lcSynthInfoFlexibleHose(float Length, int NumSections, PieceInfo* Info);
+	lcSynthInfoFlexibleHose(float Length, int NumSections, const char* EdgePart2);
 
 protected:
 	void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const override;
 
-	PieceInfo* mPieceInfo;
+	const char* mEdgePart2;
 };
 
 class lcSynthInfoFlexSystemHose : public lcSynthInfoCurved
@@ -102,11 +102,12 @@ void lcSynthInit()
 		char PartID[16];
 		float Length;
 		int NumSections;
+		char EdgePart2[8];
 	}
 	FlexibleHoses[] =
 	{
-		{ "73590a.dat",   140.0f,   51 }, // Hose Flexible  8.5L without Tabs
-		{ "73590b.dat",   140.0f,   51 }, // Hose Flexible  8.5L with Tabs
+		{ "73590a.dat", 140.0f, 51, "752.dat" }, // Hose Flexible  8.5L without Tabs
+		{ "73590b.dat", 140.0f, 51, "750.dat" }, // Hose Flexible  8.5L with Tabs
 	};
 
 	for (const auto& HoseInfo: FlexibleHoses)
@@ -114,7 +115,7 @@ void lcSynthInit()
 		PieceInfo* Info = Library->FindPiece(HoseInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoFlexibleHose(HoseInfo.Length, HoseInfo.NumSections, Info));
+			Info->SetSynthInfo(new lcSynthInfoFlexibleHose(HoseInfo.Length, HoseInfo.NumSections, HoseInfo.EdgePart2));
 	}
 
 	static const struct
@@ -375,8 +376,8 @@ lcSynthInfoCurved::lcSynthInfoCurved(lcSynthType Type, float Length, int NumSect
 	mCurve = true;
 }
 
-lcSynthInfoFlexibleHose::lcSynthInfoFlexibleHose(float Length, int NumSections, PieceInfo* Info)
-	: lcSynthInfoCurved(lcSynthType::HOSE_FLEXIBLE, Length, NumSections), mPieceInfo(Info)
+lcSynthInfoFlexibleHose::lcSynthInfoFlexibleHose(float Length, int NumSections, const char* EdgePart2)
+	: lcSynthInfoCurved(lcSynthType::HOSE_FLEXIBLE, Length, NumSections), mEdgePart2(EdgePart2)
 {
 }
 
@@ -699,17 +700,10 @@ void lcSynthInfoFlexibleHose::AddParts(lcMemFile& File, lcLibraryMeshData&, cons
 		lcMatrix33(lcVector3(0.0f, 0.0f, -1.0f), lcVector3(0.0f,  1.0f, 0.0f), lcVector3(1.0f, 0.0f, 0.0f))
 	};
 
-	const char* EdgePartsA[2] =
+	const char* EdgeParts[2] =
 	{
-		"755.dat", "752.dat"
+		"755.dat", mEdgePart2
 	};
-
-	const char* EdgePartsB[2] =
-	{
-		"755.dat", "750.dat"
-	};
-
-	const char** EdgeParts = !strcmp(mPieceInfo->mFileName, "73590a.dat") ? EdgePartsA : EdgePartsB;
 
 	for (int PartIdx = 0; PartIdx < NumEdgeParts; PartIdx++)
 	{

--- a/common/lc_synth.cpp
+++ b/common/lc_synth.cpp
@@ -37,10 +37,29 @@ void lcSynthInit()
 		float Length;
 		int NumSections;
 	}
-	CurvedPieces[] =
+	FlexibleHoses[] =
 	{
 		{ "73590a.dat",   lcSynthType::HOSE_FLEXIBLE,    140.0f,   51 }, // Hose Flexible  8.5L without Tabs
 		{ "73590b.dat",   lcSynthType::HOSE_FLEXIBLE,    140.0f,   51 }, // Hose Flexible  8.5L with Tabs
+	};
+
+	for (const auto& HoseInfo: FlexibleHoses)
+	{
+		PieceInfo* Info = Library->FindPiece(HoseInfo.PartID, nullptr, false, false);
+
+		if (Info)
+			Info->SetSynthInfo(new lcSynthInfoCurved(HoseInfo.Type, HoseInfo.Length, HoseInfo.NumSections, Info));
+	}
+
+	static const struct
+	{
+		char PartID[16];
+		lcSynthType Type;
+		float Length;
+		int NumSections;
+	}
+	FlexSystemHoses[] =
+	{
 		{ "76263.dat",    lcSynthType::FLEX_SYSTEM_HOSE,   60.0f,  29 }, // Technic Flex-System Hose  3L (60LDU)
 		{ "76250.dat",    lcSynthType::FLEX_SYSTEM_HOSE,   80.0f,  39 }, // Technic Flex-System Hose  4L (80LDU)
 		{ "76307.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  100.0f,  49 }, // Technic Flex-System Hose  5L (100LDU)
@@ -74,6 +93,25 @@ void lcSynthInit()
 		{ "46305.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  800.0f, 399 }, // Technic Flex-System Hose 40L (800LDU)
 		{ "76281.dat",    lcSynthType::FLEX_SYSTEM_HOSE,  900.0f, 449 }, // Technic Flex-System Hose 45L (900LDU)
 		{ "22296.dat",    lcSynthType::FLEX_SYSTEM_HOSE, 1060.0f, 529 }, // Technic Flex-System Hose 53L (1060LDU)
+	};
+
+	for (const auto& HoseInfo: FlexSystemHoses)
+	{
+		PieceInfo* Info = Library->FindPiece(HoseInfo.PartID, nullptr, false, false);
+
+		if (Info)
+			Info->SetSynthInfo(new lcSynthInfoCurved(HoseInfo.Type, HoseInfo.Length, HoseInfo.NumSections, Info));
+	}
+
+	static const struct
+	{
+		char PartID[16];
+		lcSynthType Type;
+		float Length;
+		int NumSections;
+	}
+	RibbedHoses[] =
+	{
 		{ "72504.dat",    lcSynthType::RIBBED_HOSE,       31.25f,   4 }, // Technic Ribbed Hose  2L
 		{ "72706.dat",    lcSynthType::RIBBED_HOSE,       50.00f,   7 }, // Technic Ribbed Hose  3L
 		{ "71952.dat",    lcSynthType::RIBBED_HOSE,       75.00f,  11 }, // Technic Ribbed Hose  4L
@@ -93,19 +131,9 @@ void lcSynthInit()
 		{ "43675.dat",    lcSynthType::RIBBED_HOSE,      375.00f,  58 }, // Technic Ribbed Hose 19L
 		{ "23397.dat",    lcSynthType::RIBBED_HOSE,      468.75f,  74 }, // Technic Ribbed Hose 24L
 		{ "33763.dat",    lcSynthType::RIBBED_HOSE,      512.50f,  81 }, // Technic Ribbed Hose 26L
-		{ "32580.dat",    lcSynthType::FLEXIBLE_AXLE,    120.00f,  15 }, // Technic Axle Flexible  7
-		{ "32199.dat",    lcSynthType::FLEXIBLE_AXLE,    200.00f,  35 }, // Technic Axle Flexible 11
-		{ "55709.dat",    lcSynthType::FLEXIBLE_AXLE,    200.00f,  35 }, // Technic Axle Flexible 11
-		{ "32200.dat",    lcSynthType::FLEXIBLE_AXLE,    220.00f,  40 }, // Technic Axle Flexible 12
-		{ "32201.dat",    lcSynthType::FLEXIBLE_AXLE,    260.00f,  50 }, // Technic Axle Flexible 14
-		{ "32202.dat",    lcSynthType::FLEXIBLE_AXLE,    300.00f,  60 }, // Technic Axle Flexible 16
-		{ "32235.dat",    lcSynthType::FLEXIBLE_AXLE,    360.00f,  75 }, // Technic Axle Flexible 19
-		{ "76384.dat",    lcSynthType::STRING_BRAIDED,   200.00f,  46 }, // String Braided 11L with End Studs
-		{ "75924.dat",    lcSynthType::STRING_BRAIDED,   400.00f,  96 }, // String Braided 21L with End Studs
-		{ "572C02.dat",   lcSynthType::STRING_BRAIDED,   800.00f, 196 }, // String Braided 41L with End Studs
 	};
 
-	for (const auto& HoseInfo: CurvedPieces)
+	for (const auto& HoseInfo: RibbedHoses)
 	{
 		PieceInfo* Info = Library->FindPiece(HoseInfo.PartID, nullptr, false, false);
 
@@ -118,23 +146,89 @@ void lcSynthInit()
 		char PartID[16];
 		lcSynthType Type;
 		float Length;
+		int NumSections;
 	}
-	StraigthPieces[] =
+	FlexibleAxles[] =
+	{
+		{ "32580.dat",    lcSynthType::FLEXIBLE_AXLE,  120.00f,  15 }, // Technic Axle Flexible  7
+		{ "32199.dat",    lcSynthType::FLEXIBLE_AXLE,  200.00f,  35 }, // Technic Axle Flexible 11
+		{ "55709.dat",    lcSynthType::FLEXIBLE_AXLE,  200.00f,  35 }, // Technic Axle Flexible 11
+		{ "32200.dat",    lcSynthType::FLEXIBLE_AXLE,  220.00f,  40 }, // Technic Axle Flexible 12
+		{ "32201.dat",    lcSynthType::FLEXIBLE_AXLE,  260.00f,  50 }, // Technic Axle Flexible 14
+		{ "32202.dat",    lcSynthType::FLEXIBLE_AXLE,  300.00f,  60 }, // Technic Axle Flexible 16
+		{ "32235.dat",    lcSynthType::FLEXIBLE_AXLE,  360.00f,  75 }, // Technic Axle Flexible 19
+	};
+
+	for (const auto& AxleInfo: FlexibleAxles)
+	{
+		PieceInfo* Info = Library->FindPiece(AxleInfo.PartID, nullptr, false, false);
+
+		if (Info)
+			Info->SetSynthInfo(new lcSynthInfoCurved(AxleInfo.Type, AxleInfo.Length, AxleInfo.NumSections, Info));
+	}
+
+	static const struct
+	{
+		char PartID[16];
+		lcSynthType Type;
+		float Length;
+		int NumSections;
+	}
+	BraidedStrings[] =
+	{
+		{ "76384.dat",    lcSynthType::STRING_BRAIDED, 200.00f,  46 }, // String Braided 11L with End Studs
+		{ "75924.dat",    lcSynthType::STRING_BRAIDED, 400.00f,  96 }, // String Braided 21L with End Studs
+		{ "572C02.dat",   lcSynthType::STRING_BRAIDED, 800.00f, 196 }, // String Braided 41L with End Studs
+	};
+
+	for (const auto& StringInfo: BraidedStrings)
+	{
+		PieceInfo* Info = Library->FindPiece(StringInfo.PartID, nullptr, false, false);
+
+		if (Info)
+			Info->SetSynthInfo(new lcSynthInfoCurved(StringInfo.Type, StringInfo.Length, StringInfo.NumSections, Info));
+	}
+
+	static const struct
+	{
+		char PartID[16];
+		lcSynthType Type;
+		float Length;
+	}
+	ShockAbsorbers[] =
 	{
 		{ "73129.dat",    lcSynthType::SHOCK_ABSORBER, 110.00f }, // Technic Shock Absorber 6.5L
 		{ "41838.dat",    lcSynthType::SHOCK_ABSORBER, 110.00f }, // Technic Shock Absorber 6.5L Soft
 		{ "76138.dat",    lcSynthType::SHOCK_ABSORBER, 110.00f }, // Technic Shock Absorber 6.5L Stiff
 		{ "76537.dat",    lcSynthType::SHOCK_ABSORBER, 110.00f }, // Technic Shock Absorber 6.5L Extra Stiff
+	};
+
+	for (const auto& AbsorberInfo: ShockAbsorbers)
+	{
+		PieceInfo* Info = Library->FindPiece(AbsorberInfo.PartID, nullptr, false, false);
+
+		if (Info)
+			Info->SetSynthInfo(new lcSynthInfoStraight(AbsorberInfo.Type, AbsorberInfo.Length, Info));
+	}
+
+	static const struct
+	{
+		char PartID[16];
+		lcSynthType Type;
+		float Length;
+	}
+	Actuators[] =
+	{
 		{ "61927C01.dat", lcSynthType::ACTUATOR,       270.00f }, // Technic Power Functions Linear Actuator (Extended)
 		{ "61927.dat",    lcSynthType::ACTUATOR,       170.00f }  // Technic Power Functions Linear Actuator (Contracted)
 	};
 
-	for (const auto& StraightInfo: StraigthPieces)
+	for (const auto& ActuatorInfo: Actuators)
 	{
-		PieceInfo* Info = Library->FindPiece(StraightInfo.PartID, nullptr, false, false);
+		PieceInfo* Info = Library->FindPiece(ActuatorInfo.PartID, nullptr, false, false);
 
 		if (Info)
-			Info->SetSynthInfo(new lcSynthInfoStraight(StraightInfo.Type, StraightInfo.Length, Info));
+			Info->SetSynthInfo(new lcSynthInfoStraight(ActuatorInfo.Type, ActuatorInfo.Length, Info));
 	}
 
 //	"758C01" // Hose Flexible  12L

--- a/common/lc_synth.cpp
+++ b/common/lc_synth.cpp
@@ -298,107 +298,71 @@ void lcSynthInit()
 lcSynthInfo::lcSynthInfo(lcSynthType Type, float Length, int NumSections)
 	: mType(Type), mLength(Length), mNumSections(NumSections)
 {
-	float EdgeSectionLength = 0.0f;
-	float MidSectionLength = 0.0f;
-	mCenterLength = 0.0f;
+	mStart.Transform = lcMatrix44Identity();
+	mMiddle.Transform = lcMatrix44Identity();
+	mEnd.Transform = lcMatrix44Identity();
 
-	switch (mType)
-	{
-	case lcSynthType::HOSE_FLEXIBLE:
-		EdgeSectionLength = 5.0f;
-		MidSectionLength = 2.56f;
-		mCenterLength = 4.56f;
-		mRigidEdges = true;
-		mCurve = true;
-		break;
-
-	case lcSynthType::FLEX_SYSTEM_HOSE:
-		EdgeSectionLength = 1.0f;
-		MidSectionLength = 2.0f;
-		mRigidEdges = true;
-		mCurve = true;
-		break;
-
-	case lcSynthType::RIBBED_HOSE:
-		EdgeSectionLength = 6.25f;
-		MidSectionLength = 6.25f;
-		mRigidEdges = false;
-		break;
-
-	case lcSynthType::FLEXIBLE_AXLE:
-		EdgeSectionLength = 30.0f;
-		MidSectionLength = 4.0f;
-		mRigidEdges = true;
-		break;
-
-	case lcSynthType::STRING_BRAIDED:
-		EdgeSectionLength = 8.0f;
-		MidSectionLength = 4.0f;
-		mRigidEdges = true;
-		break;
-
-	case lcSynthType::SHOCK_ABSORBER:
-	case lcSynthType::ACTUATOR:
-		EdgeSectionLength = 0.0f;
-		MidSectionLength = 0.0f;
-		mRigidEdges = false;
-		break;
-	}
-
-	switch (mType)
-	{
-	case lcSynthType::HOSE_FLEXIBLE:
-	case lcSynthType::RIBBED_HOSE:
-	case lcSynthType::FLEXIBLE_AXLE:
-		mStart.Transform = lcMatrix44(lcMatrix33(lcVector3(0.0f, 0.0f, 1.0f), lcVector3(1.0f, 0.0f, 0.0f), lcVector3(0.0f, 1.0f, 0.0f)), lcVector3(0.0f, 0.0f, 0.0f));
-		mMiddle.Transform = lcMatrix44Identity();
-		mEnd.Transform = lcMatrix44(lcMatrix33(lcVector3(0.0f, 0.0f, 1.0f), lcVector3(1.0f, 0.0f, 0.0f), lcVector3(0.0f, 1.0f, 0.0f)), lcVector3(0.0f, 0.0f, 0.0f));
-		break;
-
-	case lcSynthType::FLEX_SYSTEM_HOSE:
-	case lcSynthType::SHOCK_ABSORBER:
-	case lcSynthType::ACTUATOR:
-	case lcSynthType::STRING_BRAIDED:
-		mStart.Transform = lcMatrix44Identity();
-		mMiddle.Transform = lcMatrix44Identity();
-		mEnd.Transform = lcMatrix44Identity();
-		break;
-	}
-
-	mStart.Length = EdgeSectionLength;
-	mMiddle.Length = MidSectionLength;
-	mEnd.Length = EdgeSectionLength;
+	mStart.Length = 0.0f;
+	mMiddle.Length = 0.0f;
+	mEnd.Length = 0.0f;
 }
 
 lcSynthInfoCurved::lcSynthInfoCurved(lcSynthType Type, float Length, int NumSections)
 	: lcSynthInfo(Type, Length, NumSections)
 {
 	mCurve = true;
+
+	mStart.Transform = lcMatrix44(lcMatrix33(lcVector3(0.0f, 0.0f, 1.0f), lcVector3(1.0f, 0.0f, 0.0f), lcVector3(0.0f, 1.0f, 0.0f)), lcVector3(0.0f, 0.0f, 0.0f));
+	mEnd.Transform = lcMatrix44(lcMatrix33(lcVector3(0.0f, 0.0f, 1.0f), lcVector3(1.0f, 0.0f, 0.0f), lcVector3(0.0f, 1.0f, 0.0f)), lcVector3(0.0f, 0.0f, 0.0f));
 }
 
 lcSynthInfoFlexibleHose::lcSynthInfoFlexibleHose(float Length, int NumSections, const char* EdgePart2)
 	: lcSynthInfoCurved(lcSynthType::HOSE_FLEXIBLE, Length, NumSections), mEdgePart2(EdgePart2)
 {
+	mRigidEdges = true;
+	mStart.Length = 5.0f;
+	mMiddle.Length = 2.56f;
+	mEnd.Length = 5.0f;
+	mCenterLength = 4.56f;
 }
 
 lcSynthInfoFlexSystemHose::lcSynthInfoFlexSystemHose(float Length, int NumSections)
 	: lcSynthInfoCurved(lcSynthType::FLEX_SYSTEM_HOSE, Length, NumSections)
 {
+	mRigidEdges = true;
+	mStart.Transform = lcMatrix44Identity();
+	mEnd.Transform = lcMatrix44Identity();
+	mStart.Length = 1.0f;
+	mMiddle.Length = 2.0f;
+	mEnd.Length = 1.0f;
 }
 
 lcSynthInfoRibbedHose::lcSynthInfoRibbedHose(float Length, int NumSections)
 	: lcSynthInfoCurved(lcSynthType::RIBBED_HOSE, Length, NumSections)
 {
+	mStart.Length = 6.25f;
+	mMiddle.Length = 6.25f;
+	mEnd.Length = 6.25f;
 }
 
 lcSynthInfoFlexibleAxle::lcSynthInfoFlexibleAxle(float Length, int NumSections)
 	: lcSynthInfoCurved(lcSynthType::FLEXIBLE_AXLE, Length, NumSections)
 {
+	mRigidEdges = true;
+	mStart.Length = 30.0f;
+	mMiddle.Length = 4.0f;
+	mEnd.Length = 30.0f;
 }
 
 lcSynthInfoBraidedString::lcSynthInfoBraidedString(float Length, int NumSections)
 	: lcSynthInfoCurved(lcSynthType::STRING_BRAIDED, Length, NumSections)
 {
+	mRigidEdges = true;
+	mStart.Transform = lcMatrix44Identity();
+	mEnd.Transform = lcMatrix44Identity();
+	mStart.Length = 8.0f;
+	mMiddle.Length = 4.0f;
+	mEnd.Length = 8.0f;
 }
 
 lcSynthInfoStraight::lcSynthInfoStraight(lcSynthType Type, float Length)

--- a/common/lc_synth.cpp
+++ b/common/lc_synth.cpp
@@ -420,6 +420,7 @@ lcSynthInfoBraidedString::lcSynthInfoBraidedString(float Length, int NumSections
 lcSynthInfoStraight::lcSynthInfoStraight(float Length)
 	: lcSynthInfo(Length)
 {
+	mUnidirectional = true;
 }
 
 lcSynthInfoShockAbsorber::lcSynthInfoShockAbsorber(const char* SpringPart)
@@ -435,6 +436,7 @@ lcSynthInfoActuator::lcSynthInfoActuator(float Length)
 lcSynthInfoUniversalJoint::lcSynthInfoUniversalJoint(float Length, const char* EndPart, const char* CenterPart)
 	: lcSynthInfo(Length), mEndPart(EndPart), mCenterPart(CenterPart)
 {
+	mNondirectional = true;
 }
 
 void lcSynthInfoCurved::GetDefaultControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const

--- a/common/lc_synth.h
+++ b/common/lc_synth.h
@@ -45,13 +45,7 @@ public:
 protected:
 	using SectionCallbackFunc = std::function<void(const lcVector3& CurvePoint, int SegmentIndex, float t)>;
 	virtual void CalculateSections(const lcArray<lcPieceControlPoint>& ControlPoints, lcArray<lcMatrix44>& Sections, SectionCallbackFunc SectionCallback) const = 0;
-	void AddHoseFlexibleParts(lcMemFile& File, const lcArray<lcMatrix44>& Sections) const;
-	void AddFlexHoseParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const;
-	void AddRibbedHoseParts(lcMemFile& File, const lcArray<lcMatrix44>& Sections) const;
-	void AddFlexibleAxleParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const;
-	void AddStringBraidedParts(lcMemFile& File, lcLibraryMeshData& MeshData, lcArray<lcMatrix44>& Sections) const;
-	void AddShockAbsorberParts(lcMemFile& File, lcArray<lcMatrix44>& Sections) const;
-	void AddActuatorParts(lcMemFile& File, lcArray<lcMatrix44>& Sections) const;
+	virtual void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const = 0;
 
 	PieceInfo* mPieceInfo;
 	lcSynthType mType;

--- a/common/lc_synth.h
+++ b/common/lc_synth.h
@@ -22,6 +22,7 @@ public:
 	}
 
 	virtual void GetDefaultControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const = 0;
+	virtual void VerifyControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const = 0;
 	int InsertControlPoint(lcArray<lcPieceControlPoint>& ControlPoints, const lcVector3& Start, const lcVector3& End) const;
 	lcMesh* CreateMesh(const lcArray<lcPieceControlPoint>& ControlPoints) const;
 

--- a/common/lc_synth.h
+++ b/common/lc_synth.h
@@ -21,6 +21,16 @@ public:
 		return mCurve;
 	}
 
+	bool IsUnidirectional() const
+	{
+		return mUnidirectional;
+	}
+
+	bool IsNondirectional() const
+	{
+		return mNondirectional;
+	}
+
 	virtual void GetDefaultControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const = 0;
 	virtual void VerifyControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const = 0;
 	int InsertControlPoint(lcArray<lcPieceControlPoint>& ControlPoints, const lcVector3& Start, const lcVector3& End) const;
@@ -32,6 +42,8 @@ protected:
 	virtual void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const = 0;
 
 	bool mCurve = false;
+	bool mUnidirectional = false;
+	bool mNondirectional = false;
 	float mLength;
 };
 

--- a/common/lc_synth.h
+++ b/common/lc_synth.h
@@ -14,18 +14,12 @@ enum class lcSynthType
 	ACTUATOR
 };
 
-struct lcSynthComponent
-{
-	lcMatrix44 Transform;
-	float Length;
-};
-
 class lcLibraryMeshData;
 
 class lcSynthInfo
 {
 public:
-	lcSynthInfo(lcSynthType Type, float Length, int NumSections);
+	lcSynthInfo(lcSynthType Type, float Length);
 	virtual ~lcSynthInfo() = default;
 
 	bool CanAddControlPoints() const
@@ -48,14 +42,8 @@ protected:
 	virtual void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const = 0;
 
 	lcSynthType mType;
-	lcSynthComponent mStart;
-	lcSynthComponent mMiddle;
-	lcSynthComponent mEnd;
 	bool mCurve = false;
 	float mLength;
-	float mCenterLength = 0.0f;
-	int mNumSections;
-	bool mRigidEdges = false;
 };
 
 void lcSynthInit();

--- a/common/lc_synth.h
+++ b/common/lc_synth.h
@@ -25,7 +25,7 @@ class lcLibraryMeshData;
 class lcSynthInfo
 {
 public:
-	lcSynthInfo(lcSynthType Type, float Length, int NumSections, PieceInfo* Info);
+	lcSynthInfo(lcSynthType Type, float Length, int NumSections);
 	virtual ~lcSynthInfo() = default;
 
 	bool CanAddControlPoints() const
@@ -47,7 +47,6 @@ protected:
 	virtual void CalculateSections(const lcArray<lcPieceControlPoint>& ControlPoints, lcArray<lcMatrix44>& Sections, SectionCallbackFunc SectionCallback) const = 0;
 	virtual void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const = 0;
 
-	PieceInfo* mPieceInfo;
 	lcSynthType mType;
 	lcSynthComponent mStart;
 	lcSynthComponent mMiddle;

--- a/common/lc_synth.h
+++ b/common/lc_synth.h
@@ -26,6 +26,7 @@ class lcSynthInfo
 {
 public:
 	lcSynthInfo(lcSynthType Type, float Length, int NumSections, PieceInfo* Info);
+	virtual ~lcSynthInfo() = default;
 
 	bool CanAddControlPoints() const
 	{
@@ -42,10 +43,8 @@ public:
 	lcMesh* CreateMesh(const lcArray<lcPieceControlPoint>& ControlPoints) const;
 
 protected:
-	float GetSectionTwist(const lcMatrix44& StartTransform, const lcMatrix44& EndTransform) const;
 	using SectionCallbackFunc = std::function<void(const lcVector3& CurvePoint, int SegmentIndex, float t)>;
-	void CalculateCurveSections(const lcArray<lcPieceControlPoint>& ControlPoints, lcArray<lcMatrix44>& Sections, SectionCallbackFunc SectionCallback) const;
-	void CalculateLineSections(const lcArray<lcPieceControlPoint>& ControlPoints, lcArray<lcMatrix44>& Sections, SectionCallbackFunc SectionCallback) const;
+	virtual void CalculateSections(const lcArray<lcPieceControlPoint>& ControlPoints, lcArray<lcMatrix44>& Sections, SectionCallbackFunc SectionCallback) const = 0;
 	void AddHoseFlexibleParts(lcMemFile& File, const lcArray<lcMatrix44>& Sections) const;
 	void AddFlexHoseParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const;
 	void AddRibbedHoseParts(lcMemFile& File, const lcArray<lcMatrix44>& Sections) const;
@@ -59,7 +58,7 @@ protected:
 	lcSynthComponent mStart;
 	lcSynthComponent mMiddle;
 	lcSynthComponent mEnd;
-	bool mCurve;
+	bool mCurve = false;
 	float mLength;
 	float mCenterLength;
 	int mNumSections;

--- a/common/lc_synth.h
+++ b/common/lc_synth.h
@@ -38,7 +38,7 @@ public:
 		return mCurve;
 	}
 
-	void GetDefaultControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const;
+	virtual void GetDefaultControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const = 0;
 	int InsertControlPoint(lcArray<lcPieceControlPoint>& ControlPoints, const lcVector3& Start, const lcVector3& End) const;
 	lcMesh* CreateMesh(const lcArray<lcPieceControlPoint>& ControlPoints) const;
 

--- a/common/lc_synth.h
+++ b/common/lc_synth.h
@@ -53,9 +53,9 @@ protected:
 	lcSynthComponent mEnd;
 	bool mCurve = false;
 	float mLength;
-	float mCenterLength;
+	float mCenterLength = 0.0f;
 	int mNumSections;
-	bool mRigidEdges;
+	bool mRigidEdges = false;
 };
 
 void lcSynthInit();

--- a/common/lc_synth.h
+++ b/common/lc_synth.h
@@ -3,23 +3,12 @@
 #include "lc_math.h"
 #include "piece.h"
 
-enum class lcSynthType
-{
-	HOSE_FLEXIBLE,
-	FLEX_SYSTEM_HOSE,
-	RIBBED_HOSE,
-	FLEXIBLE_AXLE,
-	STRING_BRAIDED,
-	SHOCK_ABSORBER,
-	ACTUATOR
-};
-
 class lcLibraryMeshData;
 
 class lcSynthInfo
 {
 public:
-	lcSynthInfo(lcSynthType Type, float Length);
+	explicit lcSynthInfo(float Length);
 	virtual ~lcSynthInfo() = default;
 
 	bool CanAddControlPoints() const
@@ -41,7 +30,6 @@ protected:
 	virtual void CalculateSections(const lcArray<lcPieceControlPoint>& ControlPoints, lcArray<lcMatrix44>& Sections, SectionCallbackFunc SectionCallback) const = 0;
 	virtual void AddParts(lcMemFile& File, lcLibraryMeshData& MeshData, const lcArray<lcMatrix44>& Sections) const = 0;
 
-	lcSynthType mType;
 	bool mCurve = false;
 	float mLength;
 };

--- a/common/piece.cpp
+++ b/common/piece.cpp
@@ -797,19 +797,27 @@ void lcPiece::RotatePivotPoint(const lcMatrix33& RotationMatrix)
 
 quint32 lcPiece::GetAllowedTransforms() const
 {
+	const quint32 Move = LC_OBJECT_TRANSFORM_MOVE_X | LC_OBJECT_TRANSFORM_MOVE_Y | LC_OBJECT_TRANSFORM_MOVE_Z;
+	const quint32 Rotate = LC_OBJECT_TRANSFORM_ROTATE_X | LC_OBJECT_TRANSFORM_ROTATE_Y | LC_OBJECT_TRANSFORM_ROTATE_Z;
 	quint32 Section = GetFocusSection();
 
 	if (Section == LC_PIECE_SECTION_POSITION || Section == LC_PIECE_SECTION_INVALID)
-		return LC_OBJECT_TRANSFORM_MOVE_X | LC_OBJECT_TRANSFORM_MOVE_Y | LC_OBJECT_TRANSFORM_MOVE_Z | LC_OBJECT_TRANSFORM_ROTATE_X | LC_OBJECT_TRANSFORM_ROTATE_Y | LC_OBJECT_TRANSFORM_ROTATE_Z;
+		return Move | Rotate;
 
 	lcSynthInfo* SynthInfo = mPieceInfo->GetSynthInfo();
-	if (!SynthInfo)
-		return 0;
+	if (SynthInfo)
+	{
+		if (SynthInfo->IsUnidirectional())
+			return LC_OBJECT_TRANSFORM_MOVE_Z;
 
-	if (SynthInfo->IsCurve())
-		return LC_OBJECT_TRANSFORM_MOVE_X | LC_OBJECT_TRANSFORM_MOVE_Y | LC_OBJECT_TRANSFORM_MOVE_Z | LC_OBJECT_TRANSFORM_ROTATE_X | LC_OBJECT_TRANSFORM_ROTATE_Y | LC_OBJECT_TRANSFORM_ROTATE_Z | LC_OBJECT_TRANSFORM_SCALE_X;
-	else
-		return LC_OBJECT_TRANSFORM_MOVE_Z;
+		if (SynthInfo->IsCurve())
+			return Move | Rotate | LC_OBJECT_TRANSFORM_SCALE_X;
+
+		if (SynthInfo->IsNondirectional())
+			return Move;
+	}
+
+	return 0;
 }
 
 bool lcPiece::CanAddControlPoint() const

--- a/common/piece.cpp
+++ b/common/piece.cpp
@@ -866,6 +866,22 @@ bool lcPiece::RemoveFocusedControlPoint()
 	return true;
 }
 
+void lcPiece::VerifyControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const
+{
+	lcSynthInfo* SynthInfo = mPieceInfo->GetSynthInfo();
+	if (!SynthInfo)
+	{
+		ControlPoints.RemoveAll();
+	}
+	else
+	{
+		if (ControlPoints.GetSize() > LC_MAX_CONTROL_POINTS)
+			ControlPoints.SetSize(LC_MAX_CONTROL_POINTS);
+
+		SynthInfo->VerifyControlPoints(ControlPoints);
+	}
+}
+
 const char* lcPiece::GetName() const
 {
 	return mPieceInfo->m_strDescription;

--- a/common/piece.h
+++ b/common/piece.h
@@ -431,11 +431,8 @@ public:
 
 	void SetControlPoints(const lcArray<lcPieceControlPoint>& ControlPoints)
 	{
-		if (ControlPoints.GetSize() > 1)
-		{
-			mControlPoints = ControlPoints;
-			UpdateMesh();
-		}
+		mControlPoints = ControlPoints;
+		UpdateMesh();
 	}
 
 	void SetControlPointScale(int ControlPointIndex, float Scale)
@@ -472,6 +469,7 @@ public:
 
 	bool InsertControlPoint(const lcVector3& WorldStart, const lcVector3& WorldEnd);
 	bool RemoveFocusedControlPoint();
+	void VerifyControlPoints(lcArray<lcPieceControlPoint>& ControlPoints) const;
 
 	lcGroup* GetTopGroup();
 


### PR DESCRIPTION
This patch series adds synthesis of Technic Universal Joints. As a preparation, the class `lcSynthInfo` is rewritten into an abstract base class with derived classes for each kind of synthesized pieces.