### PR TITLE
Correct v21.01 download links

### DIFF
--- a/download.html
+++ b/download.html
@@ -29,16 +29,16 @@
           <h1>Downloads</h1>
           <div class="subHeader"></div>
 	<p>LeoCAD is very easy to install, and it is available for all major operating systems. In the sections below, you will find detailed instructions on how to download and install the application for each operating system.</p>
-        <h2>Windows</h2>
-	<p>Click the button below to download the latest version of the LeoCAD installer. Once the download is complete, run the installer and follow the installation instructions.</p>
-        <div class="buttons-unit downloads"><a href="https://github.com/leozide/leocad/releases/download/v19.07.1/LeoCAD-Windows-21.01.exe" class="button">Download LeoCAD for Windows</a></div>
         <h2>Linux</h2>
 	<p>Click the button below to download the latest LeoCAD AppImage. Once the download is complete, simply run the file.</p>
 	<p>If you prefer to compile it yourself, go to the <a href="https://github.com/leozide/leocad/releases">GitHub Releases Page</a> and download the latest source code archive.</p>
-        <div class="buttons-unit downloads"><a href="https://github.com/leozide/leocad/releases/download/v19.07.1/LeoCAD-Linux-21.01-x86_64.AppImage" class="button">Download LeoCAD for Linux</a></div>
+        <div class="buttons-unit downloads"><a href="https://github.com/leozide/leocad/releases/download/v21.01/LeoCAD-Linux-21.01-x86_64.AppImage" class="button">Download LeoCAD for Linux</a></div>
         <h2>macOS</h2>
 	<p>Click the button below to download the latest version of the LeoCAD DMG package. Once the download is complete, open the package and drag its contents to your &ldquo;Applications&rdquo; folder.</p>
-        <div class="buttons-unit downloads"><a href="https://github.com/leozide/leocad/releases/download/v19.07.1/LeoCAD-macOS-21.01.dmg" class="button">Download LeoCAD for macOS</a></div>
+        <div class="buttons-unit downloads"><a href="https://github.com/leozide/leocad/releases/download/v21.01/LeoCAD-macOS-21.01.dmg" class="button">Download LeoCAD for macOS</a></div>
+        <h2>Windows</h2>
+	<p>Click the button below to download the latest version of the LeoCAD installer. Once the download is complete, run the installer and follow the installation instructions.</p>
+        <div class="buttons-unit downloads"><a href="https://github.com/leozide/leocad/releases/download/v21.01/LeoCAD-Windows-21.01.exe" class="button">Download LeoCAD for Windows</a></div>
         </div>
       </section>
 <!-- footer start -->


### PR DESCRIPTION
- Correct  `v21.01` download links (broken in https://github.com/leozide/leocad/commit/14efa7c9fba7b4ecc3b8a1ce31d97ff8ba50cdfb )
  - Broken:  `https://github.com/leozide/leocad/releases/download/v19.07.1/LeoCAD-*-21.01.*`
  - Correct:  `https://github.com/leozide/leocad/releases/download/v21.01/LeoCAD-*-21.01.*`
- Sort platforms in alphabetical order (`Linux/macOS/Windows` instead of `Windows/Linux/macOS`).