### PR TITLE
Make pieces of a step visible when a new step is selected.

### DIFF
--- a/common/lc_timelinewidget.cpp
+++ b/common/lc_timelinewidget.cpp
@@ -265,6 +265,14 @@ void lcTimelineWidget::UpdateCurrentStepItem()
 			QFont Font = CurrentStepItem->font(0);
 			Font.setBold(true);
 			CurrentStepItem->setFont(0, Font);
+
+			// to make as many pieces of the step as possible visible,
+			// scroll to the step's last piece
+			auto NumChildren = CurrentStepItem->childCount();
+			if (NumChildren && CurrentStepItem->isExpanded())
+				scrollToItem(CurrentStepItem->child(NumChildren - 1));
+
+			// and then scroll to the step header
 			setCurrentItem(CurrentStepItem);
 		}
 


### PR DESCRIPTION
When a step is selected that is above the currently visible range, then
the step header is made visible in the top row, and consequently the
step's pieces become visible naturally. But when a step is selected
that is below the currently visible range, then the step header would be
located in the last line, and the step's pieces remain obscured. Make it
so that in the latter case as many items as possible are made visible by
scrolling to the last piece before going to the step header.

This addresses a complaint expressed in issue #595.