### PR TITLE
Small code modernization around file handling during parts loading.

### DIFF
--- a/common/lc_library.cpp
+++ b/common/lc_library.cpp
@@ -330,11 +330,6 @@ bool lcPiecesLibrary::OpenArchive(lcFile* File, const QString& FileName, lcZipFi
 
 	mZipFiles[ZipFileType] = ZipFile;
 
-	if (ZipFileType == LC_ZIPFILE_OFFICIAL)
-		mLibraryFileName = FileName;
-	else
-		mUnofficialFileName = FileName;
-
 	for (int FileIdx = 0; FileIdx < ZipFile->mFiles.GetSize(); FileIdx++)
 	{
 		lcZipFileInfo& FileInfo = ZipFile->mFiles[FileIdx];

--- a/common/lc_library.cpp
+++ b/common/lc_library.cpp
@@ -307,22 +307,19 @@ bool lcPiecesLibrary::Load(const QString& LibraryPath, bool ShowProgress)
 
 bool lcPiecesLibrary::OpenArchive(const QString& FileName, lcZipFileType ZipFileType)
 {
-	lcDiskFile* File = new lcDiskFile(FileName);
+	std::unique_ptr<lcDiskFile> File(new lcDiskFile(FileName));
 
-	if (!File->Open(QIODevice::ReadOnly) || !OpenArchive(File, FileName, ZipFileType))
-	{
-		delete File;
+	if (!File->Open(QIODevice::ReadOnly))
 		return false;
-	}
 
-	return true;
+	return OpenArchive(std::move(File), FileName, ZipFileType);
 }
 
-bool lcPiecesLibrary::OpenArchive(lcFile* File, const QString& FileName, lcZipFileType ZipFileType)
+bool lcPiecesLibrary::OpenArchive(std::unique_ptr<lcFile> File, const QString& FileName, lcZipFileType ZipFileType)
 {
 	lcZipFile* ZipFile = new lcZipFile();
 
-	if (!ZipFile->OpenRead(File))
+	if (!ZipFile->OpenRead(std::move(File)))
 	{
 		delete ZipFile;
 		return false;
@@ -1865,14 +1862,11 @@ bool lcPiecesLibrary::LoadBuiltinPieces()
 	if (!Resource.isValid())
 		return false;
 
-	lcMemFile* File = new lcMemFile();
+	std::unique_ptr<lcMemFile> File(new lcMemFile());
 	File->WriteBuffer(Resource.data(), Resource.size());
 
-	if (!OpenArchive(File, "builtin", LC_ZIPFILE_OFFICIAL))
-	{
-		delete File;
+	if (!OpenArchive(std::move(File), "builtin", LC_ZIPFILE_OFFICIAL))
 		return false;
-	}
 
 	lcMemFile PieceFile;
 

--- a/common/lc_library.cpp
+++ b/common/lc_library.cpp
@@ -44,8 +44,6 @@ lcPiecesLibrary::lcPiecesLibrary()
 	Dir.mkpath(mCachePath);
 
 	mNumOfficialPieces = 0;
-	mZipFiles[LC_ZIPFILE_OFFICIAL] = nullptr;
-	mZipFiles[LC_ZIPFILE_UNOFFICIAL] = nullptr;
 	mBuffersDirty = false;
 	mHasUnofficial = false;
 	mCancelLoading = false;
@@ -77,9 +75,7 @@ void lcPiecesLibrary::Unload()
 	mTextures.clear();
 
 	mNumOfficialPieces = 0;
-	delete mZipFiles[LC_ZIPFILE_OFFICIAL];
 	mZipFiles[LC_ZIPFILE_OFFICIAL] = nullptr;
-	delete mZipFiles[LC_ZIPFILE_UNOFFICIAL];
 	mZipFiles[LC_ZIPFILE_UNOFFICIAL] = nullptr;
 }
 
@@ -317,15 +313,10 @@ bool lcPiecesLibrary::OpenArchive(const QString& FileName, lcZipFileType ZipFile
 
 bool lcPiecesLibrary::OpenArchive(std::unique_ptr<lcFile> File, const QString& FileName, lcZipFileType ZipFileType)
 {
-	lcZipFile* ZipFile = new lcZipFile();
+	std::unique_ptr<lcZipFile> ZipFile(new lcZipFile());
 
 	if (!ZipFile->OpenRead(std::move(File)))
-	{
-		delete ZipFile;
 		return false;
-	}
-
-	mZipFiles[ZipFileType] = ZipFile;
 
 	for (int FileIdx = 0; FileIdx < ZipFile->mFiles.GetSize(); FileIdx++)
 	{
@@ -423,6 +414,8 @@ bool lcPiecesLibrary::OpenArchive(std::unique_ptr<lcFile> File, const QString& F
 				Primitive->SetZipFile(ZipFileType, FileIdx);
 		}
 	}
+
+	mZipFiles[ZipFileType] = std::move(ZipFile);
 
 	return true;
 }

--- a/common/lc_library.h
+++ b/common/lc_library.h
@@ -194,8 +194,6 @@ protected:
 
 	QString mCachePath;
 	qint64 mArchiveCheckSum[4];
-	QString mLibraryFileName;
-	QString mUnofficialFileName;
 	lcZipFile* mZipFiles[LC_NUM_ZIPFILES];
 	bool mHasUnofficial;
 	bool mCancelLoading;

--- a/common/lc_library.h
+++ b/common/lc_library.h
@@ -167,7 +167,7 @@ signals:
 
 protected:
 	bool OpenArchive(const QString& FileName, lcZipFileType ZipFileType);
-	bool OpenArchive(lcFile* File, const QString& FileName, lcZipFileType ZipFileType);
+	bool OpenArchive(std::unique_ptr<lcFile> File, const QString& FileName, lcZipFileType ZipFileType);
 	bool OpenDirectory(const QDir& LibraryDir, bool ShowProgress);
 	void ReadArchiveDescriptions(const QString& OfficialFileName, const QString& UnofficialFileName);
 	void ReadDirectoryDescriptions(const QFileInfoList (&FileLists)[LC_NUM_FOLDERTYPES], bool ShowProgress);

--- a/common/lc_library.h
+++ b/common/lc_library.h
@@ -194,7 +194,7 @@ protected:
 
 	QString mCachePath;
 	qint64 mArchiveCheckSum[4];
-	lcZipFile* mZipFiles[LC_NUM_ZIPFILES];
+	std::unique_ptr<lcZipFile> mZipFiles[LC_NUM_ZIPFILES];
 	bool mHasUnofficial;
 	bool mCancelLoading;
 };

--- a/common/lc_zipfile.h
+++ b/common/lc_zipfile.h
@@ -58,7 +58,7 @@ public:
 	lcZipFile& operator=(lcZipFile&&) = delete;
 
 	bool OpenRead(const QString& FileName);
-	bool OpenRead(lcFile* File);
+	bool OpenRead(std::unique_ptr<lcFile> File);
 	bool OpenWrite(const QString& FileName);
 
 	bool ExtractFile(int FileIndex, lcMemFile& File, quint32 MaxLength = 0xffffffff);
@@ -74,7 +74,7 @@ protected:
 	bool CheckFileCoherencyHeader(int FileIndex, quint32* SizeVar, quint64* OffsetLocalExtraField, quint32* SizeLocalExtraField);
 
 	QMutex mMutex;
-	lcFile* mFile;
+	std::unique_ptr<lcFile> mFile;
 
 	bool mModified;
 	bool mZip64;


### PR DESCRIPTION
Use unique_ptr<> to keep file and ZIP file objects to clarify ownership.

This is just code modernization and does not fix a bug nor change
any behavior.