### PR TITLE
Fixed initialization order at compile time

### DIFF
--- a/common/lc_pagesetupdialog.h
+++ b/common/lc_pagesetupdialog.h
@@ -17,6 +17,6 @@ public slots:
 	void accept() override;
 
 private:
-	lcInstructionsPageSetup* mPageSetup;
 	Ui::lcPageSetupDialog *ui;
+	lcInstructionsPageSetup* mPageSetup;
 };


### PR DESCRIPTION
Closes #593 

It seems pretty much that a compile warning appears because of the ordering at the constructor assignments (after the `:`). In this way, this commit would lead to a more cleaner build.