### PR TITLE
Fix incorrect control points of second and later synthesized pieces.

### DIFF
--- a/common/lc_model.cpp
+++ b/common/lc_model.cpp
@@ -659,6 +659,7 @@ void lcModel::LoadLDraw(QIODevice& Device, Project* Project)
 				Piece->SetColorCode(ColorCode);
 				Piece->VerifyControlPoints(ControlPoints);
 				Piece->SetControlPoints(ControlPoints);
+				ControlPoints.RemoveAll();
 
 				if (Piece->mPieceInfo->IsModel() && Piece->mPieceInfo->GetModel()->IncludesModel(this))
 				{


### PR DESCRIPTION
When a model that was not create by LeoCAD contains two different pieces
that are handled by lcSynth, then a set of default control points is
generated for the first piece. When the following synthesized pieces are
loaded, this set of control points is reused for the other pieces. But
the values generated for the first piece may not be a suitable default
for the subsequent pieces. Clear the control points after they have been
applied to a piece so that later pieces receive a new set of defaults.