### PR TITLE
Include GL/gl.h as necessary with Qt 5.15 on aarch64

### DIFF
--- a/qt/lc_qpreferencesdialog.cpp
+++ b/qt/lc_qpreferencesdialog.cpp
@@ -1,3 +1,5 @@
+#include <GL/gl.h>
+
 #include "lc_global.h"
 #include "lc_qpreferencesdialog.h"
 #include "ui_lc_qpreferencesdialog.h"


### PR DESCRIPTION
This is the second fix I needed for the flatpak on aarch64. Because of Qt 5.15