### PR TITLE
Accept LDview mimetype for MPD

### DIFF
--- a/qt/leocad.desktop
+++ b/qt/leocad.desktop
@@ -11,7 +11,7 @@ Exec=leocad %f
 Terminal=false
 Type=Application
 Icon=leocad
-MimeType=application/vnd.leocad;application/x-ldraw;application/x-multi-part-ldraw;application/x-ldlite;
+MimeType=application/vnd.leocad;application/x-ldraw;application/x-multi-part-ldraw;application/x-multipart-ldraw;application/x-ldlite;
 Categories=Graphics;3DGraphics;Education;
 Keywords=CAD;LEGO;LDraw;
 


### PR DESCRIPTION
If LDview is installed (Linux, etc), chances that MPD files have its MIME type are non zero. This allow alternatively to open the file in LeoCAD from the file manager.