### PR TITLE
Work around ambiguous operator== reported by modern clang.

### DIFF
--- a/common/lc_model.h
+++ b/common/lc_model.h
@@ -48,7 +48,7 @@ public:
 	void LoadDefaults();
 	void SaveDefaults();
 
-	bool operator==(const lcModelProperties& Properties)
+	bool operator==(const lcModelProperties& Properties) const
 	{
 		if (mFileName != Properties.mFileName || mModelName != Properties.mModelName || mAuthor != Properties.mAuthor ||
 			mDescription != Properties.mDescription || mComments != Properties.mComments)


### PR DESCRIPTION
The warning is about an ambiguity between a regular call and one with the
argument order reversed. Mark the operator const so that both operands are
treated equally.