### PR TITLE
Fix crash when opening a file

### DIFF
--- a/common/lc_mainwindow.h
+++ b/common/lc_mainwindow.h
@@ -45,6 +45,13 @@ public:
 		mModel = Model;
 		mActiveView = nullptr;
 	}
+	~lcModelTabWidget()
+	{
+		for (auto View : mViews)
+		{
+			RemoveView(View);
+		}
+	}
 
 	void ResetLayout();
 	void Clear();


### PR DESCRIPTION
- This is caught by the AddressSanitzer
- Removing the tab before deleting the object avoid trying to remove
the widget tab in the destructors (use-after-free)