### PR TITLE
Add version to Program Entry

### DIFF
--- a/tools/setup/leocad.nsi
+++ b/tools/setup/leocad.nsi
@@ -78,8 +78,12 @@ Section "Application Files" SecLeoCAD
   
   CreateShortCut "$SMPROGRAMS\LeoCAD.lnk" "$INSTDIR\LeoCAD.exe"
 
-  ;Create uninstaller
+  ;Define the version which should show in the Add/Remove Programs Entry
+  !define /date PRODUCT_VERSION "%y.%m.%j"
+  
+  ;Create uninstaller 
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\LeoCAD" "DisplayName" "LeoCAD"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\LeoCAD" "DisplayVersion" "${PRODUCT_VERSION}"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\LeoCAD" "Publisher" "LeoCAD.org"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\LeoCAD" "DisplayIcon" '"$INSTDIR\LeoCAD.exe"'
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\LeoCAD" "UninstallString" '"$INSTDIR\uninstall.exe"'


### PR DESCRIPTION
This change should set the version in the Add/Remove Programs entry for LeoCAD to be the last two digits of the year, then the month, then the day of the year it was created.

Example of v21.06 -
Old: 
![image](https://user-images.githubusercontent.com/12611259/142040452-11ed5001-f06b-4592-8a12-3cf9304f5e04.png)
New:
![image](https://user-images.githubusercontent.com/12611259/142040868-4940de96-00fd-479b-a90a-a4b89cbbec01.png)

