### PR TITLE
Fix moving rotated pieces

### DIFF
--- a/common/piece.h
+++ b/common/piece.h
@@ -590,8 +590,6 @@ public:
 		{
 			if (mState & LC_PIECE_PIVOT_POINT_VALID)
 				return lcMatrix33(lcMul(mModelWorld, mPivotMatrix));
-			else
-				return lcMatrix33(mModelWorld);
 		}
 		else
 		{
@@ -602,9 +600,8 @@ public:
 				const lcMatrix44& Transform = mControlPoints[ControlPointIndex].Transform;
 				return lcMatrix33(lcMul(Transform, mModelWorld));
 			}
-
-			return lcMatrix33Identity();
 		}
+		return lcMatrix33Identity();
 	}
 
 	void ResetPivotPoint()


### PR DESCRIPTION
I was working on a model, and when tried to move rotated pieces, they would go into the wrong direction.

I have debugged a bit and found that this patch actually solves the problem, but since I am not very familiar with the code base, I am not completely sure it is the right solution.

Possibly solves #655