### PR TITLE
Fix check for type of mesh index.

### DIFF
--- a/common/lc_meshloader.cpp
+++ b/common/lc_meshloader.cpp
@@ -1123,7 +1123,7 @@ lcMesh* lcLibraryMeshData::CreateMesh()
 			if (DstSection.Texture)
 				DstSection.Texture->AddRef();
 
-			if (Mesh->mNumVertices < 0x10000)
+			if (Mesh->mIndexType == GL_UNSIGNED_SHORT)
 			{
 				DstSection.IndexOffset = NumIndices * 2;
 
@@ -1294,7 +1294,7 @@ void lcLibraryMeshData::UpdateMeshBoundingBox(lcMesh* Mesh)
 			lcMeshSection& Section = Lod.Sections[SectionIdx];
 			lcVector3 SectionMin(FLT_MAX, FLT_MAX, FLT_MAX), SectionMax(-FLT_MAX, -FLT_MAX, -FLT_MAX);
 
-			if (Mesh->mNumVertices < 0x10000)
+			if (Mesh->mIndexType == GL_UNSIGNED_SHORT)
 				UpdateMeshSectionBoundingBox<quint16>(Mesh, Section, SectionMin, SectionMax);
 			else
 				UpdateMeshSectionBoundingBox<quint32>(Mesh, Section, SectionMin, SectionMax);


### PR DESCRIPTION
The index type does not only depend on the number of geometry vertices,
but also on the number of conditional line vertices. Check the stored
type, not the number of vertices.