### PR TITLE
L10n and ES i18n update

### DIFF
--- a/common/lc_application.cpp
+++ b/common/lc_application.cpp
@@ -830,7 +830,7 @@ lcCommandLineOptions lcApplication::ParseCommandLineOptions()
 			Options.StdOut += tr("  --no-highlight: Do not highlight parts in the steps they appear.\n");
 			Options.StdOut += tr("  --highlight-color: Renderinng color for highlighted parts (#AARRGGBB).\n");
 			Options.StdOut += tr("  --shading <wireframe|flat|default|full>: Select shading mode for rendering.\n");
-			Options.StdOut += tr("  --line-width <width>: Set the with of the edge lines.\n");
+			Options.StdOut += tr("  --line-width <width>: Set the width of the edge lines.\n");
 			Options.StdOut += tr("  --aa-samples <count>: AntiAliasing sample size (1, 2, 4, or 8).\n");
 			Options.StdOut += tr("  -scc, --stud-cylinder-color <#AARRGGBB>: High contrast stud cylinder color.\n");
 			Options.StdOut += tr("  -ec, --edge-color <#AARRGGBB>: High contrast edge color.\n");

--- a/common/lc_edgecolordialog.cpp
+++ b/common/lc_edgecolordialog.cpp
@@ -45,14 +45,14 @@ lcAutomateEdgeColorDialog::lcAutomateEdgeColorDialog(QWidget* Parent, bool ShowH
 		EdgeSettingsLayout->addWidget(ResetPartEdgeContrastButton,0,3);
 	}
 
-	QLabel* PartColorValueLDIndexLabel = new QLabel(tr(ShowHighContrastDialog ? "Light/Dark Value:" : "Saturation:"), this);
+	QLabel* PartColorValueLDIndexLabel = new QLabel(ShowHighContrastDialog ? tr("Light/Dark Value:") : tr("Saturation:"), this);
 	PartColorValueLDIndex = new QLabel(this);
 	PartColorValueLDIndexSlider = new QSlider(Qt::Horizontal, this);
 	PartColorValueLDIndexSlider->setRange(0, 100);
 	PartColorValueLDIndexSlider->setValue(mPartColorValueLDIndex * 100);
-	PartColorValueLDIndexSlider->setToolTip(tr(ShowHighContrastDialog ?
-		"Set to classify where color values are light or dark - e.g. Dark Bluish Gray (72) is light at 0.39." :
-		"Set to specify amount of edge color tint or shade from the saturation adjusted part color"));
+	PartColorValueLDIndexSlider->setToolTip(ShowHighContrastDialog ?
+		tr("Set to classify where color values are light or dark - e.g. Dark Bluish Gray (72) is light at 0.39.") :
+		tr("Set to specify amount of edge color tint or shade from the saturation adjusted part color"));
 	connect(PartColorValueLDIndexSlider, SIGNAL(valueChanged(int)), this, SLOT(SliderValueChanged(int)));
 	emit PartColorValueLDIndexSlider->valueChanged(PartColorValueLDIndexSlider->value());
 
@@ -176,7 +176,7 @@ void lcAutomateEdgeColorDialog::ColorButtonClicked()
 		if (lcGetPreferences().mAutomateEdgeColor)
 		{
 			QMessageBox msgBox;
-			msgBox.setText("Automate edge color appears to be enabled.<br>Black parts edge color will not be accessible.<br>Do you want to continue ?");
+			msgBox.setText(tr("Automate edge color appears to be enabled.<br>Black parts edge color will not be accessible.<br>Do you want to continue?"));
 			if (msgBox.exec() != QMessageBox::Accepted)
 				return;
 		}
@@ -188,7 +188,7 @@ void lcAutomateEdgeColorDialog::ColorButtonClicked()
 		if (lcGetPreferences().mAutomateEdgeColor)
 		{
 			QMessageBox msgBox;
-			msgBox.setText("Automate edge color appears to be enabled.<br>Dark parts edge color will not be accessible.<br>Do you want to continue ?");
+			msgBox.setText(tr("Automate edge color appears to be enabled.<br>Dark parts edge color will not be accessible.<br>Do you want to continue?"));
 			if (msgBox.exec() != QMessageBox::Accepted)
 				return;
 		}

--- a/common/lc_instructionsdialog.cpp
+++ b/common/lc_instructionsdialog.cpp
@@ -186,7 +186,7 @@ lcInstructionsPageListWidget::lcInstructionsPageListWidget(QWidget* Parent, lcIn
 	Layout->addLayout(ButtonsLayout);
 
 	QToolButton* PageSetupButton = new QToolButton();
-	PageSetupButton->setText("Page Setup");
+	PageSetupButton->setText(tr("Page Setup"));
 	ButtonsLayout->addWidget(PageSetupButton);
 
 	connect(PageSetupButton, SIGNAL(clicked()), this, SLOT(ShowPageSetupDialog()));
@@ -551,10 +551,10 @@ lcInstructionsDialog::lcInstructionsDialog(QWidget* Parent, Project* Project)
 
 	mPrintAction = mPageSettingsToolBar->addAction(tr("Print"));
 
-	mVerticalPageAction = mPageSettingsToolBar->addAction("Vertical");
+	mVerticalPageAction = mPageSettingsToolBar->addAction(tr("Vertical"));
 	mVerticalPageAction->setCheckable(true);
 
-	mHorizontalPageAction = mPageSettingsToolBar->addAction("Horizontal");
+	mHorizontalPageAction = mPageSettingsToolBar->addAction(tr("Horizontal"));
 	mHorizontalPageAction->setCheckable(true);
 
 	mRowsSpinBox = new QSpinBox(mPageSettingsToolBar);
@@ -568,7 +568,7 @@ lcInstructionsDialog::lcInstructionsDialog(QWidget* Parent, Project* Project)
 	PageDirectionGroup->addAction(mHorizontalPageAction);
 
 	for (size_t PageNumber = 0; PageNumber < mInstructions->mPages.size(); PageNumber++)
-		mPageListWidget->mThumbnailsWidget->addItem(QString("Page %1").arg(PageNumber + 1));
+		mPageListWidget->mThumbnailsWidget->addItem(QString(tr("Page %1")).arg(PageNumber + 1));
 
 	connect(mPageListWidget->mThumbnailsWidget, SIGNAL(currentRowChanged(int)), this, SLOT(CurrentThumbnailChanged(int)));
 	mPageListWidget->mThumbnailsWidget->setCurrentRow(0);

--- a/common/lc_partselectionwidget.cpp
+++ b/common/lc_partselectionwidget.cpp
@@ -899,7 +899,7 @@ void lcPartSelectionWidget::OptionsMenuAboutToShow()
 	QMenu* Menu = (QMenu*)sender();
 	Menu->clear();
 
-	Menu->addAction("Edit Palettes...", this, SLOT(EditPartPalettes()));
+	Menu->addAction(tr("Edit Palettes..."), this, SLOT(EditPartPalettes()));
 	Menu->addSeparator();
 
 	lcPartSelectionListModel* ListModel = mPartsWidget->GetListModel();

--- a/common/lc_previewwidget.cpp
+++ b/common/lc_previewwidget.cpp
@@ -74,10 +74,11 @@ void lcPreviewDockWidget::SetPreviewLock()
 	}
 
 	QIcon LockIcon(Locked ? ":/resources/action_preview_locked.png" : ":/resources/action_preview_unlocked.png");
-	QString State(Locked ? tr("Unlock") : tr("Lock"));
-	QString StatusTip(tr("%1 the preview display to %2 updates").arg(State).arg(Locked ? "enable" : "disable"));
+	QString StatusTip(Locked
+		? tr("Unlock the preview display to enable updates")
+		: tr("Lock the preview display to disable updates"));
 
-	mLockAction->setToolTip(tr("%1 Preview").arg(State));
+	mLockAction->setToolTip(Locked ? tr("Unlock Preview") : tr("Lock Preview"));
 	mLockAction->setIcon(LockIcon);
 	mLockAction->setStatusTip(StatusTip);
 }

--- a/docs/leocad.1
+++ b/docs/leocad.1
@@ -130,7 +130,7 @@ Select shading mode for rendering.
 
 .TP
 .BI "\-\-line-width " width
-Set the with of the edge lines.
+Set the width of the edge lines.
 
 .TP
 .BI "\-\-aa\-samples " count

--- a/resources/leocad_cs.ts
+++ b/resources/leocad_cs.ts
@@ -711,38 +711,37 @@
         <translation>Zobrazit.Kamery.Kamera16</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="981"/>
         <source>View.Cameras.Reset</source>
         <translatorcomment>TODO - přenastavit, obnovit, resetovat, vynulovat, obnovit tovární nastavení</translatorcomment>
-        <translation>Zobrazit.Kamery.Přenastavit</translation>
+        <translation type="vanished">Zobrazit.Kamery.Přenastavit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="988"/>
+        <location filename="../common/lc_commands.cpp" line="981"/>
         <source>View.Time.First</source>
         <translation>Zobrazit.Čas.První</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="995"/>
+        <location filename="../common/lc_commands.cpp" line="988"/>
         <source>View.Time.Previous</source>
         <translation>Zobrazit.Čas.Předchozí</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1002"/>
+        <location filename="../common/lc_commands.cpp" line="995"/>
         <source>View.Time.Next</source>
         <translation>Zobrazit.Čas.Další</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1009"/>
+        <location filename="../common/lc_commands.cpp" line="1002"/>
         <source>View.Time.Last</source>
         <translation>Zobrazit.Čas.Poslední</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1016"/>
+        <location filename="../common/lc_commands.cpp" line="1009"/>
         <source>View.Time.InsertBefore</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1023"/>
+        <location filename="../common/lc_commands.cpp" line="1016"/>
         <source>View.Time.InsertAfter</source>
         <translation></translation>
     </message>
@@ -751,554 +750,554 @@
         <translation type="vanished">Zobrazit.Čas.Vložit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1030"/>
+        <location filename="../common/lc_commands.cpp" line="1023"/>
         <source>View.Time.Delete</source>
         <translation>Čas.Zobrazit.Vymazat</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1037"/>
+        <location filename="../common/lc_commands.cpp" line="1030"/>
         <source>View.Time.AddKeys</source>
         <translation>Zobrazit.Čas.Přidat klíče</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1044"/>
+        <location filename="../common/lc_commands.cpp" line="1037"/>
         <source>View.SplitHorizontal</source>
         <translation>Zobrazit.Rozdělit vodorovně</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1051"/>
+        <location filename="../common/lc_commands.cpp" line="1044"/>
         <source>View.SplitVertical</source>
         <translation>Zobrazit.Rozdělit svisle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1058"/>
+        <location filename="../common/lc_commands.cpp" line="1051"/>
         <source>View.RemoveView</source>
         <translation>Zobrazit.Odstranit zobrazení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1065"/>
+        <location filename="../common/lc_commands.cpp" line="1058"/>
         <source>View.ResetViews</source>
         <translation>Zobrazit.Obnovit zobrazení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1072"/>
+        <location filename="../common/lc_commands.cpp" line="1065"/>
         <source>View.Toolbars.Standard</source>
         <translation>Zobrazit.Panely nástrojů.Standard</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1079"/>
+        <location filename="../common/lc_commands.cpp" line="1072"/>
         <source>View.Toolbars.Tools</source>
         <translation>Zobrazit.Panely nástrojů.Nástroje</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1086"/>
+        <location filename="../common/lc_commands.cpp" line="1079"/>
         <source>View.Toolbars.Time</source>
         <translation>Zobrazit.Panely nástrojů.Čas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1093"/>
+        <location filename="../common/lc_commands.cpp" line="1086"/>
         <source>View.Toolbars.Parts</source>
         <translation>Zobrazit.Panely nástrojů.Části</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1100"/>
+        <location filename="../common/lc_commands.cpp" line="1093"/>
         <source>View.Toolbars.Colors</source>
         <translation>Zobrazit.Panely nástrojů.Barvy</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1107"/>
+        <location filename="../common/lc_commands.cpp" line="1100"/>
         <source>View.Toolbars.Properties</source>
         <translation>Zobrazit.Panely nástrojů.Vlastnosti</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1114"/>
+        <location filename="../common/lc_commands.cpp" line="1107"/>
         <source>View.Toolbars.Timeline</source>
         <translation>Zobrazit.Panely nástrojů.Časová osa</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1121"/>
+        <location filename="../common/lc_commands.cpp" line="1114"/>
         <source>View.Toolbars.Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1128"/>
+        <location filename="../common/lc_commands.cpp" line="1121"/>
         <source>View.FullScreen</source>
         <translation>Zobrazit.Celá obrazovka</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1135"/>
+        <location filename="../common/lc_commands.cpp" line="1128"/>
         <source>View.CloseCurrentTab</source>
         <translation>Zobrazit.Zavřít aktuální kartu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1142"/>
+        <location filename="../common/lc_commands.cpp" line="1135"/>
         <source>View.Shade.Wireframe</source>
         <translation>Zobrazit.Stín.Schéma</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1149"/>
+        <location filename="../common/lc_commands.cpp" line="1142"/>
         <source>View.Shade.Flat</source>
         <translation>Zobrazit.Stín.Plochý</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1156"/>
+        <location filename="../common/lc_commands.cpp" line="1149"/>
         <source>View.Shade.DefaultLights</source>
         <translation>Zobrazit.Stín.Výchozí osvětlení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1163"/>
+        <location filename="../common/lc_commands.cpp" line="1156"/>
         <source>View.Projection.Perspective</source>
         <translation>Zobrazit.Projekce.Perspektivní</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1170"/>
+        <location filename="../common/lc_commands.cpp" line="1163"/>
         <source>View.Projection.Orthographic</source>
         <translation>Zobrazit.Projekce.Pravoúhlá</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1177"/>
+        <location filename="../common/lc_commands.cpp" line="1170"/>
         <source>View.ToggleViewSphere</source>
         <translatorcomment>TODO - space betwen words?</translatorcomment>
         <translation>Zobrazit.Přepnout sférické zobrazení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1184"/>
+        <location filename="../common/lc_commands.cpp" line="1177"/>
         <source>View.ToggleAxisIcon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1191"/>
+        <location filename="../common/lc_commands.cpp" line="1184"/>
         <source>View.ToggleGrid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1198"/>
+        <location filename="../common/lc_commands.cpp" line="1191"/>
         <source>View.FadePreviousSteps</source>
         <translation>Zobrazit.Zeslabit předchozí kroky</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1205"/>
+        <location filename="../common/lc_commands.cpp" line="1198"/>
         <source>Piece.Insert</source>
         <translatorcomment>TODO - kousek, kus, část</translatorcomment>
         <translation>Dílek.Vložit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1212"/>
+        <location filename="../common/lc_commands.cpp" line="1205"/>
         <source>Piece.Delete</source>
         <translation>Dílek.Odstranit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1219"/>
+        <location filename="../common/lc_commands.cpp" line="1212"/>
         <source>Piece.Duplicate</source>
         <translation>Dílek.Duplikovat</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1226"/>
+        <location filename="../common/lc_commands.cpp" line="1219"/>
         <source>Piece.PaintSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1233"/>
+        <location filename="../common/lc_commands.cpp" line="1226"/>
         <source>Piece.ResetPivotPoint</source>
         <translation>Dílek.Vynulovat bod otáčení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1240"/>
+        <location filename="../common/lc_commands.cpp" line="1233"/>
         <source>Piece.RemoveKeyFrames</source>
         <translation>Dílek.Odstranit klíčový snímek</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1247"/>
+        <location filename="../common/lc_commands.cpp" line="1240"/>
         <source>Piece.ControlPoint.Insert</source>
         <translation>Dílek.Kontrolní bod.Vložit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1254"/>
+        <location filename="../common/lc_commands.cpp" line="1247"/>
         <source>Piece.ControlPoint.Remove</source>
         <translation>Dílek.Kontrolní bod.Odstranit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1261"/>
+        <location filename="../common/lc_commands.cpp" line="1254"/>
         <source>Piece.Move.PlusX</source>
         <translation>Dílek.Posuny.PlusX</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1268"/>
+        <location filename="../common/lc_commands.cpp" line="1261"/>
         <source>Piece.Move.MinusX</source>
         <translation>Dílek.Posuny.MinusX</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1275"/>
+        <location filename="../common/lc_commands.cpp" line="1268"/>
         <source>Piece.Move.PlusY</source>
         <translation>Dílek.Posuny.PlusY</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1282"/>
+        <location filename="../common/lc_commands.cpp" line="1275"/>
         <source>Piece.Move.MinusY</source>
         <translation>Dílek.Posuny.MinusY</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1289"/>
+        <location filename="../common/lc_commands.cpp" line="1282"/>
         <source>Piece.Move.PlusZ</source>
         <translation>Dílek.Posuny.PlusZ</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1296"/>
+        <location filename="../common/lc_commands.cpp" line="1289"/>
         <source>Piece.Move.MinusZ</source>
         <translation>Dílek.Posuny.MinusZ</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1303"/>
+        <location filename="../common/lc_commands.cpp" line="1296"/>
         <source>Piece.Rotate.PlusX</source>
         <translation>Dílek.Otočení.PlusX</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1310"/>
+        <location filename="../common/lc_commands.cpp" line="1303"/>
         <source>Piece.Rotate.MinusX</source>
         <translation>Dílek.Otočení.MinusX</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1317"/>
+        <location filename="../common/lc_commands.cpp" line="1310"/>
         <source>Piece.Rotate.PlusY</source>
         <translation>Dílek.Otočení.PlusY</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1324"/>
+        <location filename="../common/lc_commands.cpp" line="1317"/>
         <source>Piece.Rotate.MinusY</source>
         <translation>Dílek.Otočení.MinusY</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1331"/>
+        <location filename="../common/lc_commands.cpp" line="1324"/>
         <source>Piece.Rotate.PlusZ</source>
         <translation>Dílek.Otočení.PlusZ</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1338"/>
+        <location filename="../common/lc_commands.cpp" line="1331"/>
         <source>Piece.Rotate.MinusZ</source>
         <translation>Dílek.Otočení.MinusZ</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1345"/>
+        <location filename="../common/lc_commands.cpp" line="1338"/>
         <source>Piece.MinifigWizard</source>
         <translation>Dílek.Průvodce Minifig</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1352"/>
+        <location filename="../common/lc_commands.cpp" line="1345"/>
         <source>Piece.Array</source>
         <translation>Dílek.Pole</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1359"/>
+        <location filename="../common/lc_commands.cpp" line="1352"/>
         <source>Piece.ViewSelectedModel</source>
         <translation>Dílek.Zobrazit vybraný model</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1366"/>
+        <location filename="../common/lc_commands.cpp" line="1359"/>
         <source>Piece.MoveSelectionToModel</source>
         <translation>Dílek.Přesunout výběr do modelu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1373"/>
+        <location filename="../common/lc_commands.cpp" line="1366"/>
         <source>Piece.InlineSelectedModels</source>
         <translation>Dílek.Vložené vybrané modely</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1380"/>
+        <location filename="../common/lc_commands.cpp" line="1373"/>
         <source>Piece.EditSelectedSubmodel</source>
         <translation>Dílek.Upravit vybraný podmodel</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1387"/>
+        <location filename="../common/lc_commands.cpp" line="1380"/>
         <source>Piece.EditEndSubmodel</source>
         <translation>Dílek.Upravit koncový podmodel</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1394"/>
+        <location filename="../common/lc_commands.cpp" line="1387"/>
         <source>Piece.Group</source>
         <translation>Dílek.Seskupit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1401"/>
+        <location filename="../common/lc_commands.cpp" line="1394"/>
         <source>Piece.Ungroup</source>
         <translation>Dílek.Rozdělit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1408"/>
+        <location filename="../common/lc_commands.cpp" line="1401"/>
         <source>Piece.GroupAdd</source>
         <translation>Dílek.Přidat skupinu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1415"/>
+        <location filename="../common/lc_commands.cpp" line="1408"/>
         <source>Piece.GroupRemove</source>
         <translation>Dílek.Odstranit skupinu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1422"/>
+        <location filename="../common/lc_commands.cpp" line="1415"/>
         <source>Piece.GroupEdit</source>
         <translation>Dílek.Upravit skupinu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1429"/>
+        <location filename="../common/lc_commands.cpp" line="1422"/>
         <source>Piece.HideSelected</source>
         <translation>Dílek.Skrýt vybrané</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1436"/>
+        <location filename="../common/lc_commands.cpp" line="1429"/>
         <source>Piece.HideUnselected</source>
         <translation>Dílek.Skrýt nevybrané</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1443"/>
+        <location filename="../common/lc_commands.cpp" line="1436"/>
         <source>Piece.UnhideSelected</source>
         <translation>Dílek.Zobrazit vybrané</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1450"/>
+        <location filename="../common/lc_commands.cpp" line="1443"/>
         <source>Piece.UnhideAll</source>
         <translation>Dílek.Zobrazit vše</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1457"/>
+        <location filename="../common/lc_commands.cpp" line="1450"/>
         <source>Piece.ShowEarlier</source>
         <translation>Dílek.Zobrazit dříve</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1464"/>
+        <location filename="../common/lc_commands.cpp" line="1457"/>
         <source>Piece.ShowLater</source>
         <translation>Dílek.Zobrazit později</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1471"/>
+        <location filename="../common/lc_commands.cpp" line="1464"/>
         <source>Model.New</source>
         <translation>Model.Nový</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1478"/>
+        <location filename="../common/lc_commands.cpp" line="1471"/>
         <source>Model.Properties</source>
         <translation>Model.Vlastnosti</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1485"/>
+        <location filename="../common/lc_commands.cpp" line="1478"/>
         <source>Model.List</source>
         <translation>Model.Seznam</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1492"/>
+        <location filename="../common/lc_commands.cpp" line="1485"/>
         <source>Model.Model01</source>
         <translation>Model.Model01</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1499"/>
+        <location filename="../common/lc_commands.cpp" line="1492"/>
         <source>Model.Model02</source>
         <translation>Model.Model02</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1506"/>
+        <location filename="../common/lc_commands.cpp" line="1499"/>
         <source>Model.Model03</source>
         <translation>Model.Model03</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1513"/>
+        <location filename="../common/lc_commands.cpp" line="1506"/>
         <source>Model.Model04</source>
         <translation>Model.Model04</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1520"/>
+        <location filename="../common/lc_commands.cpp" line="1513"/>
         <source>Model.Model05</source>
         <translation>Model.Model05</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1527"/>
+        <location filename="../common/lc_commands.cpp" line="1520"/>
         <source>Model.Model06</source>
         <translation>Model.Model06</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1534"/>
+        <location filename="../common/lc_commands.cpp" line="1527"/>
         <source>Model.Model07</source>
         <translation>Model.Model07</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1541"/>
+        <location filename="../common/lc_commands.cpp" line="1534"/>
         <source>Model.Model08</source>
         <translation>Model.Model08</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1548"/>
+        <location filename="../common/lc_commands.cpp" line="1541"/>
         <source>Model.Model09</source>
         <translation>Model.Model09</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1555"/>
+        <location filename="../common/lc_commands.cpp" line="1548"/>
         <source>Model.Model10</source>
         <translation>Model.Model10</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1562"/>
+        <location filename="../common/lc_commands.cpp" line="1555"/>
         <source>Model.Model11</source>
         <translation>Model.Model11</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1569"/>
+        <location filename="../common/lc_commands.cpp" line="1562"/>
         <source>Model.Model12</source>
         <translation>Model.Model12</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1576"/>
+        <location filename="../common/lc_commands.cpp" line="1569"/>
         <source>Model.Model13</source>
         <translation>Model.Model13</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1583"/>
+        <location filename="../common/lc_commands.cpp" line="1576"/>
         <source>Model.Model14</source>
         <translation>Model.Model14</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1590"/>
+        <location filename="../common/lc_commands.cpp" line="1583"/>
         <source>Model.Model15</source>
         <translation>Model.Model15</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1597"/>
+        <location filename="../common/lc_commands.cpp" line="1590"/>
         <source>Model.Model16</source>
         <translation>Model.Model16</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1604"/>
+        <location filename="../common/lc_commands.cpp" line="1597"/>
         <source>Model.Model17</source>
         <translation>Model.Model17</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1611"/>
+        <location filename="../common/lc_commands.cpp" line="1604"/>
         <source>Model.Model18</source>
         <translation>Model.Model18</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1618"/>
+        <location filename="../common/lc_commands.cpp" line="1611"/>
         <source>Model.Model19</source>
         <translation>Model.Model19</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1625"/>
+        <location filename="../common/lc_commands.cpp" line="1618"/>
         <source>Model.Model20</source>
         <translation>Model.Model20</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1632"/>
+        <location filename="../common/lc_commands.cpp" line="1625"/>
         <source>Model.Model21</source>
         <translation>Model.Model21</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1639"/>
+        <location filename="../common/lc_commands.cpp" line="1632"/>
         <source>Model.Model22</source>
         <translation>Model.Model22</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1646"/>
+        <location filename="../common/lc_commands.cpp" line="1639"/>
         <source>Model.Model23</source>
         <translation>Model.Model23</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1653"/>
+        <location filename="../common/lc_commands.cpp" line="1646"/>
         <source>Model.Model24</source>
         <translation>Model.Model24</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1660"/>
+        <location filename="../common/lc_commands.cpp" line="1653"/>
         <source>Model.Model25</source>
         <translation type="unfinished">Model.Model25</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1667"/>
+        <location filename="../common/lc_commands.cpp" line="1660"/>
         <source>Model.Model26</source>
         <translation type="unfinished">Model.Model26</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1674"/>
+        <location filename="../common/lc_commands.cpp" line="1667"/>
         <source>Model.Model27</source>
         <translation type="unfinished">Model.Model27</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1681"/>
+        <location filename="../common/lc_commands.cpp" line="1674"/>
         <source>Model.Model28</source>
         <translation type="unfinished">Model.Model28</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1688"/>
+        <location filename="../common/lc_commands.cpp" line="1681"/>
         <source>Model.Model29</source>
         <translation type="unfinished">Model.Model29</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1695"/>
+        <location filename="../common/lc_commands.cpp" line="1688"/>
         <source>Model.Model30</source>
         <translation type="unfinished">Model.Model30</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1702"/>
+        <location filename="../common/lc_commands.cpp" line="1695"/>
         <source>Model.Model31</source>
         <translation type="unfinished">Model.Model31</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1709"/>
+        <location filename="../common/lc_commands.cpp" line="1702"/>
         <source>Model.Model32</source>
         <translation type="unfinished">Model.Model32</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1716"/>
+        <location filename="../common/lc_commands.cpp" line="1709"/>
         <source>Model.Model33</source>
         <translation type="unfinished">Model.Model33</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1723"/>
+        <location filename="../common/lc_commands.cpp" line="1716"/>
         <source>Model.Model34</source>
         <translation type="unfinished">Model.Model34</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1730"/>
+        <location filename="../common/lc_commands.cpp" line="1723"/>
         <source>Model.Model35</source>
         <translation type="unfinished">Model.Model35</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1737"/>
+        <location filename="../common/lc_commands.cpp" line="1730"/>
         <source>Model.Model36</source>
         <translation type="unfinished">Model.Model36</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1744"/>
+        <location filename="../common/lc_commands.cpp" line="1737"/>
         <source>Model.Model37</source>
         <translation type="unfinished">Model.Model37</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1751"/>
+        <location filename="../common/lc_commands.cpp" line="1744"/>
         <source>Model.Model38</source>
         <translation type="unfinished">Model.Model38</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1758"/>
+        <location filename="../common/lc_commands.cpp" line="1751"/>
         <source>Model.Model39</source>
         <translation type="unfinished">Model.Model39</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1765"/>
+        <location filename="../common/lc_commands.cpp" line="1758"/>
         <source>Model.Model40</source>
         <translation type="unfinished">Model.Model40</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1772"/>
+        <location filename="../common/lc_commands.cpp" line="1765"/>
         <source>Help.HomePage</source>
         <translation>Nápověda.Domovská stránka</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1779"/>
+        <location filename="../common/lc_commands.cpp" line="1772"/>
         <source>Help.BugReport</source>
         <translation>Nápověda.Náhlásit chyby</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1786"/>
+        <location filename="../common/lc_commands.cpp" line="1779"/>
         <source>Help.Updates</source>
         <translation>Nápověda.Aktualizace</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1793"/>
+        <location filename="../common/lc_commands.cpp" line="1786"/>
         <source>Help.About</source>
         <translation>Nápověda.O</translation>
     </message>
@@ -1957,38 +1956,37 @@
         <translation>Kamera 16</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="982"/>
         <source>Reset</source>
-        <translation>Obnovit</translation>
+        <translation type="vanished">Obnovit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="989"/>
+        <location filename="../common/lc_commands.cpp" line="982"/>
         <source>First</source>
         <translation>První</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="996"/>
+        <location filename="../common/lc_commands.cpp" line="989"/>
         <source>Previous</source>
         <translation>Předchozí</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1003"/>
+        <location filename="../common/lc_commands.cpp" line="996"/>
         <source>Next</source>
         <translation>Další</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1010"/>
+        <location filename="../common/lc_commands.cpp" line="1003"/>
         <source>Last</source>
         <translatorcomment>TODO - posledn, další, následující</translatorcomment>
         <translation>Poslední</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1017"/>
+        <location filename="../common/lc_commands.cpp" line="1010"/>
         <source>Insert Before</source>
         <translation>Vložit před</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1017"/>
         <source>Insert After</source>
         <translation>Vložit za</translation>
     </message>
@@ -2052,578 +2050,578 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1031"/>
-        <location filename="../common/lc_commands.cpp" line="1815"/>
+        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1808"/>
         <source>Remove Step</source>
         <translation>Odebrat krok</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1038"/>
+        <location filename="../common/lc_commands.cpp" line="1031"/>
         <source>Add Keys</source>
         <translation>Přidat klíče</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1045"/>
+        <location filename="../common/lc_commands.cpp" line="1038"/>
         <source>Split &amp;Horizontal</source>
         <translation>Rozdělit &amp;vodorovně</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1052"/>
+        <location filename="../common/lc_commands.cpp" line="1045"/>
         <source>Split &amp;Vertical</source>
         <translation>Rozdělit &amp;svisle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1059"/>
+        <location filename="../common/lc_commands.cpp" line="1052"/>
         <source>Re&amp;move View</source>
         <translation>Ode&amp;brat zobrazení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1066"/>
+        <location filename="../common/lc_commands.cpp" line="1059"/>
         <source>Rese&amp;t Views</source>
         <translation>Obnovi&amp;t zobrazení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1073"/>
+        <location filename="../common/lc_commands.cpp" line="1066"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1080"/>
+        <location filename="../common/lc_commands.cpp" line="1073"/>
         <source>Tools</source>
         <translation>Nástroje</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1087"/>
+        <location filename="../common/lc_commands.cpp" line="1080"/>
         <source>Time</source>
         <translation>Čas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1094"/>
+        <location filename="../common/lc_commands.cpp" line="1087"/>
         <source>Parts</source>
         <translation>Části</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1101"/>
+        <location filename="../common/lc_commands.cpp" line="1094"/>
         <source>Colors</source>
         <translation>Barvy</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1108"/>
+        <location filename="../common/lc_commands.cpp" line="1101"/>
         <source>Properties</source>
         <translation>Vlastnosti</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1115"/>
+        <location filename="../common/lc_commands.cpp" line="1108"/>
         <source>Timeline</source>
         <translation>Časová osa</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1122"/>
+        <location filename="../common/lc_commands.cpp" line="1115"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1129"/>
+        <location filename="../common/lc_commands.cpp" line="1122"/>
         <source>&amp;Full Screen</source>
         <translation>&amp;Celá obrazovka</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1136"/>
+        <location filename="../common/lc_commands.cpp" line="1129"/>
         <source>Close &amp;Tab</source>
         <translation>Zavří&amp;t záložku</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1143"/>
+        <location filename="../common/lc_commands.cpp" line="1136"/>
         <source>&amp;Wireframe</source>
         <translation>&amp;Drátový model</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1150"/>
+        <location filename="../common/lc_commands.cpp" line="1143"/>
         <source>&amp;Flat Shading</source>
         <translation>&amp;Ploché stínování</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1157"/>
+        <location filename="../common/lc_commands.cpp" line="1150"/>
         <source>&amp;Default Lights</source>
         <translation>&amp;Výchozí osvětlení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1164"/>
+        <location filename="../common/lc_commands.cpp" line="1157"/>
         <source>&amp;Perspective</source>
         <translatorcomment>TODO - Perspektiva, Perspektivně</translatorcomment>
         <translation>&amp;Perspektivně</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1171"/>
+        <location filename="../common/lc_commands.cpp" line="1164"/>
         <source>&amp;Orthographic</source>
         <translatorcomment>TODO - Pravoúhle, Ortograficky</translatorcomment>
         <translation>Prav&amp;oúhle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1178"/>
+        <location filename="../common/lc_commands.cpp" line="1171"/>
         <source>View Sphere</source>
         <translatorcomment>TODO - sphere?</translatorcomment>
         <translation>Zobrazit sféru</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1185"/>
+        <location filename="../common/lc_commands.cpp" line="1178"/>
         <source>Axis Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1192"/>
+        <location filename="../common/lc_commands.cpp" line="1185"/>
         <source>Base Grid</source>
         <translation type="unfinished">Základní mřížka</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1199"/>
+        <location filename="../common/lc_commands.cpp" line="1192"/>
         <source>Fade Previous Steps</source>
         <translation>Zeslabit předchozí kroky</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1206"/>
+        <location filename="../common/lc_commands.cpp" line="1199"/>
         <source>&amp;Insert</source>
         <translation>Vlož&amp;it</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1213"/>
+        <location filename="../common/lc_commands.cpp" line="1206"/>
         <source>&amp;Delete</source>
         <translation>&amp;Odstranit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1220"/>
+        <location filename="../common/lc_commands.cpp" line="1213"/>
         <source>&amp;Duplicate</source>
         <translation>&amp;Duplikovat</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1227"/>
+        <location filename="../common/lc_commands.cpp" line="1220"/>
         <source>&amp;Paint Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1234"/>
+        <location filename="../common/lc_commands.cpp" line="1227"/>
         <source>Reset &amp;Pivot Point</source>
         <translation>Vynulovat &amp;bod otáčení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1241"/>
+        <location filename="../common/lc_commands.cpp" line="1234"/>
         <source>Remove &amp;Key Frames</source>
         <translation>Odstranit &amp;klíčové snímky</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1248"/>
+        <location filename="../common/lc_commands.cpp" line="1241"/>
         <source>Insert Control Point</source>
         <translation>Vložit kontrolní bod</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1255"/>
+        <location filename="../common/lc_commands.cpp" line="1248"/>
         <source>Remove Control Point</source>
         <translation>Odstranit kontrolní bod</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1262"/>
+        <location filename="../common/lc_commands.cpp" line="1255"/>
         <source>Move +X</source>
         <translation>Přesunout +X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1269"/>
+        <location filename="../common/lc_commands.cpp" line="1262"/>
         <source>Move -X</source>
         <translation>Přesunout -X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1276"/>
+        <location filename="../common/lc_commands.cpp" line="1269"/>
         <source>Move +Y</source>
         <translation>Přesunout +Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1283"/>
+        <location filename="../common/lc_commands.cpp" line="1276"/>
         <source>Move -Y</source>
         <translation>Přesunout -Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1290"/>
+        <location filename="../common/lc_commands.cpp" line="1283"/>
         <source>Move +Z</source>
         <translation>Přesunout +Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1297"/>
+        <location filename="../common/lc_commands.cpp" line="1290"/>
         <source>Move -Z</source>
         <translation>Přesunout -Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1304"/>
+        <location filename="../common/lc_commands.cpp" line="1297"/>
         <source>Rotate +X</source>
         <translation>Otočit +X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1311"/>
+        <location filename="../common/lc_commands.cpp" line="1304"/>
         <source>Rotate -X</source>
         <translation>Otočit -X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1318"/>
+        <location filename="../common/lc_commands.cpp" line="1311"/>
         <source>Rotate +Y</source>
         <translation>Otočit +Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1325"/>
+        <location filename="../common/lc_commands.cpp" line="1318"/>
         <source>Rotate -Y</source>
         <translation>Otočit -Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1332"/>
+        <location filename="../common/lc_commands.cpp" line="1325"/>
         <source>Rotate +Z</source>
         <translation>Otočit +Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1339"/>
+        <location filename="../common/lc_commands.cpp" line="1332"/>
         <source>Rotate -Z</source>
         <translation>Otočit -Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1346"/>
+        <location filename="../common/lc_commands.cpp" line="1339"/>
         <source>Minifig &amp;Wizard...</source>
         <translation>Průvodce &amp;Minifig...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1353"/>
+        <location filename="../common/lc_commands.cpp" line="1346"/>
         <source>A&amp;rray...</source>
         <translation>Po&amp;le...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1360"/>
+        <location filename="../common/lc_commands.cpp" line="1353"/>
         <source>Open Selected Model</source>
         <translation>Otevřít vybraný model</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1367"/>
+        <location filename="../common/lc_commands.cpp" line="1360"/>
         <source>Move to New Model...</source>
         <translation>Přesunout na nový model...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1374"/>
+        <location filename="../common/lc_commands.cpp" line="1367"/>
         <source>Inline Selected Models</source>
         <translation>Vložit vybrané modely</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1381"/>
+        <location filename="../common/lc_commands.cpp" line="1374"/>
         <source>Edit Selected Submodel</source>
         <translation>Upravit vybrané podmodely</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1388"/>
+        <location filename="../common/lc_commands.cpp" line="1381"/>
         <source>End Submodel Editing</source>
         <translation>Ukončit úpravy podmodelu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1395"/>
+        <location filename="../common/lc_commands.cpp" line="1388"/>
         <source>&amp;Group...</source>
         <translatorcomment>TODO - možná seskupit</translatorcomment>
         <translation>&amp;Skupina...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1402"/>
+        <location filename="../common/lc_commands.cpp" line="1395"/>
         <source>&amp;Ungroup</source>
         <translation>&amp;Rozdělit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1409"/>
+        <location filename="../common/lc_commands.cpp" line="1402"/>
         <source>&amp;Add to Group</source>
         <translation>&amp;Přidat do skupiny</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1416"/>
+        <location filename="../common/lc_commands.cpp" line="1409"/>
         <source>Re&amp;move from Group</source>
         <translation>&amp;Odebrat ze skupiny</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1423"/>
+        <location filename="../common/lc_commands.cpp" line="1416"/>
         <source>&amp;Edit Groups...</source>
         <translation>&amp;Upravit skupiny...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1430"/>
+        <location filename="../common/lc_commands.cpp" line="1423"/>
         <source>&amp;Hide Selected</source>
         <translation>&amp;Skrýt vybrané</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1437"/>
+        <location filename="../common/lc_commands.cpp" line="1430"/>
         <source>Hide &amp;Unselected</source>
         <translation>Skrýt &amp;nevybrané</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1444"/>
+        <location filename="../common/lc_commands.cpp" line="1437"/>
         <source>&amp;Unhide Selected</source>
         <translation>&amp;Zobrazit vybrané</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1451"/>
+        <location filename="../common/lc_commands.cpp" line="1444"/>
         <source>U&amp;nhide All</source>
         <translation>Zobrazit &amp;vše</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1458"/>
+        <location filename="../common/lc_commands.cpp" line="1451"/>
         <source>Show Earlier</source>
         <translation>Zobrazit starší</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1465"/>
+        <location filename="../common/lc_commands.cpp" line="1458"/>
         <source>Show Later</source>
         <translation>Zobrazit později</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1472"/>
+        <location filename="../common/lc_commands.cpp" line="1465"/>
         <source>New Submodel...</source>
         <translation>Nový podmodel...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1479"/>
+        <location filename="../common/lc_commands.cpp" line="1472"/>
         <source>Prope&amp;rties...</source>
         <translation>Vlastno&amp;sti...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1486"/>
+        <location filename="../common/lc_commands.cpp" line="1479"/>
         <source>Submodels...</source>
         <translation>Podmodely...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1493"/>
+        <location filename="../common/lc_commands.cpp" line="1486"/>
         <source>Model 1</source>
         <translation>Model 1</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1500"/>
+        <location filename="../common/lc_commands.cpp" line="1493"/>
         <source>Model 2</source>
         <translation>Model 2</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1507"/>
+        <location filename="../common/lc_commands.cpp" line="1500"/>
         <source>Model 3</source>
         <translation>Model 3</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1514"/>
+        <location filename="../common/lc_commands.cpp" line="1507"/>
         <source>Model 4</source>
         <translation>Model 4</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1521"/>
+        <location filename="../common/lc_commands.cpp" line="1514"/>
         <source>Model 5</source>
         <translation>Model 5</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1528"/>
+        <location filename="../common/lc_commands.cpp" line="1521"/>
         <source>Model 6</source>
         <translation>Model 6</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1535"/>
+        <location filename="../common/lc_commands.cpp" line="1528"/>
         <source>Model 7</source>
         <translation>Model 7</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1542"/>
+        <location filename="../common/lc_commands.cpp" line="1535"/>
         <source>Model 8</source>
         <translation>Model 8</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1549"/>
+        <location filename="../common/lc_commands.cpp" line="1542"/>
         <source>Model 9</source>
         <translation>Model 9</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1556"/>
+        <location filename="../common/lc_commands.cpp" line="1549"/>
         <source>Model 10</source>
         <translation>Model 10</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1563"/>
+        <location filename="../common/lc_commands.cpp" line="1556"/>
         <source>Model 11</source>
         <translation>Model 11</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1570"/>
+        <location filename="../common/lc_commands.cpp" line="1563"/>
         <source>Model 12</source>
         <translation>Model 12</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1577"/>
+        <location filename="../common/lc_commands.cpp" line="1570"/>
         <source>Model 13</source>
         <translation>Model 13</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1584"/>
+        <location filename="../common/lc_commands.cpp" line="1577"/>
         <source>Model 14</source>
         <translation>Model 14</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1591"/>
+        <location filename="../common/lc_commands.cpp" line="1584"/>
         <source>Model 15</source>
         <translation>Model 15</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1598"/>
+        <location filename="../common/lc_commands.cpp" line="1591"/>
         <source>Model 16</source>
         <translation>Model 16</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1605"/>
+        <location filename="../common/lc_commands.cpp" line="1598"/>
         <source>Model 17</source>
         <translation>Model 17</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1612"/>
+        <location filename="../common/lc_commands.cpp" line="1605"/>
         <source>Model 18</source>
         <translation>Model 18</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1619"/>
+        <location filename="../common/lc_commands.cpp" line="1612"/>
         <source>Model 19</source>
         <translation>Model 19</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1626"/>
+        <location filename="../common/lc_commands.cpp" line="1619"/>
         <source>Model 20</source>
         <translation>Model 20</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1633"/>
+        <location filename="../common/lc_commands.cpp" line="1626"/>
         <source>Model 21</source>
         <translation>Model 21</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1640"/>
+        <location filename="../common/lc_commands.cpp" line="1633"/>
         <source>Model 22</source>
         <translation>Model 22</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1647"/>
+        <location filename="../common/lc_commands.cpp" line="1640"/>
         <source>Model 23</source>
         <translation>Model 23</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1654"/>
+        <location filename="../common/lc_commands.cpp" line="1647"/>
         <source>Model 24</source>
         <translation>Model 24</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1661"/>
+        <location filename="../common/lc_commands.cpp" line="1654"/>
         <source>Model 25</source>
         <translation type="unfinished">Model 25</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1668"/>
+        <location filename="../common/lc_commands.cpp" line="1661"/>
         <source>Model 26</source>
         <translation type="unfinished">Model 26</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1675"/>
+        <location filename="../common/lc_commands.cpp" line="1668"/>
         <source>Model 27</source>
         <translation type="unfinished">Model 27</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1682"/>
+        <location filename="../common/lc_commands.cpp" line="1675"/>
         <source>Model 28</source>
         <translation type="unfinished">Model 28</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1689"/>
+        <location filename="../common/lc_commands.cpp" line="1682"/>
         <source>Model 29</source>
         <translation type="unfinished">Model 29</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1696"/>
+        <location filename="../common/lc_commands.cpp" line="1689"/>
         <source>Model 30</source>
         <translation type="unfinished">Model 30</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1703"/>
+        <location filename="../common/lc_commands.cpp" line="1696"/>
         <source>Model 31</source>
         <translation type="unfinished">Model 31</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1710"/>
+        <location filename="../common/lc_commands.cpp" line="1703"/>
         <source>Model 32</source>
         <translation type="unfinished">Model 32</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1717"/>
+        <location filename="../common/lc_commands.cpp" line="1710"/>
         <source>Model 33</source>
         <translation type="unfinished">Model 33</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1724"/>
+        <location filename="../common/lc_commands.cpp" line="1717"/>
         <source>Model 34</source>
         <translation type="unfinished">Model 34</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1731"/>
+        <location filename="../common/lc_commands.cpp" line="1724"/>
         <source>Model 35</source>
         <translation type="unfinished">Model 35</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1738"/>
+        <location filename="../common/lc_commands.cpp" line="1731"/>
         <source>Model 36</source>
         <translation type="unfinished">Model 36</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1745"/>
+        <location filename="../common/lc_commands.cpp" line="1738"/>
         <source>Model 37</source>
         <translation type="unfinished">Model 37</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1752"/>
+        <location filename="../common/lc_commands.cpp" line="1745"/>
         <source>Model 38</source>
         <translation type="unfinished">Model 38</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1759"/>
+        <location filename="../common/lc_commands.cpp" line="1752"/>
         <source>Model 39</source>
         <translation type="unfinished">Model 39</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1766"/>
+        <location filename="../common/lc_commands.cpp" line="1759"/>
         <source>Model 40</source>
         <translation type="unfinished">Model 40</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1773"/>
+        <location filename="../common/lc_commands.cpp" line="1766"/>
         <source>LeoCAD &amp;Home Page</source>
         <translation>LeoCAD &amp;domovská stránka</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1780"/>
+        <location filename="../common/lc_commands.cpp" line="1773"/>
         <source>Report a Bug</source>
         <translatorcomment>TODO - Oznámit chybu</translatorcomment>
         <translation>Nahlásit chybu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1787"/>
+        <location filename="../common/lc_commands.cpp" line="1780"/>
         <source>Check for &amp;Updates...</source>
         <translation>Zkontrolovat akt&amp;ualizace...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1794"/>
+        <location filename="../common/lc_commands.cpp" line="1787"/>
         <source>&amp;About...</source>
         <translation>&amp;O...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1801"/>
+        <location filename="../common/lc_commands.cpp" line="1794"/>
         <source>Insert Step Before</source>
         <translation>Vložit krok před</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1808"/>
+        <location filename="../common/lc_commands.cpp" line="1801"/>
         <source>Insert Step After</source>
         <translation>Vložit krok za</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1822"/>
+        <location filename="../common/lc_commands.cpp" line="1815"/>
         <source>Move Selection Here</source>
         <translation>Přesunout výběr sem</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1829"/>
+        <location filename="../common/lc_commands.cpp" line="1822"/>
         <source>Set Current Step</source>
         <translation>Nastavit aktuální krok</translation>
     </message>
@@ -2631,82 +2629,82 @@
 <context>
     <name>Mouse</name>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1839"/>
+        <location filename="../common/lc_commands.cpp" line="1832"/>
         <source>NewPiece</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Nový díl</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1840"/>
+        <location filename="../common/lc_commands.cpp" line="1833"/>
         <source>NewPointLight</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Nové bodové světlo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1841"/>
+        <location filename="../common/lc_commands.cpp" line="1834"/>
         <source>NewSpotLight</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Nový zdroj osvětlení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1842"/>
+        <location filename="../common/lc_commands.cpp" line="1835"/>
         <source>NewCamera</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Nová kamera</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1843"/>
+        <location filename="../common/lc_commands.cpp" line="1836"/>
         <source>Select</source>
         <translation>Vybrat</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1844"/>
+        <location filename="../common/lc_commands.cpp" line="1837"/>
         <source>Move</source>
         <translation>Přesunout</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1845"/>
+        <location filename="../common/lc_commands.cpp" line="1838"/>
         <source>Rotate</source>
         <translation>Otočit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1846"/>
+        <location filename="../common/lc_commands.cpp" line="1839"/>
         <source>Delete</source>
         <translation>Odstranit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1847"/>
+        <location filename="../common/lc_commands.cpp" line="1840"/>
         <source>Paint</source>
         <translation>Malování</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1848"/>
+        <location filename="../common/lc_commands.cpp" line="1841"/>
         <source>ColorPicker</source>
         <translation>Výběr barvy</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1849"/>
+        <location filename="../common/lc_commands.cpp" line="1842"/>
         <source>Zoom</source>
         <translatorcomment>Lupa</translatorcomment>
         <translation>Zvětšit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1850"/>
+        <location filename="../common/lc_commands.cpp" line="1843"/>
         <source>Pan</source>
         <translation>Posouvat</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1851"/>
+        <location filename="../common/lc_commands.cpp" line="1844"/>
         <source>Orbit</source>
         <translation>Otáčení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1852"/>
+        <location filename="../common/lc_commands.cpp" line="1845"/>
         <source>Roll</source>
         <translation>Přetočení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1853"/>
+        <location filename="../common/lc_commands.cpp" line="1846"/>
         <source>ZoomRegion</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Oblast zvětšení</translation>
@@ -2715,172 +2713,170 @@
 <context>
     <name>Project</name>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.ldr</source>
         <translation>Nový Model.ldr</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.mpd</source>
         <translation>Nový Model.mpd</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="177"/>
+        <location filename="../common/project.cpp" line="178"/>
         <source>Submodel #</source>
         <translation>Podmodel #</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="201"/>
+        <location filename="../common/project.cpp" line="202"/>
         <source>Submodel Name:</source>
         <translation>Název podmodelu:</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>Empty Name</source>
         <translation>Prázdný název</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>The submodel name cannot be empty.</source>
         <translation>Název podmodelu nesmí být prázdný.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>Duplicate Submodel</source>
         <translation>Duplikovat podmodel</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>A submodel named &apos;%1&apos; already exists, please enter a unique name.</source>
         <translation>Podmodel s názvem &apos;%1&apos; již existuje, zadejte jedinečný název.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="245"/>
+        <location filename="../common/project.cpp" line="246"/>
         <source>New Submodel</source>
         <translation>Nový podmodel</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
-        <location filename="../common/project.cpp" line="449"/>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="378"/>
+        <location filename="../common/project.cpp" line="457"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
+        <location filename="../common/project.cpp" line="378"/>
         <source>Error reading file &apos;%1&apos;:
 %2</source>
         <translation>Chyba při čtení souboru &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="449"/>
+        <location filename="../common/project.cpp" line="457"/>
         <source>Error loading file &apos;%1&apos;:
 File format is not recognized.</source>
         <translation>Chyba při načítání souboru &apos;%1&apos;:
 Formát souboru není rozpoznán.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation>Chyba zápisu do souboru &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="544"/>
+        <location filename="../common/project.cpp" line="552"/>
         <source>Merged </source>
         <translation>Sloučeno </translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
-        <location filename="../common/project.cpp" line="2060"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
+        <location filename="../common/project.cpp" line="2025"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="2060"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="2025"/>
         <source>Nothing to export.</source>
         <translation>Není co exportovat.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>Export 3D Studio</source>
         <translation>Exportovat 3D Studio</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>3DS Files (*.3ds);;All Files (*.*)</source>
         <translation>3DS soubory (*.3ds);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>Could not open file &apos;%1&apos; for writing.</source>
         <translation>Nelze otevřít soubor &apos;%1&apos; pro zápis.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>Export BrickLink</source>
         <translation>Exportovat BrickLink</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>XML Files (*.xml);;All Files (*.*)</source>
         <translation>XML soubory (*.xml);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>Export COLLADA</source>
         <translation>Exportovat COLLADA</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>COLLADA Files (*.dae);;All Files (*.*)</source>
         <translation>COLLADA soubory (*.dae);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>Export CSV</source>
         <translation>Exportovat CSV</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>CSV Files (*.csv);;All Files (*.*)</source>
         <translation>CSV soubory (*.csv);;všechny soubory (*.*)</translation>
     </message>
@@ -2889,28 +2885,28 @@ Formát souboru není rozpoznán.</translation>
         <translation type="vanished">Při vytváření obrázků došlo k chybě.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>Export POV-Ray</source>
         <translation>Exportovat POV-Ray</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>POV-Ray Files (*.pov);;All Files (*.*)</source>
         <translation>POV-Ray soubory (*.pov);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
         <source>Could not find LGEO files in folder &apos;%1&apos;.</source>
         <translation>Nelze najít soubory LGEO ve složce &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Export Wavefront</source>
         <translation>Exportovat Wavefront</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Wavefront Files (*.obj);;All Files (*.*)</source>
         <translation>Wavefront soubory (*.obj);;všechny soubory (*.*)</translation>
     </message>
@@ -2941,19 +2937,19 @@ Formát souboru není rozpoznán.</translation>
         <translation type="vanished">Zvláštní barvy</translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="507"/>
+        <location filename="../common/lc_colors.cpp" line="318"/>
         <source>Solid</source>
         <comment>Colors</comment>
         <translation>Plné</translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="508"/>
+        <location filename="../common/lc_colors.cpp" line="319"/>
         <source>Translucent</source>
         <comment>Colors</comment>
         <translation>Průsvitné</translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="509"/>
+        <location filename="../common/lc_colors.cpp" line="320"/>
         <source>Special</source>
         <comment>Colors</comment>
         <translation>Zvláštní</translation>
@@ -2962,14 +2958,21 @@ Formát souboru není rozpoznán.</translation>
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
         <source>Error</source>
-        <translation type="unfinished">Chyba</translation>
+        <translation type="obsolete">Chyba</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>LeoCAD</source>
+        <translation type="unfinished">LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
-        <source>Failed to load &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>Could not open file &apos;%1&apos; for writing.</source>
+        <translation type="unfinished">Nelze otevřít soubor &apos;%1&apos; pro zápis.</translation>
     </message>
 </context>
 <context>
@@ -3622,39 +3625,38 @@ Formát souboru není rozpoznán.</translation>
         <translation>Použít tuto kameru</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="983"/>
         <source>Reset views to their default positions</source>
-        <translation>Obnovit výchozí pozici</translation>
+        <translation type="vanished">Obnovit výchozí pozici</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="990"/>
+        <location filename="../common/lc_commands.cpp" line="983"/>
         <source>Go to the first step of the model</source>
         <translation>Přejít na první krok modelu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="997"/>
+        <location filename="../common/lc_commands.cpp" line="990"/>
         <source>Go to the previous step</source>
         <translation>Přejít na předchozí krok</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1004"/>
+        <location filename="../common/lc_commands.cpp" line="997"/>
         <source>Go to the next step</source>
         <translation>Přejít na další krok</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1004"/>
         <source>Go to the last step of the model</source>
         <translation>Přejít na poslední krok modelu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1018"/>
-        <location filename="../common/lc_commands.cpp" line="1802"/>
+        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1795"/>
         <source>Insert a new step before the current step</source>
         <translation>Vložit nový krok před aktuální krok</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1025"/>
-        <location filename="../common/lc_commands.cpp" line="1809"/>
+        <location filename="../common/lc_commands.cpp" line="1018"/>
+        <location filename="../common/lc_commands.cpp" line="1802"/>
         <source>Insert a new step after the current step</source>
         <translation>Vložit nový krok za aktuální krok</translation>
     </message>
@@ -3663,317 +3665,318 @@ Formát souboru není rozpoznán.</translation>
         <translation type="vanished">Vložit nový krok</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1032"/>
-        <location filename="../common/lc_commands.cpp" line="1816"/>
+        <location filename="../common/lc_commands.cpp" line="1025"/>
+        <location filename="../common/lc_commands.cpp" line="1809"/>
         <source>Remove current step</source>
         <translation>Odebrat aktuální krok</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1039"/>
+        <location filename="../common/lc_commands.cpp" line="1032"/>
         <source>Toggle adding new animation keys</source>
         <translation>Přepnout přidávání nových animačních klíčů</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1046"/>
+        <location filename="../common/lc_commands.cpp" line="1039"/>
         <source>Split the current view horizontally</source>
         <translation>Rozdělit aktuální pohled vodorovně</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1053"/>
+        <location filename="../common/lc_commands.cpp" line="1046"/>
         <source>Split the current view vertically</source>
         <translation>Rozdělit aktuální pohled svisle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1060"/>
+        <location filename="../common/lc_commands.cpp" line="1053"/>
         <source>Remove the current view</source>
         <translation>Odebrat aktuální zobrazení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1067"/>
+        <location filename="../common/lc_commands.cpp" line="1060"/>
         <source>Reset all views</source>
         <translation>Obnovit všechny pohledy</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1074"/>
+        <location filename="../common/lc_commands.cpp" line="1067"/>
         <source>Toggle the Standard Toolbar</source>
         <translation>Přepnout panel standardních nástrojů</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1081"/>
+        <location filename="../common/lc_commands.cpp" line="1074"/>
         <source>Toggle the Tools Toolbar</source>
         <translation>Přepnout panel nástrojů</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1088"/>
+        <location filename="../common/lc_commands.cpp" line="1081"/>
         <source>Toggle the Time Toolbar</source>
         <translation>Přepnout panel nástrojů času</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1095"/>
+        <location filename="../common/lc_commands.cpp" line="1088"/>
         <source>Toggle the Parts Toolbar</source>
         <translation>Přepnout panel částí</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1102"/>
+        <location filename="../common/lc_commands.cpp" line="1095"/>
         <source>Toggle the Colors Toolbar</source>
         <translation>Přepnout panel nástrojů barev</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1109"/>
+        <location filename="../common/lc_commands.cpp" line="1102"/>
         <source>Toggle the Properties Toolbar</source>
         <translation>Přepnout panel vlastností</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1116"/>
+        <location filename="../common/lc_commands.cpp" line="1109"/>
         <source>Toggle the Timeline Toolbar</source>
         <translation>Přepnout panel časové osy</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1123"/>
+        <location filename="../common/lc_commands.cpp" line="1116"/>
         <source>Toggle the Preview Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1130"/>
+        <location filename="../common/lc_commands.cpp" line="1123"/>
         <source>Toggle fullscreen mode</source>
         <translation>Přepnout režim celé obrazovky</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1137"/>
+        <location filename="../common/lc_commands.cpp" line="1130"/>
         <source>Close current tab</source>
         <translation>Zavřít aktuální záložku</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1144"/>
+        <location filename="../common/lc_commands.cpp" line="1137"/>
         <source>Display the scene as wireframe</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Zobrazit scénu jako drátový model</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1151"/>
+        <location filename="../common/lc_commands.cpp" line="1144"/>
         <source>Display the scene without any shading or lights</source>
         <translation>Zobrazit scénu bez stínování nebo osvětlení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1158"/>
+        <location filename="../common/lc_commands.cpp" line="1151"/>
         <source>Display the scene with the default lights</source>
         <translation>Zobrazit scénu s výchozími světly</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1165"/>
+        <location filename="../common/lc_commands.cpp" line="1158"/>
         <source>Set the current camera to use a perspective projection</source>
         <translation>Nastavte aktuální kameru tak, aby použila perspektivní projekci</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1172"/>
+        <location filename="../common/lc_commands.cpp" line="1165"/>
         <source>Set the current camera to use an orthographic projection</source>
         <translation>Nastavte aktuální kameru tak, aby použila pravoúhlou projekci</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1179"/>
+        <location filename="../common/lc_commands.cpp" line="1172"/>
         <source>Toggle the view sphere</source>
         <translation>Přepnout sférické zobrazení</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1186"/>
+        <location filename="../common/lc_commands.cpp" line="1179"/>
         <source>Toggle axis icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1193"/>
+        <location filename="../common/lc_commands.cpp" line="1186"/>
         <source>Toggle grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1200"/>
+        <location filename="../common/lc_commands.cpp" line="1193"/>
         <source>Toggle fading previous model steps</source>
         <translation>Přepnout zeslabování předchozích kroků modelu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1207"/>
+        <location filename="../common/lc_commands.cpp" line="1200"/>
         <source>Add a new piece to the model</source>
         <translation>Přidat nový dílek do modelu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1214"/>
+        <location filename="../common/lc_commands.cpp" line="1207"/>
         <source>Delete selected objects</source>
         <translation>Odstranit vybrané objekty</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1221"/>
+        <location filename="../common/lc_commands.cpp" line="1214"/>
         <source>Create a copy of the selected pieces</source>
         <translation>Vytvořte kopii vybraných dílků</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1228"/>
+        <location filename="../common/lc_commands.cpp" line="1221"/>
         <source>Change the color of the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1235"/>
+        <location filename="../common/lc_commands.cpp" line="1228"/>
         <source>Reset the pivot point of the selected pieces to their origin</source>
         <translatorcomment>TODO - původ, zdroj, počátek, vznik</translatorcomment>
         <translation>Obnovte bod otáčení vybraných dílků dle jejich původu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1242"/>
+        <location filename="../common/lc_commands.cpp" line="1235"/>
         <source>Remove all key frames from the selected pieces</source>
         <translation>Odstraňte všechny klíčové snímky z vybraných dílků</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1249"/>
+        <location filename="../common/lc_commands.cpp" line="1242"/>
         <source>Insert a new control point</source>
         <translation>Vložit nový kontrolní bod</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1256"/>
+        <location filename="../common/lc_commands.cpp" line="1249"/>
         <source>Remove the selected control point</source>
         <translation>Odstranit vybraný kontrolní bod</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1256"/>
         <location filename="../common/lc_commands.cpp" line="1263"/>
-        <location filename="../common/lc_commands.cpp" line="1270"/>
         <source>Move selected objects along the X axis</source>
         <translation>Přesunout vybrané objekty podél osy X</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1270"/>
         <location filename="../common/lc_commands.cpp" line="1277"/>
-        <location filename="../common/lc_commands.cpp" line="1284"/>
         <source>Move selected objects along the Y axis</source>
         <translation>Přesunout vybrané objekty podél osy Y</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1284"/>
         <location filename="../common/lc_commands.cpp" line="1291"/>
-        <location filename="../common/lc_commands.cpp" line="1298"/>
         <source>Move selected objects along the Z axis</source>
         <translation>Přesunout vybrané objekty podél osy Z</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1298"/>
         <location filename="../common/lc_commands.cpp" line="1305"/>
-        <location filename="../common/lc_commands.cpp" line="1312"/>
         <source>Rotate selected objects along the X axis</source>
         <translation>Otočit vybrané objekty podél osy X</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1312"/>
         <location filename="../common/lc_commands.cpp" line="1319"/>
-        <location filename="../common/lc_commands.cpp" line="1326"/>
         <source>Rotate selected objects along the Y axis</source>
         <translation>Otočit vybrané objekty podél osy Y</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1326"/>
         <location filename="../common/lc_commands.cpp" line="1333"/>
-        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Rotate selected objects along the Z axis</source>
         <translation>Otočit vybrané objekty podél osy Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1347"/>
+        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Add a new minifig to the model</source>
         <translation>Přidat k modelu nový minifig</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1354"/>
+        <location filename="../common/lc_commands.cpp" line="1347"/>
         <source>Make copies of the selected pieces</source>
         <translation>Vytvořit kopie vybraných dílků</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1361"/>
+        <location filename="../common/lc_commands.cpp" line="1354"/>
         <source>Open the model referenced by the selected piece in a new tab</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Otevřete model, na který odkazuje vybraný dílek, na nové kartě</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1368"/>
+        <location filename="../common/lc_commands.cpp" line="1361"/>
         <source>Move the selected pieces to a new model and replace them with a reference to the model</source>
         <translation>Přesuňte vybrané dílky do nového modelu a nahraďte je odkazem na model</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1375"/>
+        <location filename="../common/lc_commands.cpp" line="1368"/>
         <source>Insert the contents of the selected model references into the current model</source>
         <translation>Vložte obsah vybraných referencí modelu do aktuálního modelu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1382"/>
+        <location filename="../common/lc_commands.cpp" line="1375"/>
         <source>Edit the currently selected submodel in-place</source>
         <translatorcomment>TODO - in-place -&gt; vložený, na místě, v místě</translatorcomment>
         <translation>Upravte aktuálně vybraný vložený podmodel</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1389"/>
+        <location filename="../common/lc_commands.cpp" line="1382"/>
         <source>End in-place submodel editing</source>
         <translation>Ukončit místní úpravy podmodelu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1396"/>
+        <location filename="../common/lc_commands.cpp" line="1389"/>
         <source>Group selected pieces together</source>
         <translation>Seskupit vybrané dílky dohromady</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1403"/>
+        <location filename="../common/lc_commands.cpp" line="1396"/>
         <source>Ungroup selected group</source>
         <translation>Oddělit vybranou skupinu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1410"/>
+        <location filename="../common/lc_commands.cpp" line="1403"/>
         <source>Add focused piece to selected group</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1417"/>
+        <location filename="../common/lc_commands.cpp" line="1410"/>
         <source>Remove focused piece from group</source>
         <translation>Odstranit vybraný kousek ze skupiny</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1424"/>
+        <location filename="../common/lc_commands.cpp" line="1417"/>
         <source>Edit groups</source>
         <translation>Upravit skupiny</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1431"/>
+        <location filename="../common/lc_commands.cpp" line="1424"/>
         <source>Hide selected objects</source>
         <translation>Skrýt vybrané objekty</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1438"/>
+        <location filename="../common/lc_commands.cpp" line="1431"/>
         <source>Hide objects that are not selected</source>
         <translation>Skrýt objekty, které nejsou vybrány</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1445"/>
+        <location filename="../common/lc_commands.cpp" line="1438"/>
         <source>Show hidden objects that are selected</source>
         <translation>Zobrazit skryté vybrané objekty</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1452"/>
+        <location filename="../common/lc_commands.cpp" line="1445"/>
         <source>Show all hidden objects</source>
         <translation>Zobrazit všechny skryté objekty</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1459"/>
+        <location filename="../common/lc_commands.cpp" line="1452"/>
         <source>Show selected pieces one step earlier</source>
         <translation>Zobrazit vybrané dílky o krok dříve</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1466"/>
+        <location filename="../common/lc_commands.cpp" line="1459"/>
         <source>Show selected pieces one step later</source>
         <translation>Zobrazit vybrané dílky o krok později</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1473"/>
+        <location filename="../common/lc_commands.cpp" line="1466"/>
         <source>Create a new submodel</source>
         <translation>Vytvořit nový podmodel</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1480"/>
+        <location filename="../common/lc_commands.cpp" line="1473"/>
         <source>Display the properties of the current submodel</source>
         <translation>Zobrazit vlastnosti aktuálního podmodelu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1487"/>
+        <location filename="../common/lc_commands.cpp" line="1480"/>
         <source>Show a list of all submodels</source>
         <translation>Zobrazit seznam všech podmodelů</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1487"/>
         <location filename="../common/lc_commands.cpp" line="1494"/>
         <location filename="../common/lc_commands.cpp" line="1501"/>
         <location filename="../common/lc_commands.cpp" line="1508"/>
@@ -4013,37 +4016,36 @@ Formát souboru není rozpoznán.</translation>
         <location filename="../common/lc_commands.cpp" line="1746"/>
         <location filename="../common/lc_commands.cpp" line="1753"/>
         <location filename="../common/lc_commands.cpp" line="1760"/>
-        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Switch to this submodel</source>
         <translation>Přepnout na tento podmodel</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1774"/>
+        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Open LeoCAD&apos;s home page on the internet using your default web browser</source>
         <translation>Otevřít domovskou stránku LeoCADu na internetu výchozím webovím prohlížečem</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1781"/>
+        <location filename="../common/lc_commands.cpp" line="1774"/>
         <source>Open LeoCAD&apos;s bug report form on your default web browser</source>
         <translation>Otevřít formulář hlášení chyb LeoCADu ve výchozím webovém prohlížeči</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1788"/>
+        <location filename="../common/lc_commands.cpp" line="1781"/>
         <source>Check if a newer LeoCAD version or parts library has been released</source>
         <translation>Zkontrolovat, zda nebyla vydána novější verze LeoCADu nebo knihovny součástí</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1795"/>
+        <location filename="../common/lc_commands.cpp" line="1788"/>
         <source>Display program version number and system information</source>
         <translation>Zobrazit verzi programu a systémové informace</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1823"/>
+        <location filename="../common/lc_commands.cpp" line="1816"/>
         <source>Move the selected parts into this step</source>
         <translation>Přesunout vybrané části do tohoto kroku</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1830"/>
+        <location filename="../common/lc_commands.cpp" line="1823"/>
         <source>View the model at this point in the timeline</source>
         <translation>Zobrazit model v tomto okamžiku na časové ose</translation>
     </message>
@@ -4084,398 +4086,398 @@ Formát souboru není rozpoznán.</translation>
 <context>
     <name>lcApplication</name>
     <message>
-        <location filename="../common/lc_application.cpp" line="401"/>
-        <location filename="../common/lc_application.cpp" line="426"/>
-        <location filename="../common/lc_application.cpp" line="449"/>
-        <location filename="../common/lc_application.cpp" line="472"/>
-        <location filename="../common/lc_application.cpp" line="482"/>
-        <location filename="../common/lc_application.cpp" line="505"/>
-        <location filename="../common/lc_application.cpp" line="530"/>
+        <location filename="../common/lc_application.cpp" line="421"/>
+        <location filename="../common/lc_application.cpp" line="446"/>
+        <location filename="../common/lc_application.cpp" line="469"/>
+        <location filename="../common/lc_application.cpp" line="492"/>
+        <location filename="../common/lc_application.cpp" line="502"/>
+        <location filename="../common/lc_application.cpp" line="525"/>
+        <location filename="../common/lc_application.cpp" line="550"/>
         <source>Not enough parameters for the &apos;%1&apos; option.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="423"/>
-        <location filename="../common/lc_application.cpp" line="446"/>
-        <location filename="../common/lc_application.cpp" line="469"/>
-        <location filename="../common/lc_application.cpp" line="502"/>
-        <location filename="../common/lc_application.cpp" line="527"/>
-        <location filename="../common/lc_application.cpp" line="580"/>
-        <location filename="../common/lc_application.cpp" line="734"/>
-        <location filename="../common/lc_application.cpp" line="745"/>
+        <location filename="../common/lc_application.cpp" line="443"/>
+        <location filename="../common/lc_application.cpp" line="466"/>
+        <location filename="../common/lc_application.cpp" line="489"/>
+        <location filename="../common/lc_application.cpp" line="522"/>
+        <location filename="../common/lc_application.cpp" line="547"/>
+        <location filename="../common/lc_application.cpp" line="600"/>
+        <location filename="../common/lc_application.cpp" line="754"/>
+        <location filename="../common/lc_application.cpp" line="765"/>
         <source>Invalid parameter value specified for the &apos;%1&apos; option: &apos;%2&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="541"/>
+        <location filename="../common/lc_application.cpp" line="561"/>
         <source>The file &apos;%1&apos; is not readable.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="589"/>
+        <location filename="../common/lc_application.cpp" line="609"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: limits are +/- 360.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="601"/>
+        <location filename="../common/lc_application.cpp" line="621"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="620"/>
+        <location filename="../common/lc_application.cpp" line="640"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: requirements are: 1 &lt;= &lt;near&gt; &lt; &lt;far&gt;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="630"/>
-        <location filename="../common/lc_application.cpp" line="641"/>
-        <location filename="../common/lc_application.cpp" line="652"/>
-        <location filename="../common/lc_application.cpp" line="663"/>
+        <location filename="../common/lc_application.cpp" line="650"/>
+        <location filename="../common/lc_application.cpp" line="661"/>
+        <location filename="../common/lc_application.cpp" line="672"/>
+        <location filename="../common/lc_application.cpp" line="683"/>
         <source>High contrast stud style is required for the &apos;%1&apos; option but is not enabled.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="678"/>
-        <location filename="../common/lc_application.cpp" line="689"/>
+        <location filename="../common/lc_application.cpp" line="698"/>
+        <location filename="../common/lc_application.cpp" line="709"/>
         <source>Automate edge color is required for the &apos;%1&apos; option but is not enabled.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="779"/>
+        <location filename="../common/lc_application.cpp" line="799"/>
         <source>LeoCAD Continuous Build %1
 </source>
         <translation type="unfinished">LeoCAD průběžné sestavení %1
 </translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="781"/>
+        <location filename="../common/lc_application.cpp" line="801"/>
         <source>LeoCAD Version %1
 </source>
         <translation type="unfinished">LeoCAD verze %1
 </translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="783"/>
+        <location filename="../common/lc_application.cpp" line="803"/>
         <source>Compiled %1
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="788"/>
+        <location filename="../common/lc_application.cpp" line="808"/>
         <source>Usage: leocad [options] [file]
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="789"/>
+        <location filename="../common/lc_application.cpp" line="809"/>
         <source>  [options] can be:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="790"/>
+        <location filename="../common/lc_application.cpp" line="810"/>
         <source>  -l, --libpath &lt;path&gt;: Set the Parts Library location to path.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="791"/>
+        <location filename="../common/lc_application.cpp" line="811"/>
         <source>  -i, --image &lt;outfile.ext&gt;: Save a picture in the format specified by ext and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="792"/>
+        <location filename="../common/lc_application.cpp" line="812"/>
         <source>  -w, --width &lt;width&gt;: Set the picture width.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="793"/>
+        <location filename="../common/lc_application.cpp" line="813"/>
         <source>  -h, --height &lt;height&gt;: Set the picture height.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="794"/>
+        <location filename="../common/lc_application.cpp" line="814"/>
         <source>  -f, --from &lt;step&gt;: Set the first step to save pictures.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="795"/>
+        <location filename="../common/lc_application.cpp" line="815"/>
         <source>  -t, --to &lt;step&gt;: Set the last step to save pictures.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="796"/>
+        <location filename="../common/lc_application.cpp" line="816"/>
         <source>  -s, --submodel &lt;submodel&gt;: Set the active submodel.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="797"/>
+        <location filename="../common/lc_application.cpp" line="817"/>
         <source>  -c, --camera &lt;camera&gt;: Set the active camera.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="798"/>
+        <location filename="../common/lc_application.cpp" line="818"/>
         <source>  -ss, --stud-style &lt;id&gt;: Set the stud style 0=No style, 1=LDraw single wire, 2=LDraw double wire, 3=LDraw raised floating, 4=LDraw raised rounded, 5=LDraw subtle rounded, 6=LEGO no logo, 7=LEGO single wire.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="799"/>
+        <location filename="../common/lc_application.cpp" line="819"/>
         <source>  --viewpoint &lt;front|back|left|right|top|bottom|home&gt;: Set the viewpoint.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="800"/>
+        <location filename="../common/lc_application.cpp" line="820"/>
         <source>  --camera-angles &lt;latitude&gt; &lt;longitude&gt;: Set the camera angles in degrees around the model.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="801"/>
+        <location filename="../common/lc_application.cpp" line="821"/>
         <source>  --camera-position &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="802"/>
+        <location filename="../common/lc_application.cpp" line="822"/>
         <source>  --camera-position-ldraw &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector using LDraw coordinates.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="803"/>
+        <location filename="../common/lc_application.cpp" line="823"/>
         <source>  --orthographic: Render images using an orthographic projection.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="804"/>
+        <location filename="../common/lc_application.cpp" line="824"/>
         <source>  --fov &lt;degrees&gt;: Set the vertical field of view used to render images (&lt; 180).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="805"/>
+        <location filename="../common/lc_application.cpp" line="825"/>
         <source>  --zplanes &lt;near&gt; &lt;far&gt;: Set the near and far clipping planes used to render images (1 &lt;= &lt;near&gt; &lt; &lt;far&gt;).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="806"/>
+        <location filename="../common/lc_application.cpp" line="826"/>
         <source>  --fade-steps: Render parts from prior steps faded.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="807"/>
+        <location filename="../common/lc_application.cpp" line="827"/>
         <source>  --no-fade-steps: Do not render parts from prior steps faded.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="808"/>
+        <location filename="../common/lc_application.cpp" line="828"/>
         <source>  --fade-steps-color &lt;rgba&gt;: Renderinng color for prior step parts (#AARRGGBB).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="809"/>
+        <location filename="../common/lc_application.cpp" line="829"/>
         <source>  --highlight: Highlight parts in the steps they appear.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="810"/>
+        <location filename="../common/lc_application.cpp" line="830"/>
         <source>  --no-highlight: Do not highlight parts in the steps they appear.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="811"/>
+        <location filename="../common/lc_application.cpp" line="831"/>
         <source>  --highlight-color: Renderinng color for highlighted parts (#AARRGGBB).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="812"/>
+        <location filename="../common/lc_application.cpp" line="832"/>
         <source>  --shading &lt;wireframe|flat|default|full&gt;: Select shading mode for rendering.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="813"/>
-        <source>  --line-width &lt;width&gt;: Set the with of the edge lines.
+        <location filename="../common/lc_application.cpp" line="833"/>
+        <source>  --line-width &lt;width&gt;: Set the width of the edge lines.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="814"/>
+        <location filename="../common/lc_application.cpp" line="834"/>
         <source>  --aa-samples &lt;count&gt;: AntiAliasing sample size (1, 2, 4, or 8).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="815"/>
+        <location filename="../common/lc_application.cpp" line="835"/>
         <source>  -scc, --stud-cylinder-color &lt;#AARRGGBB&gt;: High contrast stud cylinder color.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="816"/>
+        <location filename="../common/lc_application.cpp" line="836"/>
         <source>  -ec, --edge-color &lt;#AARRGGBB&gt;: High contrast edge color.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="817"/>
+        <location filename="../common/lc_application.cpp" line="837"/>
         <source>  -bec, --black-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for black parts.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="818"/>
+        <location filename="../common/lc_application.cpp" line="838"/>
         <source>  -dec, --dark-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for dark color parts.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="819"/>
+        <location filename="../common/lc_application.cpp" line="839"/>
         <source>  -aec, --automate-edge-color: Enable automatically adjusted edge colors.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="820"/>
+        <location filename="../common/lc_application.cpp" line="840"/>
         <source>  -cc, --color-contrast &lt;float&gt;: Color contrast value between 0.0 and 1.0.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="821"/>
+        <location filename="../common/lc_application.cpp" line="841"/>
         <source>  -ldv, --light-dark-value &lt;float&gt;: Light/Dark color value between 0.0 and 1.0.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="822"/>
+        <location filename="../common/lc_application.cpp" line="842"/>
         <source>  -obj, --export-wavefront &lt;outfile.obj&gt;: Export the model to Wavefront OBJ format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="823"/>
+        <location filename="../common/lc_application.cpp" line="843"/>
         <source>  -3ds, --export-3ds &lt;outfile.3ds&gt;: Export the model to 3D Studio 3DS format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="824"/>
+        <location filename="../common/lc_application.cpp" line="844"/>
         <source>  -dae, --export-collada &lt;outfile.dae&gt;: Export the model to COLLADA DAE format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="825"/>
+        <location filename="../common/lc_application.cpp" line="845"/>
         <source>  -html, --export-html &lt;folder&gt;: Create an HTML page for the model.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="826"/>
+        <location filename="../common/lc_application.cpp" line="846"/>
         <source>  -v, --version: Output version information and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="827"/>
+        <location filename="../common/lc_application.cpp" line="847"/>
         <source>  -?, --help: Display this help message and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="833"/>
+        <location filename="../common/lc_application.cpp" line="853"/>
         <source>Unknown option: &apos;%1&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="840"/>
+        <location filename="../common/lc_application.cpp" line="860"/>
         <source>High contrast stud and edge color settings are ignored when -aec or --automate-edge-color is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="846"/>
+        <location filename="../common/lc_application.cpp" line="866"/>
         <source>--viewpoint is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="849"/>
+        <location filename="../common/lc_application.cpp" line="869"/>
         <source>--orthographic is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="852"/>
+        <location filename="../common/lc_application.cpp" line="872"/>
         <source>--camera-angles is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="855"/>
+        <location filename="../common/lc_application.cpp" line="875"/>
         <source>--camera-position is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="860"/>
+        <location filename="../common/lc_application.cpp" line="880"/>
         <source>--camera-angles is ignored when --viewpoint is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="863"/>
+        <location filename="../common/lc_application.cpp" line="883"/>
         <source>--camera-position is ignored when --viewpoint is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="868"/>
+        <location filename="../common/lc_application.cpp" line="888"/>
         <source>--camera-position is ignored when --camera-angles is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="875"/>
+        <location filename="../common/lc_application.cpp" line="895"/>
         <source>No file name specified.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="908"/>
+        <location filename="../common/lc_application.cpp" line="928"/>
         <source>Error creating OpenGL context.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="929"/>
+        <location filename="../common/lc_application.cpp" line="949"/>
         <source>LeoCAD could not find a compatible Parts Library so only a small number of parts will be available.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
@@ -4484,7 +4486,7 @@ Please visit https://www.leocad.org for information on how to download and insta
 Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese https://www.leocad.org.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="931"/>
+        <location filename="../common/lc_application.cpp" line="951"/>
         <source>LeoCAD could not load Parts Library.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
@@ -4493,28 +4495,28 @@ Please visit https://www.leocad.org for information on how to download and insta
 Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese https://www.leocad.org.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="934"/>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="954"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1002"/>
+        <location filename="../common/lc_application.cpp" line="1022"/>
         <source>Error: model &apos;%1&apos; does not exist.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1093"/>
-        <location filename="../common/lc_application.cpp" line="1121"/>
-        <location filename="../common/lc_application.cpp" line="1146"/>
-        <location filename="../common/lc_application.cpp" line="1171"/>
+        <location filename="../common/lc_application.cpp" line="1113"/>
+        <location filename="../common/lc_application.cpp" line="1141"/>
+        <location filename="../common/lc_application.cpp" line="1166"/>
+        <location filename="../common/lc_application.cpp" line="1191"/>
         <source>Saved &apos;%1&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>Some changes will only take effect the next time you start LeoCAD.</source>
         <translation>Některé změny se projeví až při příštím spuštění LeoCADu.</translation>
     </message>
@@ -4552,6 +4554,26 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
         <translation type="unfinished">Obnovit</translation>
     </message>
     <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Light/Dark Value:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Saturation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="54"/>
+        <source>Set to classify where color values are light or dark - e.g. Dark Bluish Gray (72) is light at 0.39.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="55"/>
+        <source>Set to specify amount of edge color tint or shade from the saturation adjusted part color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="68"/>
         <source>High Contrast</source>
         <translation type="unfinished"></translation>
@@ -4587,8 +4609,18 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="179"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Black parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="183"/>
         <source>Select Black Edge Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="191"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Dark parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4649,109 +4681,134 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
 <context>
     <name>lcInstructionsDialog</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="527"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="532"/>
         <source>Instructions</source>
         <translation>Pokyny</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="542"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="547"/>
         <source>Page Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="552"/>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="554"/>
+        <source>Vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="557"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="571"/>
+        <source>Page %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPageListWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="174"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="179"/>
         <source>Pages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="189"/>
+        <source>Page Setup</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPropertiesWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="288"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="293"/>
         <source>Properties</source>
         <translation type="unfinished">Vlastnosti</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Default</source>
         <translation type="unfinished">Výchozí</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Forward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="296"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="301"/>
         <source>Scope:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="301"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="306"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="351"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="356"/>
         <source>Select Step Number Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="355"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="360"/>
         <source>Select Step Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="359"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="364"/>
         <source>Select Parts List Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="363"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="368"/>
         <source>Select Parts List Border Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="367"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="372"/>
         <source>Select Parts List Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="417"/>
-        <location filename="../common/lc_instructionsdialog.cpp" line="438"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="422"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="443"/>
         <source>Select Step Number Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="421"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="426"/>
         <source>Select Parts List Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="477"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="482"/>
         <source>Step Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="493"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="498"/>
         <source>Step Number Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="508"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="513"/>
         <source>Parts List Properties</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4759,210 +4816,205 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
 <context>
     <name>lcMainWindow</name>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="172"/>
+        <location filename="../common/lc_mainwindow.cpp" line="145"/>
         <source>New Model</source>
         <translation>Nový model</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="173"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
+        <location filename="../common/lc_mainwindow.cpp" line="146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
         <source>Open Model</source>
         <translation>Otevřít model</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="174"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2507"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2434"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save Model</source>
         <translation>Uložit model</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="403"/>
-        <location filename="../common/lc_mainwindow.cpp" line="606"/>
-        <location filename="../common/lc_mainwindow.cpp" line="613"/>
+        <location filename="../common/lc_mainwindow.cpp" line="376"/>
+        <location filename="../common/lc_mainwindow.cpp" line="577"/>
+        <location filename="../common/lc_mainwindow.cpp" line="584"/>
         <source>Transform</source>
         <translation>Transformace</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="410"/>
+        <location filename="../common/lc_mainwindow.cpp" line="383"/>
         <source>C&amp;ameras</source>
         <translation>K&amp;amery</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="419"/>
+        <location filename="../common/lc_mainwindow.cpp" line="389"/>
         <source>&amp;Viewpoints</source>
         <translatorcomment>TODO - pohled, hledisko, vyhlídka, zorný úhel,</translatorcomment>
         <translation>&amp;Pohledy</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="398"/>
         <source>Projection</source>
         <translation>Projekce</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="432"/>
+        <location filename="../common/lc_mainwindow.cpp" line="402"/>
         <source>Sh&amp;ading</source>
         <translation>Stínov&amp;ání</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="437"/>
-        <location filename="../common/lc_mainwindow.cpp" line="674"/>
+        <location filename="../common/lc_mainwindow.cpp" line="407"/>
+        <location filename="../common/lc_mainwindow.cpp" line="645"/>
         <source>Tools</source>
         <translation>Nástroje</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="456"/>
+        <location filename="../common/lc_mainwindow.cpp" line="426"/>
         <source>&amp;File</source>
         <translation>&amp;Soubor</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="464"/>
+        <location filename="../common/lc_mainwindow.cpp" line="434"/>
         <source>&amp;Import</source>
         <translation>&amp;Importovat</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="467"/>
+        <location filename="../common/lc_mainwindow.cpp" line="437"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportovat</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="488"/>
+        <location filename="../common/lc_mainwindow.cpp" line="458"/>
         <source>&amp;Edit</source>
         <translation>&amp;Upravit</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="512"/>
+        <location filename="../common/lc_mainwindow.cpp" line="482"/>
         <source>&amp;View</source>
         <translatorcomment>TODO - Zobrazit, pohled,</translatorcomment>
         <translation>&amp;Zobrazit</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="521"/>
+        <location filename="../common/lc_mainwindow.cpp" line="491"/>
         <source>Ste&amp;p</source>
         <translation>Kro&amp;k</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="506"/>
         <source>T&amp;oolbars</source>
         <translation>Panely nástr&amp;ojů</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="549"/>
+        <location filename="../common/lc_mainwindow.cpp" line="519"/>
         <source>&amp;Piece</source>
         <translatorcomment>TODO - dílek, kus</translatorcomment>
         <translation>&amp;Dílek</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="575"/>
+        <location filename="../common/lc_mainwindow.cpp" line="546"/>
         <source>Sub&amp;model</source>
         <translation>Pod&amp;model</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="583"/>
+        <location filename="../common/lc_mainwindow.cpp" line="554"/>
         <source>&amp;Help</source>
         <translation>&amp;Nápověda</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="597"/>
-        <location filename="../common/lc_mainwindow.cpp" line="601"/>
+        <location filename="../common/lc_mainwindow.cpp" line="568"/>
+        <location filename="../common/lc_mainwindow.cpp" line="572"/>
         <source>Selection Mode</source>
         <translation>Režim výběru</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="602"/>
+        <location filename="../common/lc_mainwindow.cpp" line="573"/>
         <source>Change selection mode</source>
         <translation>Změna režimu výběru</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="614"/>
+        <location filename="../common/lc_mainwindow.cpp" line="585"/>
         <source>Transform Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="618"/>
+        <location filename="../common/lc_mainwindow.cpp" line="589"/>
         <source>Snap XY</source>
         <translatorcomment>TODO - Přichytit, Lusknutí, Přichycení</translatorcomment>
         <translation>Přichycení XY</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="622"/>
+        <location filename="../common/lc_mainwindow.cpp" line="593"/>
         <source>Snap Z</source>
         <translation>Přichycení Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="626"/>
+        <location filename="../common/lc_mainwindow.cpp" line="597"/>
         <source>Snap Menu</source>
         <translation>Nabídka přichycení</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="632"/>
+        <location filename="../common/lc_mainwindow.cpp" line="603"/>
         <source>Movement Snap</source>
         <translatorcomment>TODO - pohyb, přesun</translatorcomment>
         <translation>Přesun přichycení</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="633"/>
+        <location filename="../common/lc_mainwindow.cpp" line="604"/>
         <source>Snap translations to fixed intervals</source>
         <translation>Přichycení posunů k pevným bodům</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="637"/>
+        <location filename="../common/lc_mainwindow.cpp" line="608"/>
         <source>Snap Angle Menu</source>
         <translation>Nabídka úhlů přichycení</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="643"/>
+        <location filename="../common/lc_mainwindow.cpp" line="614"/>
         <source>Rotation Snap</source>
         <translation>Otočení přichycení</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="644"/>
+        <location filename="../common/lc_mainwindow.cpp" line="615"/>
         <source>Snap rotations to fixed intervals</source>
         <translation>Přychycení otáčení k pevným bodům</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="648"/>
+        <location filename="../common/lc_mainwindow.cpp" line="619"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="666"/>
+        <location filename="../common/lc_mainwindow.cpp" line="637"/>
         <source>Time</source>
         <translation>Čas</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="696"/>
+        <location filename="../common/lc_mainwindow.cpp" line="667"/>
         <source>Parts</source>
         <translation>Části</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="702"/>
+        <location filename="../common/lc_mainwindow.cpp" line="673"/>
         <source>Colors</source>
         <translation>Barvy</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="731"/>
+        <location filename="../common/lc_mainwindow.cpp" line="702"/>
         <source>Properties</source>
         <translation>Vlastnosti</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="766"/>
+        <location filename="../common/lc_mainwindow.cpp" line="737"/>
         <source>Timeline</source>
         <translation>Časová osa</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
-        <source>Part preview for &apos;%1&apos; failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_mainwindow.cpp" line="814"/>
-        <location filename="../common/lc_mainwindow.cpp" line="815"/>
+        <location filename="../common/lc_mainwindow.cpp" line="784"/>
+        <location filename="../common/lc_mainwindow.cpp" line="785"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1031"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1001"/>
         <source>Close Other Tabs</source>
         <translation>Zavřít ostatní záložky</translation>
     </message>
@@ -4971,22 +5023,22 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
         <translation type="vanished">Obnovit zobrazení</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1113"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1083"/>
         <source>The file &apos;%1&apos; has been modified by another application, do you want to reload it?</source>
         <translation>Soubor &apos;%1&apos; byl upraven jinou aplikací, chcete jej znovu načíst?</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1119"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1089"/>
         <source>File Changed</source>
         <translation>Soubor byl změněn</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2058"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1985"/>
         <source>%1 (ID: %2)</source>
         <translation>%1 (ID: %2)</translation>
     </message>
     <message numerus="yes">
-        <location filename="../common/lc_mainwindow.cpp" line="2064"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1991"/>
         <source>%n Object(s) selected</source>
         <translation>
             <numerusform>%n vybraný objekt</numerusform>
@@ -4995,17 +5047,17 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
         </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2068"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1995"/>
         <source> - %1 (ID: %2)</source>
         <translation> - %1 (ID: %2)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2072"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1999"/>
         <source> in group &apos;%1&apos;</source>
         <translation> ve skupině &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2110"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2037"/>
         <source>Step %1</source>
         <translation>Krok %1</translation>
     </message>
@@ -5014,183 +5066,182 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
         <translation type="vanished"> M: %1 %2 R: %3 </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2168"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2095"/>
         <source>&amp;Undo %1</source>
         <translation>&amp;Zpět %1</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2173"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2100"/>
         <source>&amp;Undo</source>
         <translation>&amp;Zpět</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2179"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2106"/>
         <source>&amp;Redo %1</source>
         <translation>&amp;Znovu %1</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2184"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2111"/>
         <source>&amp;Redo</source>
         <translation>&amp;Znovu</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Supported Files (*.lcd *.ldr *.dat *.mpd);;All Files (*.*)</source>
         <translation>Podporované soubory (*.lcd *.ldr *.dat *.mpd);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Merge Model</source>
         <translation>Sloučit model</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
         <source>Merged 1 submodel.</source>
         <translation>Sloučit 1 podmodel.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>Merged %1 submodels.</source>
         <translation>Sloučit %1 podmodelů.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>Import</source>
         <translation>Importovat</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>LEGO Diginal Designer Files (*.lxf);;All Files (*.*)</source>
         <translation>LEGO Diginal Designer soubory (*.lxf);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.mpd);;All Files (*.*)</source>
         <translation>Podporované soubory (*.mpd);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.ldr *.dat *.mpd);;All Files (*.*)</source>
         <translation>Podporované soubory (*.ldr *.dat *.mpd);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Rel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Abs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2074"/>
         <source> M: %1 %2 R: %3 %4 </source>
         <translation type="unfinished"> M: %1 %2 R: %3  {1 %2 ?} {3 %4 ?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Saving files in LCD format is no longer supported, please use the LDR or MPD formats instead.</source>
         <translation>Ukládání souborů ve formátu LCD již není podporováno, místo toho použijte formáty LDR nebo MPD.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save changes to &apos;%1&apos;?</source>
         <translation>Chcete uložit změny v &apos;%1&apos;?</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/20S</source>
         <translation>1/20S</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/4S</source>
         <translation>1/4S</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1F</source>
         <translation>1F</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/2S</source>
         <translation>1/2S</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1S</source>
         <translation>1S</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>2S</source>
         <translation>2S</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>3S</source>
         <translation>3S</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>4S</source>
         <translation>4S</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>8S</source>
         <translation>8S</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="152"/>
-        <location filename="../common/lc_mainwindow.h" line="158"/>
-        <location filename="../common/lc_mainwindow.h" line="163"/>
+        <location filename="../common/lc_mainwindow.h" line="131"/>
+        <location filename="../common/lc_mainwindow.h" line="137"/>
+        <location filename="../common/lc_mainwindow.h" line="142"/>
         <source>None</source>
         <translation>Žádné</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1B</source>
         <translation>1B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>2B</source>
         <translation>2B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>4B</source>
         <translation>4B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>8B</source>
         <translation>8B</translation>
     </message>
@@ -5303,131 +5354,131 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
 <context>
     <name>lcModel</name>
     <message>
-        <location filename="../common/lc_model.cpp" line="957"/>
-        <location filename="../common/lc_model.cpp" line="1831"/>
+        <location filename="../common/lc_model.cpp" line="954"/>
+        <location filename="../common/lc_model.cpp" line="1834"/>
         <source>Group #</source>
         <translation>Skupina #</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1100"/>
+        <location filename="../common/lc_model.cpp" line="1097"/>
         <source>Cutting</source>
         <translatorcomment>TODO - Vyjmutí, Řezání</translatorcomment>
         <translation>Vyjmutí</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1146"/>
+        <location filename="../common/lc_model.cpp" line="1143"/>
         <source>Pasting</source>
         <translation>Vkládání</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1219"/>
+        <location filename="../common/lc_model.cpp" line="1216"/>
         <source>Duplicating Pieces</source>
         <translation>Duplikování dílků</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="2531"/>
-        <location filename="../common/lc_model.cpp" line="4307"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
         <source>Error creating images.</source>
         <translation>Při vytváření obrázků došlo k chybě.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation>Chyba zápisu do souboru &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1765"/>
+        <location filename="../common/lc_model.cpp" line="1768"/>
         <source>Inserting Step</source>
         <translation>Vložen krok</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1784"/>
+        <location filename="../common/lc_model.cpp" line="1787"/>
         <source>Removing Step</source>
         <translation>Odebrání kroku</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
         <source>No pieces selected.</source>
         <translation>Nejsou vybrány žádné dílky.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1850"/>
-        <location filename="../common/lc_model.cpp" line="1916"/>
+        <location filename="../common/lc_model.cpp" line="1853"/>
+        <location filename="../common/lc_model.cpp" line="1919"/>
         <source>Grouping</source>
         <translation>Seskupení</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1886"/>
-        <location filename="../common/lc_model.cpp" line="1931"/>
+        <location filename="../common/lc_model.cpp" line="1889"/>
+        <location filename="../common/lc_model.cpp" line="1934"/>
         <source>Ungrouping</source>
         <translation>Rozdělení</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1977"/>
+        <location filename="../common/lc_model.cpp" line="1980"/>
         <source>Editing Groups</source>
         <translation>Úpravy skupin</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2176"/>
+        <location filename="../common/lc_model.cpp" line="2179"/>
         <source>Adding Piece</source>
         <translation>Přidání dílku</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2218"/>
+        <location filename="../common/lc_model.cpp" line="2221"/>
         <source>Resetting Cameras</source>
         <translation>Resetování kamer</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2229"/>
-        <location filename="../common/lc_model.cpp" line="4131"/>
+        <location filename="../common/lc_model.cpp" line="2232"/>
+        <location filename="../common/lc_model.cpp" line="4149"/>
         <source>Deleting</source>
         <translation>Odstraňování</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2258"/>
+        <location filename="../common/lc_model.cpp" line="2261"/>
         <source>Removing Key Frames</source>
         <translation>Odstranění klíčových snímků</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2275"/>
-        <location filename="../common/lc_model.cpp" line="2292"/>
-        <location filename="../common/lc_model.cpp" line="2334"/>
-        <location filename="../common/lc_model.cpp" line="2379"/>
-        <location filename="../common/lc_model.cpp" line="2414"/>
+        <location filename="../common/lc_model.cpp" line="2278"/>
+        <location filename="../common/lc_model.cpp" line="2295"/>
+        <location filename="../common/lc_model.cpp" line="2337"/>
+        <location filename="../common/lc_model.cpp" line="2382"/>
+        <location filename="../common/lc_model.cpp" line="2417"/>
         <source>Modifying</source>
         <translation>Úprava</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2482"/>
+        <location filename="../common/lc_model.cpp" line="2485"/>
         <source>New Model</source>
         <translation>Nový model</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2531"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
         <source>No models selected.</source>
         <translation>Nebyly vybrány žádné modely.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2535"/>
+        <location filename="../common/lc_model.cpp" line="2538"/>
         <source>Inlining</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Inlining</translation>
@@ -5449,7 +5500,7 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2844"/>
-        <location filename="../common/lc_model.cpp" line="4145"/>
+        <location filename="../common/lc_model.cpp" line="4163"/>
         <source>Painting</source>
         <translation>Malování</translation>
     </message>
@@ -5486,112 +5537,112 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
         <translation>Přejmenovávání kamery</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3723"/>
-        <location filename="../common/lc_model.cpp" line="3746"/>
+        <location filename="../common/lc_model.cpp" line="3741"/>
+        <location filename="../common/lc_model.cpp" line="3764"/>
         <source>Hide</source>
         <translation>Skrýt</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3769"/>
-        <location filename="../common/lc_model.cpp" line="3792"/>
+        <location filename="../common/lc_model.cpp" line="3787"/>
+        <location filename="../common/lc_model.cpp" line="3810"/>
         <source>Unhide</source>
         <translation>Zobrazit</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3834"/>
+        <location filename="../common/lc_model.cpp" line="3852"/>
         <source>Replacing Part</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3939"/>
+        <location filename="../common/lc_model.cpp" line="3957"/>
         <source>New SpotLight</source>
         <translation>Nový zdroj osvětlení</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3944"/>
+        <location filename="../common/lc_model.cpp" line="3962"/>
         <source>New Camera</source>
         <translation>Nová kamera</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3951"/>
+        <location filename="../common/lc_model.cpp" line="3969"/>
         <source>Move</source>
         <translation>Přesunout</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3955"/>
+        <location filename="../common/lc_model.cpp" line="3973"/>
         <source>Rotate</source>
         <translation>Otočit</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3965"/>
-        <location filename="../common/lc_model.cpp" line="4206"/>
-        <location filename="../common/lc_model.cpp" line="4266"/>
-        <location filename="../common/lc_model.cpp" line="4278"/>
+        <location filename="../common/lc_model.cpp" line="3983"/>
+        <location filename="../common/lc_model.cpp" line="4224"/>
+        <location filename="../common/lc_model.cpp" line="4284"/>
+        <location filename="../common/lc_model.cpp" line="4296"/>
         <source>Zoom</source>
         <translation>Zvětšit</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3970"/>
+        <location filename="../common/lc_model.cpp" line="3988"/>
         <source>Pan</source>
         <translation>Posouvat</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3975"/>
+        <location filename="../common/lc_model.cpp" line="3993"/>
         <source>Orbit</source>
         <translation>Otočení</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3980"/>
+        <location filename="../common/lc_model.cpp" line="3998"/>
         <source>Roll</source>
         <translation>Přetočení</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4002"/>
+        <location filename="../common/lc_model.cpp" line="4020"/>
         <source>Insert</source>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4012"/>
+        <location filename="../common/lc_model.cpp" line="4030"/>
         <source>New Light</source>
         <translation>Nové osvětlení</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4229"/>
+        <location filename="../common/lc_model.cpp" line="4247"/>
         <source>Look At</source>
         <translation>Prohledávat</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4239"/>
+        <location filename="../common/lc_model.cpp" line="4257"/>
         <source>Moving Camera</source>
         <translation>Přesunití kamery</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4300"/>
+        <location filename="../common/lc_model.cpp" line="4319"/>
         <source>Changing Properties</source>
         <translation>Změna vlastností</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4307"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
         <source>Nothing to select.</source>
         <translation>Není nic vybráno.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>Array only has 1 element or less, no pieces added.</source>
         <translation>Pole obsahuje pouze 1 prvek nebo méně, nejsou přidávány žádné dílky.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4390"/>
+        <location filename="../common/lc_model.cpp" line="4409"/>
         <source>Array</source>
         <translation>Pole</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4402"/>
+        <location filename="../common/lc_model.cpp" line="4421"/>
         <source>Minifig #</source>
         <translation>Minifig #</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4424"/>
+        <location filename="../common/lc_model.cpp" line="4443"/>
         <source>Minifig</source>
         <translation>Minifig</translation>
     </message>
@@ -5721,17 +5772,17 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
 <context>
     <name>lcPartSelectionListView</name>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="524"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="551"/>
         <source>Add to Palette</source>
         <translation>Přidat do palety</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="535"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="562"/>
         <source>None</source>
         <translation>Žádné</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="539"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="566"/>
         <source>Remove from Palette</source>
         <translation>Odebrat z palety</translation>
     </message>
@@ -5739,80 +5790,85 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
 <context>
     <name>lcPartSelectionWidget</name>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="719"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="746"/>
         <source>Search Parts</source>
         <translation>Prohledat části</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="726"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="753"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="884"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="902"/>
+        <source>Edit Palettes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_partselectionwidget.cpp" line="911"/>
         <source>No Icons</source>
         <translation>Žádné ikony</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="889"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="916"/>
         <source>Small Icons</source>
         <translation>Malé ikony</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="894"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="921"/>
         <source>Medium Icons</source>
         <translation>Střední ikony</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="899"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="926"/>
         <source>Large Icons</source>
         <translation>Velké ikony</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="904"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="931"/>
         <source>Extra Large Icons</source>
         <translation>Největší ikony</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="914"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="941"/>
         <source>Show Part Names</source>
         <translatorcomment>Otázka je zda nepojmenovat parts -&gt; díly, (části)</translatorcomment>
         <translation>Zobrazit názvy částí</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="919"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="946"/>
         <source>Show Decorated Parts</source>
         <translatorcomment>Otázka co znamená zdobené?</translatorcomment>
         <translation>Zobrazit zdobené součásti</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="923"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="950"/>
         <source>Show Part Aliases</source>
         <translatorcomment>Allises -&gt; popis, přezdívka, označení</translatorcomment>
         <translation>Zobrazit přezdívny částí</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="929"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="956"/>
         <source>List Mode</source>
         <translation>Režim seznamu</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="933"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="960"/>
         <source>Lock Preview Color</source>
         <translation>Uzamknutí barevného náhledu</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="975"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1002"/>
         <source>Favorites</source>
         <translation>Oblíbené</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1091"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1118"/>
         <source>All Parts</source>
         <translation>Všechny části</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1097"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1124"/>
         <source>In Use</source>
         <translation>Využíváno</translation>
     </message>
@@ -5821,7 +5877,7 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
         <translation type="vanished">Používané části</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1103"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1130"/>
         <source>Submodels</source>
         <translation>Podmodely</translation>
     </message>
@@ -5829,12 +5885,12 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
 <context>
     <name>lcPiecesLibrary</name>
     <message>
-        <location filename="../common/lc_library.cpp" line="775"/>
+        <location filename="../common/lc_library.cpp" line="782"/>
         <source>Initializing</source>
         <translation>Zahajuji načítání</translation>
     </message>
     <message>
-        <location filename="../common/lc_library.cpp" line="776"/>
+        <location filename="../common/lc_library.cpp" line="783"/>
         <source>Loading Parts Library</source>
         <translation>Načítání knihovny dílů</translation>
     </message>
@@ -5843,6 +5899,7 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
     <name>lcPreviewDockWidget</name>
     <message>
         <location filename="../common/lc_previewwidget.cpp" line="19"/>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
         <source>Lock Preview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5867,23 +5924,18 @@ Informace o tom, jak stáhnout a nainstalovat knihovnu, naleznete na adrese http
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Unlock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Lock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../common/lc_previewwidget.cpp" line="78"/>
-        <source>%1 the preview display to %2 updates</source>
+        <source>Unlock the preview display to enable updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="80"/>
-        <source>%1 Preview</source>
+        <location filename="../common/lc_previewwidget.cpp" line="79"/>
+        <source>Lock the preview display to disable updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
+        <source>Unlock Preview</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6722,23 +6774,23 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <translation type="vanished">Ikona osy</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="409"/>
         <source>Shading Mode:</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Režim stínování:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="439"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
         <source>2x</source>
         <translation>2x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
         <source>4x</source>
         <translation>4x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="454"/>
         <source>8x</source>
         <translation>8x</translation>
     </message>
@@ -6747,7 +6799,7 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <translation type="vanished">šířka</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="436"/>
         <source>Anti-aliasing</source>
         <translation>Antialiasing</translation>
     </message>
@@ -6777,28 +6829,27 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <translation type="vanished">Logo5</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="359"/>
         <source>Edge lines</source>
         <translatorcomment>TODO</translatorcomment>
-        <translation>Okrajové čáry</translation>
+        <translation type="vanished">Okrajové čáry</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="546"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="347"/>
         <source>Wireframe</source>
         <translation>Drátový model</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="551"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="352"/>
         <source>Flat Shading</source>
         <translation>Ploché stínování</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="357"/>
         <source>Default Lights</source>
         <translation>Výchozí osvětlení</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="476"/>
         <source>Mesh LOD</source>
         <translation>Síť LOD</translation>
     </message>
@@ -6833,17 +6884,15 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <translation>Obnovit rozvržení karty</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="431"/>
         <source>Highlight new parts</source>
-        <translation>Zvýrazněte nové části</translation>
+        <translation type="vanished">Zvýrazněte nové části</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="394"/>
         <source>Fade previous steps</source>
-        <translation>Zeslabit předchozí kroky</translation>
+        <translation type="vanished">Zeslabit předchozí kroky</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="941"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="916"/>
         <source>Interface</source>
         <translation>Rozhraní</translation>
     </message>
@@ -6852,7 +6901,7 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <translation type="vanished">Překrývání</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="961"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="978"/>
         <source>Overlay Color:</source>
         <translation>Barva překrytí:</translation>
     </message>
@@ -6861,60 +6910,60 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <translation type="vanished">Aktivní zobrazení:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="678"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="745"/>
         <source>Base Grid</source>
         <translation>Základní mřížka</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="728"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="795"/>
         <source>Draw studs</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Nakreslete cvočky</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="751"/>
         <source>studs</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>cvočky</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="704"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="771"/>
         <source>Draw lines every</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Nakreslí včechny čáry</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1111"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1052"/>
         <source>View Sphere</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Zobrazit sféru</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="615"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="783"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="850"/>
         <source>Disabled</source>
         <translation>Zakázáno</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="620"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="656"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="855"/>
         <source>Small</source>
         <translation>Malé</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="625"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="793"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="661"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="860"/>
         <source>Medium</source>
         <translation>Střední</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="630"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="798"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="666"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="865"/>
         <source>Large</source>
         <translation>Velké</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1145"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1118"/>
         <source>Highlight Color:</source>
         <translation>Barva zvýraznění:</translation>
     </message>
@@ -6923,682 +6972,782 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <translation type="vanished">Velikost:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1117"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1058"/>
         <source>Color:</source>
         <translation>Barva:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1131"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1088"/>
         <source>Text Color:</source>
         <translation>Barva textu:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="600"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="775"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="636"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="711"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="842"/>
         <source>Location:</source>
         <translatorcomment>TODO - poloha, umístění , místo</translatorcomment>
         <translation>Umístění:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="429"/>
         <source>Stud Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="465"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="366"/>
         <source>Plain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="470"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="371"/>
         <source>Thin Lines Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="475"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="376"/>
         <source>Outline Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="381"/>
         <source>Sharp Top Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="386"/>
         <source>Rounded Top Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="490"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="391"/>
         <source>Flattened Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="495"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="396"/>
         <source>High Contrast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="500"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
         <source>High Contrast with Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="524"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
         <source>Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="531"/>
-        <source>Automate edge color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="538"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
         <source>Contrast Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="581"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="617"/>
         <source>Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="587"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="623"/>
         <source>Model Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="744"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="629"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="811"/>
         <source>Axis Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="607"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="806"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="643"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="873"/>
         <source>View Sphere:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="639"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="752"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="675"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="819"/>
         <source>Top Left</source>
         <translation>Vlevo nahoře</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="644"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="757"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="680"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="724"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="824"/>
         <source>Top Right</source>
         <translation>Vpravo nahoře</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="649"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="762"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="685"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="729"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="829"/>
         <source>Bottom Left</source>
         <translation>Vlevo dole</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="654"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="767"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="690"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="734"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="834"/>
         <source>Bottom Right</source>
         <translation>Vpravo dole</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="721"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
         <source>Draw origin lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="805"/>
         <source>Part Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="843"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="910"/>
         <source>Colors</source>
         <translation type="unfinished">Barvy</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="849"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1227"/>
         <source>Background</source>
         <translation type="unfinished">Pozadí</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="857"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1235"/>
         <source>Top Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="871"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1265"/>
         <source>Bottom Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="900"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
         <source>So&amp;lid Color</source>
         <translation type="unfinished">P&amp;lná barva</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="907"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1301"/>
         <source>&amp;Gradient</source>
         <translation type="unfinished">Př&amp;echod</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="947"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="936"/>
         <source>Inactive View Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="968"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1026"/>
         <source>Active View Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="989"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="950"/>
         <source>Camera Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1016"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="985"/>
         <source>Axis Icon Labels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1030"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="922"/>
         <source>Marquee Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1044"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="469"/>
+        <source>Highlight New Parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="506"/>
+        <source>Fade Previous Steps</source>
+        <translation type="unfinished">Zeslabit předchozí kroky</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="523"/>
+        <source>Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="536"/>
+        <source>Conditional Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <source>Line Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="579"/>
+        <source>Edge Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="586"/>
+        <source>Automate Edge Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="964"/>
         <source>Marquee Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1061"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1161"/>
         <source>Grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1067"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1167"/>
         <source>Lines:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1197"/>
         <source>Studs:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1189"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1230"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1335"/>
+        <source>Objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1341"/>
+        <source>Light:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1371"/>
+        <source>Focused:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1385"/>
+        <source>Control Point Focused:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1420"/>
+        <source>Control Point:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1427"/>
+        <source>Selected:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1434"/>
+        <source>Camera:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1458"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1499"/>
         <source>Categories</source>
         <translation>Kategorie</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1195"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1464"/>
         <source>Parts Library Categories</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Kategorie knihoven součástí</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1264"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1533"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1538"/>
         <source>Number</source>
         <translation>Číslo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1280"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1408"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1541"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1549"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1677"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1810"/>
         <source>Import...</source>
         <translation>Importovat...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1287"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1415"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1548"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1817"/>
         <source>Export...</source>
         <translation>Exportovat...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1422"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1555"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1563"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1691"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1824"/>
         <source>Reset...</source>
         <translatorcomment>TODO - Vynulovat, obnovit, zrušit, přenastavit, resetovat</translatorcomment>
         <translation>Obnovit...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1319"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1588"/>
         <source>Category</source>
         <translation>Kategorie</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1325"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1594"/>
         <source>New...</source>
         <translation>Nová...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1332"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1601"/>
         <source>Edit...</source>
         <translation>Upravit...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1608"/>
         <source>Delete...</source>
         <translation>Odstranit...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1363"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1632"/>
         <source>Keyboard</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Klávesnice</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1642"/>
         <source>Keyboard Shortcuts</source>
         <translation>Klávesové zkratky</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1386"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1655"/>
         <source>Command</source>
         <translation>Příkaz</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1391"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1450"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1584"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1660"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1853"/>
         <source>Shortcut</source>
         <translation>Zkratka</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1399"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1668"/>
         <source>Search shortcuts</source>
         <translation>Hledání zkratky</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1456"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1725"/>
         <source>Key se&amp;quence:</source>
         <translation>Kom&amp;binace kláves:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1469"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1920"/>
         <source>Assign</source>
         <translation>Přiřadit</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1476"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1658"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1745"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1927"/>
         <source>Remove</source>
         <translation>Odebrat</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1498"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1767"/>
         <source>Mouse</source>
         <translation>Myš</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1506"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1775"/>
         <source>Mouse Shortcuts</source>
         <translation>Zkratky myší</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1521"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1790"/>
         <source>Action</source>
         <translation>Akce</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1526"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1795"/>
         <source>Shortcut 1</source>
         <translation>Zkratka 1</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1531"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1800"/>
         <source>Shortcut 2</source>
         <translation>Zkratka 2</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1592"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1861"/>
         <source>Button:</source>
         <translation>Tlačítko:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1600"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1869"/>
         <source>None</source>
         <translation>Žádné</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1605"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1874"/>
         <source>Left</source>
         <translation>Levé</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1610"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1879"/>
         <source>Middle</source>
         <translation>Střední</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1615"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1884"/>
         <source>Right</source>
         <translation>Pravé</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1623"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1892"/>
         <source>Modifiers:</source>
         <translation>Modifikátory:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1630"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1899"/>
         <source>Control</source>
         <translation>Control</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1637"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1906"/>
         <source>Alt</source>
         <translation>Alt</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1644"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1913"/>
         <source>Shift</source>
         <translation>Shift</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1672"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1941"/>
         <source>Mouse sensitivity:</source>
         <translation>Citlivost myši:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="242"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="263"/>
         <source>Grid spacing must be greater than 0.</source>
         <translation>Rozteč mřížky musí být větší než 0.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="331"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="354"/>
         <source>Select Parts Library Folder</source>
         <translation>Vyberte složku knihovny částí</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Select Parts Library Archive</source>
         <translation>Vyberte archiv knihovny částí</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Supported Archives (*.zip *.bin);;All Files (*.*)</source>
         <translation>Podporované archivy (*.zip *.bin);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Select Color Configuration File</source>
         <translation>Vyberte konfigurační soubor barev</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Settings Files (*.ldr);;All Files (*.*)</source>
         <translation>Soubory nastavení (*.ldr);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Select Minifig Settings File</source>
         <translation>Vyberte soubor nastavení Minifig</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Settings Files (*.ini);;All Files (*.*)</source>
         <translation>Soubory nastavení (*.ini);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="364"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
         <source>Executable Files (*.exe);;All Files (*.*)</source>
         <translation>Spustitelné soubory (*.exe);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="366"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="389"/>
         <source>All Files (*.*)</source>
         <translation>Všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="369"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="392"/>
         <source>Select POV-Ray Executable</source>
         <translation>Vyberte spustitelný soubor POV-Ray</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="377"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="400"/>
         <source>Open LGEO Folder</source>
         <translation>Otevřete složku LGEO</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Reset Colors</source>
         <translation>Obnovit barvy</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Would you like to also reset the interface colors to match the color theme?</source>
         <translation>Chcete také resetovat barvy rozhraní tak, aby odpovídaly barevnému motivu?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="424"/>
         <source>Select Background Color</source>
         <translation type="unfinished">Vybrat barvu pozadí</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="406"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="429"/>
         <source>Select Gradient Top Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="411"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="434"/>
         <source>Select Gradient Bottom Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="416"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="439"/>
         <source>Select Axes Color</source>
         <translation>Vybrat barvu os</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="421"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="444"/>
         <source>Select Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="426"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="449"/>
         <source>Select Marquee Border Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="431"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="454"/>
         <source>Select Marquee Fill Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="437"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="460"/>
         <source>Select Overlay Color</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="442"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="465"/>
         <source>Select Active View Color</source>
         <translation>Vybrat barvu aktivního pohledu</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="447"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="470"/>
         <source>Select Inactive View Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="452"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="475"/>
         <source>Select Fade Color</source>
         <translation>Výbrat barvu slábnutí</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="458"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="481"/>
         <source>Select Highlight Color</source>
         <translation>Vybrat barvu zvýraznění</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="464"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="487"/>
         <source>Select Grid Stud Color</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Vyberte barevnou mřížku Stud</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="470"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="493"/>
         <source>Select Grid Line Color</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Vyberte barevnou mřížku Line</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="475"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="498"/>
         <source>Select View Sphere Color</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Vyberte pohled dle barvy Sphere</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="503"/>
         <source>Select View Sphere Text Color</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Vyberte pohled dle barvy textu Sphere</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="508"/>
         <source>Select View Sphere Highlight Color</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Vyberte pohled dle barvy zvíraznění Sphere</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="596"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="513"/>
+        <source>Select Object Selected Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="518"/>
+        <source>Select Object Focused Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="523"/>
+        <source>Select Camera Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="528"/>
+        <source>Select Light Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="533"/>
+        <source>Select Control Point Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="539"/>
+        <source>Select Control Point Focused Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="661"/>
         <source>Unassigned</source>
         <translation>Nepřiřazeno</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="710"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="775"/>
         <source>Are you sure you want to delete the category &apos;%1&apos;?</source>
         <translation>Opravdu chcete smazat kategorii &apos;%1&apos;?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
         <source>Import Categories</source>
         <translation>Importovat kategorie</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Text Files (*.txt);;All Files (*.*)</source>
         <translation>Textové soubory (*.txt);;všechny soubory (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="731"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="796"/>
         <source>Error loading categories file.</source>
         <translation>Při načítání souboru kategorií došlo k chybě.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
         <source>Export Categories</source>
         <translation>Exportovat kategorie</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="749"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="814"/>
         <source>Error saving categories file.</source>
         <translation>Chyba při ukládání souboru kategorií.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="756"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="821"/>
         <source>Are you sure you want to load the default categories?</source>
         <translation>Opravdu chcete načíst výchozí kategorie?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="957"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1022"/>
         <source>The shortcut &apos;%1&apos; is already assigned to &apos;%2&apos;. Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
         <source>Import shortcuts</source>
         <translation>Importovat zkratky</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1020"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1085"/>
         <source>Error loading keyboard shortcuts file.</source>
         <translation>Chyba při čtení souboru klávesových zkratek.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
         <source>Export shortcuts</source>
         <translation>Exportovat zkratky</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1039"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1104"/>
         <source>Error saving keyboard shortcuts file.</source>
         <translation>Chyba při ukládání souboru klávesových zkratek.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1046"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1111"/>
         <source>Are you sure you want to load the default keyboard shortcuts?</source>
         <translation>Opravdu chcete načíst výchozí klávesové zkratky?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1073"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1138"/>
         <source>Left Button</source>
         <translation>Levé tlačítko</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1142"/>
         <source>Middle Button</source>
         <translation>Střední tlačítko</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1146"/>
         <source>Right Button</source>
         <translation>Pravé tlačítko</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="959"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1024"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>Override Shortcut</source>
         <translation>Přepsat zkratky</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>This shortcut is already assigned to &apos;%1&apos;, do you want to replace it?</source>
         <translation>Tato zkratka je již přiřazena k &apos;%1&apos;, chcete ji nahradit?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
         <source>Import Shortcuts</source>
         <translation>Importovat zkratky</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1212"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1277"/>
         <source>Error loading mouse shortcuts file.</source>
         <translation>Chyba při čtení souboru zkratek myši.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Export Shortcuts</source>
         <translation>Exportovat zkratky</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1231"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1296"/>
         <source>Error saving mouse shortcuts file.</source>
         <translation>Při ukládání souboru klávesových zkratek došlo k chybě.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1236"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1301"/>
         <source>Are you sure you want to load the default mouse shortcuts?</source>
         <translation>Opravdu chcete načíst výchozí zkratky pro myš?</translation>
     </message>
@@ -7629,6 +7778,11 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <location filename="../qt/lc_qpropertiesdialog.ui" line="56"/>
         <source>Comments:</source>
         <translation>Komentáře:</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="76"/>
+        <source>Measurements:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scene</source>
@@ -7664,7 +7818,7 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <translation type="vanished">Nastavit jako výchozí možnosti pro nové projekty</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.ui" line="77"/>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="91"/>
         <source>Parts Used</source>
         <translation>Použité díly</translation>
     </message>
@@ -7674,13 +7828,20 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <translation>%1 Vlastnosti</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="62"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="51"/>
+        <source>%1 x %2 x %3 cm
+%4 x %5 x %6 inches
+%7 x %8 x %9 LDU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="70"/>
         <source>Part</source>
         <translation>Část</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="73"/>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="110"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="81"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="118"/>
         <source>Total</source>
         <translation>Celkem</translation>
     </message>
@@ -7718,40 +7879,40 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="886"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1018"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="895"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1027"/>
         <source>Position</source>
         <translation>Pozice</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="887"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="892"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1019"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1024"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="888"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="893"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1020"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1025"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1039"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="889"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="894"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1021"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1026"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1031"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="903"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1040"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="891"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
         <source>Rotation</source>
         <translation>Rotace</translation>
     </message>
@@ -7760,73 +7921,73 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
         <translation type="vanished">Viditelnost</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="905"/>
         <source>Visible Steps</source>
         <translation>Viditelné kroky</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="906"/>
         <source>Show</source>
         <translation>Zobrazit</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="907"/>
         <source>Hide</source>
         <translation>Skrýt</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="909"/>
         <source>Appearance</source>
         <translation>Vzhled</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="910"/>
         <source>Color</source>
         <translation>Barva</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="911"/>
         <source>Part</source>
         <translation>Část</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1023"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1032"/>
         <source>Target</source>
         <translation>Cíl</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1042"/>
         <source>Up</source>
         <translation>Nahoru</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1043"/>
         <source>Orthographic</source>
         <translation>Pravoúhle</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1044"/>
         <source>FOV</source>
         <translation>FOV</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1036"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1045"/>
         <source>Near</source>
         <translation>Blízko</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1046"/>
         <source>Far</source>
         <translation>Daleko</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1047"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1118"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1127"/>
         <source>Multiple Objects Selected</source>
         <translation>Bylo vybráno několik objektů</translation>
     </message>
@@ -8119,22 +8280,22 @@ GL_EXT_texture_filter_anisotropic rozšíření: %5
 <context>
     <name>lcView</name>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>LeoCAD</source>
         <translation type="unfinished">LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>Error creating images.</source>
         <translation type="unfinished">Při vytváření obrázků došlo k chybě.</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation type="unfinished">Chyba zápisu do souboru &apos;%1&apos;:

--- a/resources/leocad_de.ts
+++ b/resources/leocad_de.ts
@@ -700,586 +700,581 @@
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="981"/>
-        <source>View.Cameras.Reset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="988"/>
         <source>View.Time.First</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="995"/>
+        <location filename="../common/lc_commands.cpp" line="988"/>
         <source>View.Time.Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1002"/>
+        <location filename="../common/lc_commands.cpp" line="995"/>
         <source>View.Time.Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1009"/>
+        <location filename="../common/lc_commands.cpp" line="1002"/>
         <source>View.Time.Last</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1016"/>
+        <location filename="../common/lc_commands.cpp" line="1009"/>
         <source>View.Time.InsertBefore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1023"/>
+        <location filename="../common/lc_commands.cpp" line="1016"/>
         <source>View.Time.InsertAfter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1030"/>
+        <location filename="../common/lc_commands.cpp" line="1023"/>
         <source>View.Time.Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1037"/>
+        <location filename="../common/lc_commands.cpp" line="1030"/>
         <source>View.Time.AddKeys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1044"/>
+        <location filename="../common/lc_commands.cpp" line="1037"/>
         <source>View.SplitHorizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1051"/>
+        <location filename="../common/lc_commands.cpp" line="1044"/>
         <source>View.SplitVertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1058"/>
+        <location filename="../common/lc_commands.cpp" line="1051"/>
         <source>View.RemoveView</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1065"/>
+        <location filename="../common/lc_commands.cpp" line="1058"/>
         <source>View.ResetViews</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1072"/>
+        <location filename="../common/lc_commands.cpp" line="1065"/>
         <source>View.Toolbars.Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1079"/>
+        <location filename="../common/lc_commands.cpp" line="1072"/>
         <source>View.Toolbars.Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1086"/>
+        <location filename="../common/lc_commands.cpp" line="1079"/>
         <source>View.Toolbars.Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1093"/>
+        <location filename="../common/lc_commands.cpp" line="1086"/>
         <source>View.Toolbars.Parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1100"/>
+        <location filename="../common/lc_commands.cpp" line="1093"/>
         <source>View.Toolbars.Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1107"/>
+        <location filename="../common/lc_commands.cpp" line="1100"/>
         <source>View.Toolbars.Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1114"/>
+        <location filename="../common/lc_commands.cpp" line="1107"/>
         <source>View.Toolbars.Timeline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1121"/>
+        <location filename="../common/lc_commands.cpp" line="1114"/>
         <source>View.Toolbars.Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1128"/>
+        <location filename="../common/lc_commands.cpp" line="1121"/>
         <source>View.FullScreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1135"/>
+        <location filename="../common/lc_commands.cpp" line="1128"/>
         <source>View.CloseCurrentTab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1142"/>
+        <location filename="../common/lc_commands.cpp" line="1135"/>
         <source>View.Shade.Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1149"/>
+        <location filename="../common/lc_commands.cpp" line="1142"/>
         <source>View.Shade.Flat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1156"/>
+        <location filename="../common/lc_commands.cpp" line="1149"/>
         <source>View.Shade.DefaultLights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1163"/>
+        <location filename="../common/lc_commands.cpp" line="1156"/>
         <source>View.Projection.Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1170"/>
+        <location filename="../common/lc_commands.cpp" line="1163"/>
         <source>View.Projection.Orthographic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1177"/>
+        <location filename="../common/lc_commands.cpp" line="1170"/>
         <source>View.ToggleViewSphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1184"/>
+        <location filename="../common/lc_commands.cpp" line="1177"/>
         <source>View.ToggleAxisIcon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1191"/>
+        <location filename="../common/lc_commands.cpp" line="1184"/>
         <source>View.ToggleGrid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1198"/>
+        <location filename="../common/lc_commands.cpp" line="1191"/>
         <source>View.FadePreviousSteps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1205"/>
+        <location filename="../common/lc_commands.cpp" line="1198"/>
         <source>Piece.Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1212"/>
+        <location filename="../common/lc_commands.cpp" line="1205"/>
         <source>Piece.Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1219"/>
+        <location filename="../common/lc_commands.cpp" line="1212"/>
         <source>Piece.Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1226"/>
+        <location filename="../common/lc_commands.cpp" line="1219"/>
         <source>Piece.PaintSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1233"/>
+        <location filename="../common/lc_commands.cpp" line="1226"/>
         <source>Piece.ResetPivotPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1240"/>
+        <location filename="../common/lc_commands.cpp" line="1233"/>
         <source>Piece.RemoveKeyFrames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1247"/>
+        <location filename="../common/lc_commands.cpp" line="1240"/>
         <source>Piece.ControlPoint.Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1254"/>
+        <location filename="../common/lc_commands.cpp" line="1247"/>
         <source>Piece.ControlPoint.Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1261"/>
+        <location filename="../common/lc_commands.cpp" line="1254"/>
         <source>Piece.Move.PlusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1268"/>
+        <location filename="../common/lc_commands.cpp" line="1261"/>
         <source>Piece.Move.MinusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1275"/>
+        <location filename="../common/lc_commands.cpp" line="1268"/>
         <source>Piece.Move.PlusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1282"/>
+        <location filename="../common/lc_commands.cpp" line="1275"/>
         <source>Piece.Move.MinusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1289"/>
+        <location filename="../common/lc_commands.cpp" line="1282"/>
         <source>Piece.Move.PlusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1296"/>
+        <location filename="../common/lc_commands.cpp" line="1289"/>
         <source>Piece.Move.MinusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1303"/>
+        <location filename="../common/lc_commands.cpp" line="1296"/>
         <source>Piece.Rotate.PlusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1310"/>
+        <location filename="../common/lc_commands.cpp" line="1303"/>
         <source>Piece.Rotate.MinusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1317"/>
+        <location filename="../common/lc_commands.cpp" line="1310"/>
         <source>Piece.Rotate.PlusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1324"/>
+        <location filename="../common/lc_commands.cpp" line="1317"/>
         <source>Piece.Rotate.MinusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1331"/>
+        <location filename="../common/lc_commands.cpp" line="1324"/>
         <source>Piece.Rotate.PlusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1338"/>
+        <location filename="../common/lc_commands.cpp" line="1331"/>
         <source>Piece.Rotate.MinusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1345"/>
+        <location filename="../common/lc_commands.cpp" line="1338"/>
         <source>Piece.MinifigWizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1352"/>
+        <location filename="../common/lc_commands.cpp" line="1345"/>
         <source>Piece.Array</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1359"/>
+        <location filename="../common/lc_commands.cpp" line="1352"/>
         <source>Piece.ViewSelectedModel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1366"/>
+        <location filename="../common/lc_commands.cpp" line="1359"/>
         <source>Piece.MoveSelectionToModel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1373"/>
+        <location filename="../common/lc_commands.cpp" line="1366"/>
         <source>Piece.InlineSelectedModels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1380"/>
+        <location filename="../common/lc_commands.cpp" line="1373"/>
         <source>Piece.EditSelectedSubmodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1387"/>
+        <location filename="../common/lc_commands.cpp" line="1380"/>
         <source>Piece.EditEndSubmodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1394"/>
+        <location filename="../common/lc_commands.cpp" line="1387"/>
         <source>Piece.Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1401"/>
+        <location filename="../common/lc_commands.cpp" line="1394"/>
         <source>Piece.Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1408"/>
+        <location filename="../common/lc_commands.cpp" line="1401"/>
         <source>Piece.GroupAdd</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1415"/>
+        <location filename="../common/lc_commands.cpp" line="1408"/>
         <source>Piece.GroupRemove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1422"/>
+        <location filename="../common/lc_commands.cpp" line="1415"/>
         <source>Piece.GroupEdit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1429"/>
+        <location filename="../common/lc_commands.cpp" line="1422"/>
         <source>Piece.HideSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1436"/>
+        <location filename="../common/lc_commands.cpp" line="1429"/>
         <source>Piece.HideUnselected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1443"/>
+        <location filename="../common/lc_commands.cpp" line="1436"/>
         <source>Piece.UnhideSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1450"/>
+        <location filename="../common/lc_commands.cpp" line="1443"/>
         <source>Piece.UnhideAll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1457"/>
+        <location filename="../common/lc_commands.cpp" line="1450"/>
         <source>Piece.ShowEarlier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1464"/>
+        <location filename="../common/lc_commands.cpp" line="1457"/>
         <source>Piece.ShowLater</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1471"/>
+        <location filename="../common/lc_commands.cpp" line="1464"/>
         <source>Model.New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1478"/>
+        <location filename="../common/lc_commands.cpp" line="1471"/>
         <source>Model.Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1485"/>
+        <location filename="../common/lc_commands.cpp" line="1478"/>
         <source>Model.List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1492"/>
+        <location filename="../common/lc_commands.cpp" line="1485"/>
         <source>Model.Model01</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1499"/>
+        <location filename="../common/lc_commands.cpp" line="1492"/>
         <source>Model.Model02</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1506"/>
+        <location filename="../common/lc_commands.cpp" line="1499"/>
         <source>Model.Model03</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1513"/>
+        <location filename="../common/lc_commands.cpp" line="1506"/>
         <source>Model.Model04</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1520"/>
+        <location filename="../common/lc_commands.cpp" line="1513"/>
         <source>Model.Model05</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1527"/>
+        <location filename="../common/lc_commands.cpp" line="1520"/>
         <source>Model.Model06</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1534"/>
+        <location filename="../common/lc_commands.cpp" line="1527"/>
         <source>Model.Model07</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1541"/>
+        <location filename="../common/lc_commands.cpp" line="1534"/>
         <source>Model.Model08</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1548"/>
+        <location filename="../common/lc_commands.cpp" line="1541"/>
         <source>Model.Model09</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1555"/>
+        <location filename="../common/lc_commands.cpp" line="1548"/>
         <source>Model.Model10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1562"/>
+        <location filename="../common/lc_commands.cpp" line="1555"/>
         <source>Model.Model11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1569"/>
+        <location filename="../common/lc_commands.cpp" line="1562"/>
         <source>Model.Model12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1576"/>
+        <location filename="../common/lc_commands.cpp" line="1569"/>
         <source>Model.Model13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1583"/>
+        <location filename="../common/lc_commands.cpp" line="1576"/>
         <source>Model.Model14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1590"/>
+        <location filename="../common/lc_commands.cpp" line="1583"/>
         <source>Model.Model15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1597"/>
+        <location filename="../common/lc_commands.cpp" line="1590"/>
         <source>Model.Model16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1604"/>
+        <location filename="../common/lc_commands.cpp" line="1597"/>
         <source>Model.Model17</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1611"/>
+        <location filename="../common/lc_commands.cpp" line="1604"/>
         <source>Model.Model18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1618"/>
+        <location filename="../common/lc_commands.cpp" line="1611"/>
         <source>Model.Model19</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1625"/>
+        <location filename="../common/lc_commands.cpp" line="1618"/>
         <source>Model.Model20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1632"/>
+        <location filename="../common/lc_commands.cpp" line="1625"/>
         <source>Model.Model21</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1639"/>
+        <location filename="../common/lc_commands.cpp" line="1632"/>
         <source>Model.Model22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1646"/>
+        <location filename="../common/lc_commands.cpp" line="1639"/>
         <source>Model.Model23</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1653"/>
+        <location filename="../common/lc_commands.cpp" line="1646"/>
         <source>Model.Model24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1660"/>
+        <location filename="../common/lc_commands.cpp" line="1653"/>
         <source>Model.Model25</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1667"/>
+        <location filename="../common/lc_commands.cpp" line="1660"/>
         <source>Model.Model26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1674"/>
+        <location filename="../common/lc_commands.cpp" line="1667"/>
         <source>Model.Model27</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1681"/>
+        <location filename="../common/lc_commands.cpp" line="1674"/>
         <source>Model.Model28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1688"/>
+        <location filename="../common/lc_commands.cpp" line="1681"/>
         <source>Model.Model29</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1695"/>
+        <location filename="../common/lc_commands.cpp" line="1688"/>
         <source>Model.Model30</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1702"/>
+        <location filename="../common/lc_commands.cpp" line="1695"/>
         <source>Model.Model31</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1709"/>
+        <location filename="../common/lc_commands.cpp" line="1702"/>
         <source>Model.Model32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1716"/>
+        <location filename="../common/lc_commands.cpp" line="1709"/>
         <source>Model.Model33</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1723"/>
+        <location filename="../common/lc_commands.cpp" line="1716"/>
         <source>Model.Model34</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1730"/>
+        <location filename="../common/lc_commands.cpp" line="1723"/>
         <source>Model.Model35</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1737"/>
+        <location filename="../common/lc_commands.cpp" line="1730"/>
         <source>Model.Model36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1744"/>
+        <location filename="../common/lc_commands.cpp" line="1737"/>
         <source>Model.Model37</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1751"/>
+        <location filename="../common/lc_commands.cpp" line="1744"/>
         <source>Model.Model38</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1758"/>
+        <location filename="../common/lc_commands.cpp" line="1751"/>
         <source>Model.Model39</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1765"/>
+        <location filename="../common/lc_commands.cpp" line="1758"/>
         <source>Model.Model40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1772"/>
+        <location filename="../common/lc_commands.cpp" line="1765"/>
         <source>Help.HomePage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1779"/>
+        <location filename="../common/lc_commands.cpp" line="1772"/>
         <source>Help.BugReport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1786"/>
+        <location filename="../common/lc_commands.cpp" line="1779"/>
         <source>Help.Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1793"/>
+        <location filename="../common/lc_commands.cpp" line="1786"/>
         <source>Help.About</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1381,37 +1376,37 @@
         <translation>Einrasten eingeschaltet</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1017"/>
+        <location filename="../common/lc_commands.cpp" line="1010"/>
         <source>Insert Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1017"/>
         <source>Insert After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1360"/>
+        <location filename="../common/lc_commands.cpp" line="1353"/>
         <source>Open Selected Model</source>
         <translation>Öffne Ausgewähltes Modell</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1381"/>
+        <location filename="../common/lc_commands.cpp" line="1374"/>
         <source>Edit Selected Submodel</source>
         <translation>Bearbeite Ausgewähltes Untermodell</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1388"/>
+        <location filename="../common/lc_commands.cpp" line="1381"/>
         <source>End Submodel Editing</source>
         <translation>Beende Untermodell Bearbeitung</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1472"/>
+        <location filename="../common/lc_commands.cpp" line="1465"/>
         <source>New Submodel...</source>
         <translation>Neues Untermodell...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1479"/>
+        <location filename="../common/lc_commands.cpp" line="1472"/>
         <source>Prope&amp;rties...</source>
         <translation>&amp;Eigenschaften…</translation>
     </message>
@@ -1983,27 +1978,26 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="982"/>
         <source>Reset</source>
-        <translation>Zurücksetzen</translation>
+        <translation type="vanished">Zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="989"/>
+        <location filename="../common/lc_commands.cpp" line="982"/>
         <source>First</source>
         <translation>Erster</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="996"/>
+        <location filename="../common/lc_commands.cpp" line="989"/>
         <source>Previous</source>
         <translation>Vorheriger</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1003"/>
+        <location filename="../common/lc_commands.cpp" line="996"/>
         <source>Next</source>
         <translation>Nächster</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1010"/>
+        <location filename="../common/lc_commands.cpp" line="1003"/>
         <source>Last</source>
         <translation>Letzter</translation>
     </message>
@@ -2012,533 +2006,533 @@
         <translation type="vanished">Schritt einfügen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1031"/>
-        <location filename="../common/lc_commands.cpp" line="1815"/>
+        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1808"/>
         <source>Remove Step</source>
         <translation>Schritt entfernen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1038"/>
+        <location filename="../common/lc_commands.cpp" line="1031"/>
         <source>Add Keys</source>
         <translation>Schlüssel hinzufügen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1045"/>
+        <location filename="../common/lc_commands.cpp" line="1038"/>
         <source>Split &amp;Horizontal</source>
         <translation>&amp;Horizontal teilen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1052"/>
+        <location filename="../common/lc_commands.cpp" line="1045"/>
         <source>Split &amp;Vertical</source>
         <translation>&amp;Vertikal teilen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1059"/>
+        <location filename="../common/lc_commands.cpp" line="1052"/>
         <source>Re&amp;move View</source>
         <translation>Ansicht &amp;entfernen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1066"/>
+        <location filename="../common/lc_commands.cpp" line="1059"/>
         <source>Rese&amp;t Views</source>
         <translation>Ansicht z&amp;urücksetzen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1073"/>
+        <location filename="../common/lc_commands.cpp" line="1066"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1080"/>
+        <location filename="../common/lc_commands.cpp" line="1073"/>
         <source>Tools</source>
         <translation type="unfinished">Werkzeuge</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1087"/>
+        <location filename="../common/lc_commands.cpp" line="1080"/>
         <source>Time</source>
         <translation type="unfinished">Zeit</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1094"/>
+        <location filename="../common/lc_commands.cpp" line="1087"/>
         <source>Parts</source>
         <translation type="unfinished">Teile</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1101"/>
+        <location filename="../common/lc_commands.cpp" line="1094"/>
         <source>Colors</source>
         <translation type="unfinished">Farben</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1108"/>
+        <location filename="../common/lc_commands.cpp" line="1101"/>
         <source>Properties</source>
         <translation type="unfinished">Eigenschaften</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1115"/>
+        <location filename="../common/lc_commands.cpp" line="1108"/>
         <source>Timeline</source>
         <translation type="unfinished">Zeitachse</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1122"/>
+        <location filename="../common/lc_commands.cpp" line="1115"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1129"/>
+        <location filename="../common/lc_commands.cpp" line="1122"/>
         <source>&amp;Full Screen</source>
         <translation>&amp;Vollbildansicht</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1136"/>
+        <location filename="../common/lc_commands.cpp" line="1129"/>
         <source>Close &amp;Tab</source>
         <translation>Schließe &amp;Tab</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1143"/>
+        <location filename="../common/lc_commands.cpp" line="1136"/>
         <source>&amp;Wireframe</source>
         <translation>&amp;Drahtrahmen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1150"/>
+        <location filename="../common/lc_commands.cpp" line="1143"/>
         <source>&amp;Flat Shading</source>
         <translation>&amp;Einfache Schattierung</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1157"/>
+        <location filename="../common/lc_commands.cpp" line="1150"/>
         <source>&amp;Default Lights</source>
         <translation>&amp;Default Beleuchtung</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1164"/>
+        <location filename="../common/lc_commands.cpp" line="1157"/>
         <source>&amp;Perspective</source>
         <translation>&amp;Perspektive</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1171"/>
+        <location filename="../common/lc_commands.cpp" line="1164"/>
         <source>&amp;Orthographic</source>
         <translation>&amp;Rechtwinklig</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1178"/>
+        <location filename="../common/lc_commands.cpp" line="1171"/>
         <source>View Sphere</source>
         <translation type="unfinished">Ansichtskugel</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1185"/>
+        <location filename="../common/lc_commands.cpp" line="1178"/>
         <source>Axis Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1192"/>
+        <location filename="../common/lc_commands.cpp" line="1185"/>
         <source>Base Grid</source>
         <translation type="unfinished">Grundraster</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1199"/>
+        <location filename="../common/lc_commands.cpp" line="1192"/>
         <source>Fade Previous Steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1206"/>
+        <location filename="../common/lc_commands.cpp" line="1199"/>
         <source>&amp;Insert</source>
         <translation>&amp;Einfügen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1213"/>
+        <location filename="../common/lc_commands.cpp" line="1206"/>
         <source>&amp;Delete</source>
         <translation>&amp;Löschen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1220"/>
+        <location filename="../common/lc_commands.cpp" line="1213"/>
         <source>&amp;Duplicate</source>
         <translation>&amp;Duplizieren</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1227"/>
+        <location filename="../common/lc_commands.cpp" line="1220"/>
         <source>&amp;Paint Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1234"/>
+        <location filename="../common/lc_commands.cpp" line="1227"/>
         <source>Reset &amp;Pivot Point</source>
         <translation>&amp;Ursprungspunkt zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1241"/>
+        <location filename="../common/lc_commands.cpp" line="1234"/>
         <source>Remove &amp;Key Frames</source>
         <translation>&amp;Keyframes entfernen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1248"/>
+        <location filename="../common/lc_commands.cpp" line="1241"/>
         <source>Insert Control Point</source>
         <translation>Steuerpunkt setzen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1255"/>
+        <location filename="../common/lc_commands.cpp" line="1248"/>
         <source>Remove Control Point</source>
         <translation>Steuerpunkt entfernen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1262"/>
+        <location filename="../common/lc_commands.cpp" line="1255"/>
         <source>Move +X</source>
         <translation>Bewege +X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1269"/>
+        <location filename="../common/lc_commands.cpp" line="1262"/>
         <source>Move -X</source>
         <translation>Bewege -X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1276"/>
+        <location filename="../common/lc_commands.cpp" line="1269"/>
         <source>Move +Y</source>
         <translation>Bewege +Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1283"/>
+        <location filename="../common/lc_commands.cpp" line="1276"/>
         <source>Move -Y</source>
         <translation>Bewege -Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1290"/>
+        <location filename="../common/lc_commands.cpp" line="1283"/>
         <source>Move +Z</source>
         <translation>Bewege +Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1297"/>
+        <location filename="../common/lc_commands.cpp" line="1290"/>
         <source>Move -Z</source>
         <translation>Bewege -Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1304"/>
+        <location filename="../common/lc_commands.cpp" line="1297"/>
         <source>Rotate +X</source>
         <translation>Drehe +X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1311"/>
+        <location filename="../common/lc_commands.cpp" line="1304"/>
         <source>Rotate -X</source>
         <translation>Drehe -X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1318"/>
+        <location filename="../common/lc_commands.cpp" line="1311"/>
         <source>Rotate +Y</source>
         <translation>Drehe +Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1325"/>
+        <location filename="../common/lc_commands.cpp" line="1318"/>
         <source>Rotate -Y</source>
         <translation>Drehe -Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1332"/>
+        <location filename="../common/lc_commands.cpp" line="1325"/>
         <source>Rotate +Z</source>
         <translation>Drehe +Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1339"/>
+        <location filename="../common/lc_commands.cpp" line="1332"/>
         <source>Rotate -Z</source>
         <translation>Drehe -Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1346"/>
+        <location filename="../common/lc_commands.cpp" line="1339"/>
         <source>Minifig &amp;Wizard...</source>
         <translation>Minifig &amp;Assistent…</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1353"/>
+        <location filename="../common/lc_commands.cpp" line="1346"/>
         <source>A&amp;rray...</source>
         <translation>&amp;Vervielfachen…</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1367"/>
+        <location filename="../common/lc_commands.cpp" line="1360"/>
         <source>Move to New Model...</source>
         <translation>In Neues Modell verschieben…</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1374"/>
+        <location filename="../common/lc_commands.cpp" line="1367"/>
         <source>Inline Selected Models</source>
         <translation>Ausgewählte Modelle integrieren</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1395"/>
+        <location filename="../common/lc_commands.cpp" line="1388"/>
         <source>&amp;Group...</source>
         <translation>&amp;Gruppieren...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1402"/>
+        <location filename="../common/lc_commands.cpp" line="1395"/>
         <source>&amp;Ungroup</source>
         <translation>&amp;Gruppierung aufheben</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1409"/>
+        <location filename="../common/lc_commands.cpp" line="1402"/>
         <source>&amp;Add to Group</source>
         <translation>Zur Gru&amp;ppe hinzufügen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1416"/>
+        <location filename="../common/lc_commands.cpp" line="1409"/>
         <source>Re&amp;move from Group</source>
         <translation>A&amp;us der Gruppe entfernen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1423"/>
+        <location filename="../common/lc_commands.cpp" line="1416"/>
         <source>&amp;Edit Groups...</source>
         <translation>Grup&amp;pen Bearbeiten…</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1430"/>
+        <location filename="../common/lc_commands.cpp" line="1423"/>
         <source>&amp;Hide Selected</source>
         <translation>Auswahl &amp;ausblenden</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1437"/>
+        <location filename="../common/lc_commands.cpp" line="1430"/>
         <source>Hide &amp;Unselected</source>
         <translation>Nichtausgewähltes aus&amp;blenden</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1444"/>
+        <location filename="../common/lc_commands.cpp" line="1437"/>
         <source>&amp;Unhide Selected</source>
         <translation>Auswahl einb&amp;lenden</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1451"/>
+        <location filename="../common/lc_commands.cpp" line="1444"/>
         <source>U&amp;nhide All</source>
         <translation>Alles einbl&amp;enden</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1458"/>
+        <location filename="../common/lc_commands.cpp" line="1451"/>
         <source>Show Earlier</source>
         <translation>Früheres zeigen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1465"/>
+        <location filename="../common/lc_commands.cpp" line="1458"/>
         <source>Show Later</source>
         <translation>Späteres zeigen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1486"/>
+        <location filename="../common/lc_commands.cpp" line="1479"/>
         <source>Submodels...</source>
         <translation>Untermodelle...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1493"/>
+        <location filename="../common/lc_commands.cpp" line="1486"/>
         <source>Model 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1500"/>
+        <location filename="../common/lc_commands.cpp" line="1493"/>
         <source>Model 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1507"/>
+        <location filename="../common/lc_commands.cpp" line="1500"/>
         <source>Model 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1514"/>
+        <location filename="../common/lc_commands.cpp" line="1507"/>
         <source>Model 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1521"/>
+        <location filename="../common/lc_commands.cpp" line="1514"/>
         <source>Model 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1528"/>
+        <location filename="../common/lc_commands.cpp" line="1521"/>
         <source>Model 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1535"/>
+        <location filename="../common/lc_commands.cpp" line="1528"/>
         <source>Model 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1542"/>
+        <location filename="../common/lc_commands.cpp" line="1535"/>
         <source>Model 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1549"/>
+        <location filename="../common/lc_commands.cpp" line="1542"/>
         <source>Model 9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1556"/>
+        <location filename="../common/lc_commands.cpp" line="1549"/>
         <source>Model 10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1563"/>
+        <location filename="../common/lc_commands.cpp" line="1556"/>
         <source>Model 11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1570"/>
+        <location filename="../common/lc_commands.cpp" line="1563"/>
         <source>Model 12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1577"/>
+        <location filename="../common/lc_commands.cpp" line="1570"/>
         <source>Model 13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1584"/>
+        <location filename="../common/lc_commands.cpp" line="1577"/>
         <source>Model 14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1591"/>
+        <location filename="../common/lc_commands.cpp" line="1584"/>
         <source>Model 15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1598"/>
+        <location filename="../common/lc_commands.cpp" line="1591"/>
         <source>Model 16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1605"/>
+        <location filename="../common/lc_commands.cpp" line="1598"/>
         <source>Model 17</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1612"/>
+        <location filename="../common/lc_commands.cpp" line="1605"/>
         <source>Model 18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1619"/>
+        <location filename="../common/lc_commands.cpp" line="1612"/>
         <source>Model 19</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1626"/>
+        <location filename="../common/lc_commands.cpp" line="1619"/>
         <source>Model 20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1633"/>
+        <location filename="../common/lc_commands.cpp" line="1626"/>
         <source>Model 21</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1640"/>
+        <location filename="../common/lc_commands.cpp" line="1633"/>
         <source>Model 22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1647"/>
+        <location filename="../common/lc_commands.cpp" line="1640"/>
         <source>Model 23</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1654"/>
+        <location filename="../common/lc_commands.cpp" line="1647"/>
         <source>Model 24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1661"/>
+        <location filename="../common/lc_commands.cpp" line="1654"/>
         <source>Model 25</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1668"/>
+        <location filename="../common/lc_commands.cpp" line="1661"/>
         <source>Model 26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1675"/>
+        <location filename="../common/lc_commands.cpp" line="1668"/>
         <source>Model 27</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1682"/>
+        <location filename="../common/lc_commands.cpp" line="1675"/>
         <source>Model 28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1689"/>
+        <location filename="../common/lc_commands.cpp" line="1682"/>
         <source>Model 29</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1696"/>
+        <location filename="../common/lc_commands.cpp" line="1689"/>
         <source>Model 30</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1703"/>
+        <location filename="../common/lc_commands.cpp" line="1696"/>
         <source>Model 31</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1710"/>
+        <location filename="../common/lc_commands.cpp" line="1703"/>
         <source>Model 32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1717"/>
+        <location filename="../common/lc_commands.cpp" line="1710"/>
         <source>Model 33</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1724"/>
+        <location filename="../common/lc_commands.cpp" line="1717"/>
         <source>Model 34</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1731"/>
+        <location filename="../common/lc_commands.cpp" line="1724"/>
         <source>Model 35</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1738"/>
+        <location filename="../common/lc_commands.cpp" line="1731"/>
         <source>Model 36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1745"/>
+        <location filename="../common/lc_commands.cpp" line="1738"/>
         <source>Model 37</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1752"/>
+        <location filename="../common/lc_commands.cpp" line="1745"/>
         <source>Model 38</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1759"/>
+        <location filename="../common/lc_commands.cpp" line="1752"/>
         <source>Model 39</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1766"/>
+        <location filename="../common/lc_commands.cpp" line="1759"/>
         <source>Model 40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1801"/>
+        <location filename="../common/lc_commands.cpp" line="1794"/>
         <source>Insert Step Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1808"/>
+        <location filename="../common/lc_commands.cpp" line="1801"/>
         <source>Insert Step After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1822"/>
+        <location filename="../common/lc_commands.cpp" line="1815"/>
         <source>Move Selection Here</source>
         <translation>Bewege die Auswahl hierher</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1829"/>
+        <location filename="../common/lc_commands.cpp" line="1822"/>
         <source>Set Current Step</source>
         <translation>Aktuelle Schrittweite festlegen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1773"/>
+        <location filename="../common/lc_commands.cpp" line="1766"/>
         <source>LeoCAD &amp;Home Page</source>
         <translation>&amp;Homepage von LeoCAD</translation>
     </message>
@@ -2573,17 +2567,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1787"/>
+        <location filename="../common/lc_commands.cpp" line="1780"/>
         <source>Check for &amp;Updates...</source>
         <translation>Auf Aktualisierungen prü&amp;fen…</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1794"/>
+        <location filename="../common/lc_commands.cpp" line="1787"/>
         <source>&amp;About...</source>
         <translation>&amp;Über…</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1780"/>
+        <location filename="../common/lc_commands.cpp" line="1773"/>
         <source>Report a Bug</source>
         <translation>Einen Fehler melden</translation>
     </message>
@@ -2591,77 +2585,77 @@
 <context>
     <name>Mouse</name>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1839"/>
+        <location filename="../common/lc_commands.cpp" line="1832"/>
         <source>NewPiece</source>
         <translation>Neues Teil</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1840"/>
+        <location filename="../common/lc_commands.cpp" line="1833"/>
         <source>NewPointLight</source>
         <translation>Neues Punktlicht</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1841"/>
+        <location filename="../common/lc_commands.cpp" line="1834"/>
         <source>NewSpotLight</source>
         <translation>Neues Spotlicht</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1842"/>
+        <location filename="../common/lc_commands.cpp" line="1835"/>
         <source>NewCamera</source>
         <translation>Neue Kamera</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1843"/>
+        <location filename="../common/lc_commands.cpp" line="1836"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1844"/>
+        <location filename="../common/lc_commands.cpp" line="1837"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1845"/>
+        <location filename="../common/lc_commands.cpp" line="1838"/>
         <source>Rotate</source>
         <translation>Drehen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1846"/>
+        <location filename="../common/lc_commands.cpp" line="1839"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1847"/>
+        <location filename="../common/lc_commands.cpp" line="1840"/>
         <source>Paint</source>
         <translation>Anmalen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1848"/>
+        <location filename="../common/lc_commands.cpp" line="1841"/>
         <source>ColorPicker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1849"/>
+        <location filename="../common/lc_commands.cpp" line="1842"/>
         <source>Zoom</source>
         <translation>Zoomen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1850"/>
+        <location filename="../common/lc_commands.cpp" line="1843"/>
         <source>Pan</source>
         <translation>Verschieben</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1851"/>
+        <location filename="../common/lc_commands.cpp" line="1844"/>
         <source>Orbit</source>
         <translation>Umkreisen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1852"/>
+        <location filename="../common/lc_commands.cpp" line="1845"/>
         <source>Roll</source>
         <translation>Rollen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1853"/>
+        <location filename="../common/lc_commands.cpp" line="1846"/>
         <source>ZoomRegion</source>
         <translation>Bereich zoomen</translation>
     </message>
@@ -2669,117 +2663,115 @@
 <context>
     <name>Project</name>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>Empty Name</source>
         <translation>Leerer Name</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
-        <location filename="../common/project.cpp" line="449"/>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="378"/>
+        <location filename="../common/project.cpp" line="457"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
+        <location filename="../common/project.cpp" line="378"/>
         <source>Error reading file &apos;%1&apos;:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="449"/>
+        <location filename="../common/project.cpp" line="457"/>
         <source>Error loading file &apos;%1&apos;:
 File format is not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="544"/>
+        <location filename="../common/project.cpp" line="552"/>
         <source>Merged </source>
         <translation>Vereint </translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
-        <location filename="../common/project.cpp" line="2060"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
+        <location filename="../common/project.cpp" line="2025"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="2060"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="2025"/>
         <source>Nothing to export.</source>
         <translation>Nichts zu exportieren.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>Export 3D Studio</source>
         <translation>Ins 3D Studio exportieren</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>3DS Files (*.3ds);;All Files (*.*)</source>
         <translation>3DS Datei (*.3ds);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>Could not open file &apos;%1&apos; for writing.</source>
         <translation>Konnte Datei » %1 « nicht zum Schreiben öffnen.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>Export BrickLink</source>
         <translation>Nach BrickLink exportieren</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>XML Files (*.xml);;All Files (*.*)</source>
         <translation>XML Dateien (*.xml);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>Export COLLADA</source>
         <translation>COLLADA exportieren</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>COLLADA Files (*.dae);;All Files (*.*)</source>
         <translation>COLLADA Dateien (*.dae);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>Export CSV</source>
         <translation>Nach CSV exportieren</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>CSV Files (*.csv);;All Files (*.*)</source>
         <translation>CSV Datei (*.csv);;Alle Dateien (*.*)</translation>
     </message>
@@ -2788,81 +2780,81 @@ File format is not recognized.</source>
         <translation type="vanished">Fehler beim Erzeugen der Bilder.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>Export POV-Ray</source>
         <translation>POV-Ray exportieren</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>POV-Ray Files (*.pov);;All Files (*.*)</source>
         <translation>POV-Ray Datei (*.pov);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
         <source>Could not find LGEO files in folder &apos;%1&apos;.</source>
         <translation>Konnte keine LGEO Dateien im Verzeichnis » %1 « finden.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Export Wavefront</source>
         <translation>Nach Wavefront exportieren</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Wavefront Files (*.obj);;All Files (*.*)</source>
         <translation>Wavefront Dateien (*.obj);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation>Fehler beim Schreiben der Datei » %1 « :
 %2</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.ldr</source>
         <translation>Neues Modell.ldr</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.mpd</source>
         <translation>Neues Modell.mpd</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="177"/>
+        <location filename="../common/project.cpp" line="178"/>
         <source>Submodel #</source>
         <translation>Untermodell #</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="201"/>
+        <location filename="../common/project.cpp" line="202"/>
         <source>Submodel Name:</source>
         <translation>Untermodellname:</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>The submodel name cannot be empty.</source>
         <translation>Das Untermodell kann nicht leer sein.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>Duplicate Submodel</source>
         <translation>Untermodell duplizieren</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>A submodel named &apos;%1&apos; already exists, please enter a unique name.</source>
         <translation>Ein Untermodell names &apos;%1&apos; existiert bereits, bitte geben sie einen eindeutigen Namen ein.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="245"/>
+        <location filename="../common/project.cpp" line="246"/>
         <source>New Submodel</source>
         <translation>Neues Untermodell</translation>
     </message>
@@ -2890,19 +2882,19 @@ File format is not recognized.</source>
         <translation type="vanished">Spezialfarben</translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="507"/>
+        <location filename="../common/lc_colors.cpp" line="318"/>
         <source>Solid</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="508"/>
+        <location filename="../common/lc_colors.cpp" line="319"/>
         <source>Translucent</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="509"/>
+        <location filename="../common/lc_colors.cpp" line="320"/>
         <source>Special</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
@@ -2911,14 +2903,21 @@ File format is not recognized.</source>
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
         <source>Error</source>
-        <translation type="unfinished">Fehler</translation>
+        <translation type="obsolete">Fehler</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>LeoCAD</source>
+        <translation type="unfinished">LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
-        <source>Failed to load &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>Could not open file &apos;%1&apos; for writing.</source>
+        <translation type="unfinished">Konnte Datei » %1 « nicht zum Schreiben öffnen.</translation>
     </message>
 </context>
 <context>
@@ -3517,27 +3516,26 @@ File format is not recognized.</source>
         <translation>Diese Kamera benutzen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="983"/>
         <source>Reset views to their default positions</source>
-        <translation>Alle Ansichten auf Voreinstellung zurücksetzen</translation>
+        <translation type="vanished">Alle Ansichten auf Voreinstellung zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="990"/>
+        <location filename="../common/lc_commands.cpp" line="983"/>
         <source>Go to the first step of the model</source>
         <translation>Gehe zum ersten Schritt des Modells</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="997"/>
+        <location filename="../common/lc_commands.cpp" line="990"/>
         <source>Go to the previous step</source>
         <translation>Gehe zum vorangehenden Schritt</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1004"/>
+        <location filename="../common/lc_commands.cpp" line="997"/>
         <source>Go to the next step</source>
         <translation>Gehe zum folgenden Schritt</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1004"/>
         <source>Go to the last step of the model</source>
         <translation>Gehe zum letzten Schritt des Modells</translation>
     </message>
@@ -3546,42 +3544,43 @@ File format is not recognized.</source>
         <translation type="vanished">Einen neuen Schritt einfügen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1032"/>
-        <location filename="../common/lc_commands.cpp" line="1816"/>
+        <location filename="../common/lc_commands.cpp" line="1025"/>
+        <location filename="../common/lc_commands.cpp" line="1809"/>
         <source>Remove current step</source>
         <translation>Aktuellen Schritt entfernen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1137"/>
+        <location filename="../common/lc_commands.cpp" line="1130"/>
         <source>Close current tab</source>
         <translation>Aktuellen Tab schließen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1256"/>
+        <location filename="../common/lc_commands.cpp" line="1249"/>
         <source>Remove the selected control point</source>
         <translation>Ausgewählten Steuerungspunkt entfernen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1368"/>
+        <location filename="../common/lc_commands.cpp" line="1361"/>
         <source>Move the selected pieces to a new model and replace them with a reference to the model</source>
         <translation>Bewege die ausgewählten Teile in ein neues Modell und ersetze diese durch eine Referenz auf das Modell</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1473"/>
+        <location filename="../common/lc_commands.cpp" line="1466"/>
         <source>Create a new submodel</source>
         <translation>Erzeuge ein neues Untermodell</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1480"/>
+        <location filename="../common/lc_commands.cpp" line="1473"/>
         <source>Display the properties of the current submodel</source>
         <translation>Eigenschaften des aktuellen Untermodells anzeigen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1487"/>
+        <location filename="../common/lc_commands.cpp" line="1480"/>
         <source>Show a list of all submodels</source>
         <translation>Liste aller Untermodell anzeigen</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1487"/>
         <location filename="../common/lc_commands.cpp" line="1494"/>
         <location filename="../common/lc_commands.cpp" line="1501"/>
         <location filename="../common/lc_commands.cpp" line="1508"/>
@@ -3621,27 +3620,26 @@ File format is not recognized.</source>
         <location filename="../common/lc_commands.cpp" line="1746"/>
         <location filename="../common/lc_commands.cpp" line="1753"/>
         <location filename="../common/lc_commands.cpp" line="1760"/>
-        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Switch to this submodel</source>
         <translation>Wechsel zu diesem Untermodell</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1781"/>
+        <location filename="../common/lc_commands.cpp" line="1774"/>
         <source>Open LeoCAD&apos;s bug report form on your default web browser</source>
         <translation>LeoCADs Fehlerreportformular im voreingestellten Browser zeigen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1823"/>
+        <location filename="../common/lc_commands.cpp" line="1816"/>
         <source>Move the selected parts into this step</source>
         <translation>Bewege die ausgewählten Teile in diesen Schritt</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1830"/>
+        <location filename="../common/lc_commands.cpp" line="1823"/>
         <source>View the model at this point in the timeline</source>
         <translation>Zeige das Modell an diesem Punkt der Zeitachse</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1039"/>
+        <location filename="../common/lc_commands.cpp" line="1032"/>
         <source>Toggle adding new animation keys</source>
         <translation>Hinzufügen neuer Animationsschlüssel umschalten</translation>
     </message>
@@ -3696,295 +3694,295 @@ File format is not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1018"/>
-        <location filename="../common/lc_commands.cpp" line="1802"/>
+        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1795"/>
         <source>Insert a new step before the current step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1025"/>
-        <location filename="../common/lc_commands.cpp" line="1809"/>
+        <location filename="../common/lc_commands.cpp" line="1018"/>
+        <location filename="../common/lc_commands.cpp" line="1802"/>
         <source>Insert a new step after the current step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1046"/>
+        <location filename="../common/lc_commands.cpp" line="1039"/>
         <source>Split the current view horizontally</source>
         <translation>Ansicht horizontal teilen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1053"/>
+        <location filename="../common/lc_commands.cpp" line="1046"/>
         <source>Split the current view vertically</source>
         <translation>Ansicht vertikal teilen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1060"/>
+        <location filename="../common/lc_commands.cpp" line="1053"/>
         <source>Remove the current view</source>
         <translation>Aktuelle Ansicht entfernen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1067"/>
+        <location filename="../common/lc_commands.cpp" line="1060"/>
         <source>Reset all views</source>
         <translation>Alle Ansichten zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1074"/>
+        <location filename="../common/lc_commands.cpp" line="1067"/>
         <source>Toggle the Standard Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1081"/>
+        <location filename="../common/lc_commands.cpp" line="1074"/>
         <source>Toggle the Tools Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1088"/>
+        <location filename="../common/lc_commands.cpp" line="1081"/>
         <source>Toggle the Time Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1095"/>
+        <location filename="../common/lc_commands.cpp" line="1088"/>
         <source>Toggle the Parts Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1102"/>
+        <location filename="../common/lc_commands.cpp" line="1095"/>
         <source>Toggle the Colors Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1109"/>
+        <location filename="../common/lc_commands.cpp" line="1102"/>
         <source>Toggle the Properties Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1116"/>
+        <location filename="../common/lc_commands.cpp" line="1109"/>
         <source>Toggle the Timeline Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1123"/>
+        <location filename="../common/lc_commands.cpp" line="1116"/>
         <source>Toggle the Preview Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1130"/>
+        <location filename="../common/lc_commands.cpp" line="1123"/>
         <source>Toggle fullscreen mode</source>
         <translation>Vollbildmodus umschalten</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1144"/>
+        <location filename="../common/lc_commands.cpp" line="1137"/>
         <source>Display the scene as wireframe</source>
         <translation>Anzeige der Szene als Drahtgittermodell</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1151"/>
+        <location filename="../common/lc_commands.cpp" line="1144"/>
         <source>Display the scene without any shading or lights</source>
         <translation>Anzeige der Szene ohne Schatten und Beleuchtung</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1158"/>
+        <location filename="../common/lc_commands.cpp" line="1151"/>
         <source>Display the scene with the default lights</source>
         <translation>Anzeige der Szene mit voreingestellter Beleuchtung</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1165"/>
+        <location filename="../common/lc_commands.cpp" line="1158"/>
         <source>Set the current camera to use a perspective projection</source>
         <translation>Aktuelle Kamera auf perspektivische Projektion umstellen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1172"/>
+        <location filename="../common/lc_commands.cpp" line="1165"/>
         <source>Set the current camera to use an orthographic projection</source>
         <translation>Aktuelle Kamera auf orthografische Projektion umstellen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1179"/>
+        <location filename="../common/lc_commands.cpp" line="1172"/>
         <source>Toggle the view sphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1186"/>
+        <location filename="../common/lc_commands.cpp" line="1179"/>
         <source>Toggle axis icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1193"/>
+        <location filename="../common/lc_commands.cpp" line="1186"/>
         <source>Toggle grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1200"/>
+        <location filename="../common/lc_commands.cpp" line="1193"/>
         <source>Toggle fading previous model steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1207"/>
+        <location filename="../common/lc_commands.cpp" line="1200"/>
         <source>Add a new piece to the model</source>
         <translation>Ein neues Teil zum Modell hinzufügen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1214"/>
+        <location filename="../common/lc_commands.cpp" line="1207"/>
         <source>Delete selected objects</source>
         <translation>Ausgewählte Objekte entfernen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1221"/>
+        <location filename="../common/lc_commands.cpp" line="1214"/>
         <source>Create a copy of the selected pieces</source>
         <translation>Erzeuge eine Kopie der ausgewählten Teile</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1228"/>
+        <location filename="../common/lc_commands.cpp" line="1221"/>
         <source>Change the color of the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1235"/>
+        <location filename="../common/lc_commands.cpp" line="1228"/>
         <source>Reset the pivot point of the selected pieces to their origin</source>
         <translation>Drehpunkt der ausgewählten Teile auf deren Ursprung zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1242"/>
+        <location filename="../common/lc_commands.cpp" line="1235"/>
         <source>Remove all key frames from the selected pieces</source>
         <translation>Entferne alle Keyframes aus den ausgewählten Teilen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1249"/>
+        <location filename="../common/lc_commands.cpp" line="1242"/>
         <source>Insert a new control point</source>
         <translation>Einen neuen Steuerungspunkt einfügen</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1256"/>
         <location filename="../common/lc_commands.cpp" line="1263"/>
-        <location filename="../common/lc_commands.cpp" line="1270"/>
         <source>Move selected objects along the X axis</source>
         <translation>Ausgewählte Teile entlang der X-Achse bewegen</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1270"/>
         <location filename="../common/lc_commands.cpp" line="1277"/>
-        <location filename="../common/lc_commands.cpp" line="1284"/>
         <source>Move selected objects along the Y axis</source>
         <translation>Ausgewählte Teile entlang der Y-Achse bewegen</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1284"/>
         <location filename="../common/lc_commands.cpp" line="1291"/>
-        <location filename="../common/lc_commands.cpp" line="1298"/>
         <source>Move selected objects along the Z axis</source>
         <translation>Ausgewählte Teile entlang der Z-Achse bewegen</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1298"/>
         <location filename="../common/lc_commands.cpp" line="1305"/>
-        <location filename="../common/lc_commands.cpp" line="1312"/>
         <source>Rotate selected objects along the X axis</source>
         <translation>Ausgewählte Teile entlang der X-Achse drehen</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1312"/>
         <location filename="../common/lc_commands.cpp" line="1319"/>
-        <location filename="../common/lc_commands.cpp" line="1326"/>
         <source>Rotate selected objects along the Y axis</source>
         <translation>Ausgewählte Teile entlang der Y-Achse drehen</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1326"/>
         <location filename="../common/lc_commands.cpp" line="1333"/>
-        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Rotate selected objects along the Z axis</source>
         <translation>Ausgewählte Teile entlang der Z-Achse drehen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1347"/>
+        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Add a new minifig to the model</source>
         <translation>Ein neues minifig zum Modell hinzufügen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1354"/>
+        <location filename="../common/lc_commands.cpp" line="1347"/>
         <source>Make copies of the selected pieces</source>
         <translation>Erstelle Kopien der ausgewählten Teile</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1361"/>
+        <location filename="../common/lc_commands.cpp" line="1354"/>
         <source>Open the model referenced by the selected piece in a new tab</source>
         <translation>Öffne das vom ausgewählten Teil referenzierte Modell in einem neuen Tab</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1375"/>
+        <location filename="../common/lc_commands.cpp" line="1368"/>
         <source>Insert the contents of the selected model references into the current model</source>
         <translation>Inhalte der ausgewählten Modellreferenzen in ein neues Modell einfügen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1382"/>
+        <location filename="../common/lc_commands.cpp" line="1375"/>
         <source>Edit the currently selected submodel in-place</source>
         <translation>Bearbeite das ausgewählte Untermodell an Ort und Stelle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1389"/>
+        <location filename="../common/lc_commands.cpp" line="1382"/>
         <source>End in-place submodel editing</source>
         <translation>Beende Untermodellbearbeitung an Ort und Stelle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1396"/>
+        <location filename="../common/lc_commands.cpp" line="1389"/>
         <source>Group selected pieces together</source>
         <translation>Ausgewählte Teile gruppieren</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1403"/>
+        <location filename="../common/lc_commands.cpp" line="1396"/>
         <source>Ungroup selected group</source>
         <translation>Ausgewählte Gruppe auflösen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1410"/>
+        <location filename="../common/lc_commands.cpp" line="1403"/>
         <source>Add focused piece to selected group</source>
         <translation>Füge Teil mit Fokus zur ausgewählten Gruppe hinzu</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1417"/>
+        <location filename="../common/lc_commands.cpp" line="1410"/>
         <source>Remove focused piece from group</source>
         <translation>Entferne Teil mit Fokus aus der Gruppe</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1424"/>
+        <location filename="../common/lc_commands.cpp" line="1417"/>
         <source>Edit groups</source>
         <translation>Gruppe bearbeiten</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1431"/>
+        <location filename="../common/lc_commands.cpp" line="1424"/>
         <source>Hide selected objects</source>
         <translation>Ausgewählte Teile ausblenden</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1438"/>
+        <location filename="../common/lc_commands.cpp" line="1431"/>
         <source>Hide objects that are not selected</source>
         <translation>Nicht ausgewählte Teile ausblenden</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1445"/>
+        <location filename="../common/lc_commands.cpp" line="1438"/>
         <source>Show hidden objects that are selected</source>
         <translation>Zeige ausgeblendete Objekte die ausgewählt sind</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1452"/>
+        <location filename="../common/lc_commands.cpp" line="1445"/>
         <source>Show all hidden objects</source>
         <translation>Zeige alle ausgeblendeten Objekte</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1459"/>
+        <location filename="../common/lc_commands.cpp" line="1452"/>
         <source>Show selected pieces one step earlier</source>
         <translation>Zeige ausgewählte Teile einen Schritt vorher</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1466"/>
+        <location filename="../common/lc_commands.cpp" line="1459"/>
         <source>Show selected pieces one step later</source>
         <translation>Zeige ausgewählte Teile einen Schritt danach</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1774"/>
+        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Open LeoCAD&apos;s home page on the internet using your default web browser</source>
         <translation>LeoCAD&apos;s Homepage im Standardbrowsers öffnen</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1788"/>
+        <location filename="../common/lc_commands.cpp" line="1781"/>
         <source>Check if a newer LeoCAD version or parts library has been released</source>
         <translation>Prüfe ob eine aktualisierte Version von LeoCAD oder der Teilebibliothek verfügbar ist</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1795"/>
+        <location filename="../common/lc_commands.cpp" line="1788"/>
         <source>Display program version number and system information</source>
         <translation>Zeige die Programmversion und Systemversion</translation>
     </message>
@@ -4025,13 +4023,13 @@ File format is not recognized.</source>
 <context>
     <name>lcApplication</name>
     <message>
-        <location filename="../common/lc_application.cpp" line="934"/>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="954"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="929"/>
+        <location filename="../common/lc_application.cpp" line="949"/>
         <source>LeoCAD could not find a compatible Parts Library so only a small number of parts will be available.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
@@ -4040,397 +4038,397 @@ Please visit https://www.leocad.org for information on how to download and insta
 Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunterläd und installiert.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="401"/>
-        <location filename="../common/lc_application.cpp" line="426"/>
-        <location filename="../common/lc_application.cpp" line="449"/>
-        <location filename="../common/lc_application.cpp" line="472"/>
-        <location filename="../common/lc_application.cpp" line="482"/>
-        <location filename="../common/lc_application.cpp" line="505"/>
-        <location filename="../common/lc_application.cpp" line="530"/>
+        <location filename="../common/lc_application.cpp" line="421"/>
+        <location filename="../common/lc_application.cpp" line="446"/>
+        <location filename="../common/lc_application.cpp" line="469"/>
+        <location filename="../common/lc_application.cpp" line="492"/>
+        <location filename="../common/lc_application.cpp" line="502"/>
+        <location filename="../common/lc_application.cpp" line="525"/>
+        <location filename="../common/lc_application.cpp" line="550"/>
         <source>Not enough parameters for the &apos;%1&apos; option.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="423"/>
-        <location filename="../common/lc_application.cpp" line="446"/>
-        <location filename="../common/lc_application.cpp" line="469"/>
-        <location filename="../common/lc_application.cpp" line="502"/>
-        <location filename="../common/lc_application.cpp" line="527"/>
-        <location filename="../common/lc_application.cpp" line="580"/>
-        <location filename="../common/lc_application.cpp" line="734"/>
-        <location filename="../common/lc_application.cpp" line="745"/>
+        <location filename="../common/lc_application.cpp" line="443"/>
+        <location filename="../common/lc_application.cpp" line="466"/>
+        <location filename="../common/lc_application.cpp" line="489"/>
+        <location filename="../common/lc_application.cpp" line="522"/>
+        <location filename="../common/lc_application.cpp" line="547"/>
+        <location filename="../common/lc_application.cpp" line="600"/>
+        <location filename="../common/lc_application.cpp" line="754"/>
+        <location filename="../common/lc_application.cpp" line="765"/>
         <source>Invalid parameter value specified for the &apos;%1&apos; option: &apos;%2&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="541"/>
+        <location filename="../common/lc_application.cpp" line="561"/>
         <source>The file &apos;%1&apos; is not readable.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="589"/>
+        <location filename="../common/lc_application.cpp" line="609"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: limits are +/- 360.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="601"/>
+        <location filename="../common/lc_application.cpp" line="621"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="620"/>
+        <location filename="../common/lc_application.cpp" line="640"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: requirements are: 1 &lt;= &lt;near&gt; &lt; &lt;far&gt;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="630"/>
-        <location filename="../common/lc_application.cpp" line="641"/>
-        <location filename="../common/lc_application.cpp" line="652"/>
-        <location filename="../common/lc_application.cpp" line="663"/>
+        <location filename="../common/lc_application.cpp" line="650"/>
+        <location filename="../common/lc_application.cpp" line="661"/>
+        <location filename="../common/lc_application.cpp" line="672"/>
+        <location filename="../common/lc_application.cpp" line="683"/>
         <source>High contrast stud style is required for the &apos;%1&apos; option but is not enabled.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="678"/>
-        <location filename="../common/lc_application.cpp" line="689"/>
+        <location filename="../common/lc_application.cpp" line="698"/>
+        <location filename="../common/lc_application.cpp" line="709"/>
         <source>Automate edge color is required for the &apos;%1&apos; option but is not enabled.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="779"/>
+        <location filename="../common/lc_application.cpp" line="799"/>
         <source>LeoCAD Continuous Build %1
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="781"/>
+        <location filename="../common/lc_application.cpp" line="801"/>
         <source>LeoCAD Version %1
 </source>
         <translation type="unfinished">LeoCAD Version %1
 </translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="783"/>
+        <location filename="../common/lc_application.cpp" line="803"/>
         <source>Compiled %1
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="788"/>
+        <location filename="../common/lc_application.cpp" line="808"/>
         <source>Usage: leocad [options] [file]
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="789"/>
+        <location filename="../common/lc_application.cpp" line="809"/>
         <source>  [options] can be:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="790"/>
+        <location filename="../common/lc_application.cpp" line="810"/>
         <source>  -l, --libpath &lt;path&gt;: Set the Parts Library location to path.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="791"/>
+        <location filename="../common/lc_application.cpp" line="811"/>
         <source>  -i, --image &lt;outfile.ext&gt;: Save a picture in the format specified by ext and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="792"/>
+        <location filename="../common/lc_application.cpp" line="812"/>
         <source>  -w, --width &lt;width&gt;: Set the picture width.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="793"/>
+        <location filename="../common/lc_application.cpp" line="813"/>
         <source>  -h, --height &lt;height&gt;: Set the picture height.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="794"/>
+        <location filename="../common/lc_application.cpp" line="814"/>
         <source>  -f, --from &lt;step&gt;: Set the first step to save pictures.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="795"/>
+        <location filename="../common/lc_application.cpp" line="815"/>
         <source>  -t, --to &lt;step&gt;: Set the last step to save pictures.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="796"/>
+        <location filename="../common/lc_application.cpp" line="816"/>
         <source>  -s, --submodel &lt;submodel&gt;: Set the active submodel.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="797"/>
+        <location filename="../common/lc_application.cpp" line="817"/>
         <source>  -c, --camera &lt;camera&gt;: Set the active camera.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="798"/>
+        <location filename="../common/lc_application.cpp" line="818"/>
         <source>  -ss, --stud-style &lt;id&gt;: Set the stud style 0=No style, 1=LDraw single wire, 2=LDraw double wire, 3=LDraw raised floating, 4=LDraw raised rounded, 5=LDraw subtle rounded, 6=LEGO no logo, 7=LEGO single wire.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="799"/>
+        <location filename="../common/lc_application.cpp" line="819"/>
         <source>  --viewpoint &lt;front|back|left|right|top|bottom|home&gt;: Set the viewpoint.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="800"/>
+        <location filename="../common/lc_application.cpp" line="820"/>
         <source>  --camera-angles &lt;latitude&gt; &lt;longitude&gt;: Set the camera angles in degrees around the model.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="801"/>
+        <location filename="../common/lc_application.cpp" line="821"/>
         <source>  --camera-position &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="802"/>
+        <location filename="../common/lc_application.cpp" line="822"/>
         <source>  --camera-position-ldraw &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector using LDraw coordinates.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="803"/>
+        <location filename="../common/lc_application.cpp" line="823"/>
         <source>  --orthographic: Render images using an orthographic projection.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="804"/>
+        <location filename="../common/lc_application.cpp" line="824"/>
         <source>  --fov &lt;degrees&gt;: Set the vertical field of view used to render images (&lt; 180).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="805"/>
+        <location filename="../common/lc_application.cpp" line="825"/>
         <source>  --zplanes &lt;near&gt; &lt;far&gt;: Set the near and far clipping planes used to render images (1 &lt;= &lt;near&gt; &lt; &lt;far&gt;).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="806"/>
+        <location filename="../common/lc_application.cpp" line="826"/>
         <source>  --fade-steps: Render parts from prior steps faded.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="807"/>
+        <location filename="../common/lc_application.cpp" line="827"/>
         <source>  --no-fade-steps: Do not render parts from prior steps faded.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="808"/>
+        <location filename="../common/lc_application.cpp" line="828"/>
         <source>  --fade-steps-color &lt;rgba&gt;: Renderinng color for prior step parts (#AARRGGBB).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="809"/>
+        <location filename="../common/lc_application.cpp" line="829"/>
         <source>  --highlight: Highlight parts in the steps they appear.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="810"/>
+        <location filename="../common/lc_application.cpp" line="830"/>
         <source>  --no-highlight: Do not highlight parts in the steps they appear.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="811"/>
+        <location filename="../common/lc_application.cpp" line="831"/>
         <source>  --highlight-color: Renderinng color for highlighted parts (#AARRGGBB).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="812"/>
+        <location filename="../common/lc_application.cpp" line="832"/>
         <source>  --shading &lt;wireframe|flat|default|full&gt;: Select shading mode for rendering.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="813"/>
-        <source>  --line-width &lt;width&gt;: Set the with of the edge lines.
+        <location filename="../common/lc_application.cpp" line="833"/>
+        <source>  --line-width &lt;width&gt;: Set the width of the edge lines.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="814"/>
+        <location filename="../common/lc_application.cpp" line="834"/>
         <source>  --aa-samples &lt;count&gt;: AntiAliasing sample size (1, 2, 4, or 8).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="815"/>
+        <location filename="../common/lc_application.cpp" line="835"/>
         <source>  -scc, --stud-cylinder-color &lt;#AARRGGBB&gt;: High contrast stud cylinder color.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="816"/>
+        <location filename="../common/lc_application.cpp" line="836"/>
         <source>  -ec, --edge-color &lt;#AARRGGBB&gt;: High contrast edge color.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="817"/>
+        <location filename="../common/lc_application.cpp" line="837"/>
         <source>  -bec, --black-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for black parts.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="818"/>
+        <location filename="../common/lc_application.cpp" line="838"/>
         <source>  -dec, --dark-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for dark color parts.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="819"/>
+        <location filename="../common/lc_application.cpp" line="839"/>
         <source>  -aec, --automate-edge-color: Enable automatically adjusted edge colors.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="820"/>
+        <location filename="../common/lc_application.cpp" line="840"/>
         <source>  -cc, --color-contrast &lt;float&gt;: Color contrast value between 0.0 and 1.0.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="821"/>
+        <location filename="../common/lc_application.cpp" line="841"/>
         <source>  -ldv, --light-dark-value &lt;float&gt;: Light/Dark color value between 0.0 and 1.0.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="822"/>
+        <location filename="../common/lc_application.cpp" line="842"/>
         <source>  -obj, --export-wavefront &lt;outfile.obj&gt;: Export the model to Wavefront OBJ format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="823"/>
+        <location filename="../common/lc_application.cpp" line="843"/>
         <source>  -3ds, --export-3ds &lt;outfile.3ds&gt;: Export the model to 3D Studio 3DS format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="824"/>
+        <location filename="../common/lc_application.cpp" line="844"/>
         <source>  -dae, --export-collada &lt;outfile.dae&gt;: Export the model to COLLADA DAE format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="825"/>
+        <location filename="../common/lc_application.cpp" line="845"/>
         <source>  -html, --export-html &lt;folder&gt;: Create an HTML page for the model.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="826"/>
+        <location filename="../common/lc_application.cpp" line="846"/>
         <source>  -v, --version: Output version information and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="827"/>
+        <location filename="../common/lc_application.cpp" line="847"/>
         <source>  -?, --help: Display this help message and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="833"/>
+        <location filename="../common/lc_application.cpp" line="853"/>
         <source>Unknown option: &apos;%1&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="840"/>
+        <location filename="../common/lc_application.cpp" line="860"/>
         <source>High contrast stud and edge color settings are ignored when -aec or --automate-edge-color is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="846"/>
+        <location filename="../common/lc_application.cpp" line="866"/>
         <source>--viewpoint is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="849"/>
+        <location filename="../common/lc_application.cpp" line="869"/>
         <source>--orthographic is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="852"/>
+        <location filename="../common/lc_application.cpp" line="872"/>
         <source>--camera-angles is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="855"/>
+        <location filename="../common/lc_application.cpp" line="875"/>
         <source>--camera-position is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="860"/>
+        <location filename="../common/lc_application.cpp" line="880"/>
         <source>--camera-angles is ignored when --viewpoint is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="863"/>
+        <location filename="../common/lc_application.cpp" line="883"/>
         <source>--camera-position is ignored when --viewpoint is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="868"/>
+        <location filename="../common/lc_application.cpp" line="888"/>
         <source>--camera-position is ignored when --camera-angles is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="875"/>
+        <location filename="../common/lc_application.cpp" line="895"/>
         <source>No file name specified.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="908"/>
+        <location filename="../common/lc_application.cpp" line="928"/>
         <source>Error creating OpenGL context.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="931"/>
+        <location filename="../common/lc_application.cpp" line="951"/>
         <source>LeoCAD could not load Parts Library.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
@@ -4439,22 +4437,22 @@ Please visit https://www.leocad.org for information on how to download and insta
 Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunterläd und installiert.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1002"/>
+        <location filename="../common/lc_application.cpp" line="1022"/>
         <source>Error: model &apos;%1&apos; does not exist.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1093"/>
-        <location filename="../common/lc_application.cpp" line="1121"/>
-        <location filename="../common/lc_application.cpp" line="1146"/>
-        <location filename="../common/lc_application.cpp" line="1171"/>
+        <location filename="../common/lc_application.cpp" line="1113"/>
+        <location filename="../common/lc_application.cpp" line="1141"/>
+        <location filename="../common/lc_application.cpp" line="1166"/>
+        <location filename="../common/lc_application.cpp" line="1191"/>
         <source>Saved &apos;%1&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>Some changes will only take effect the next time you start LeoCAD.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4504,6 +4502,26 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
         <translation type="unfinished">Zurücksetzen</translation>
     </message>
     <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Light/Dark Value:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Saturation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="54"/>
+        <source>Set to classify where color values are light or dark - e.g. Dark Bluish Gray (72) is light at 0.39.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="55"/>
+        <source>Set to specify amount of edge color tint or shade from the saturation adjusted part color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="68"/>
         <source>High Contrast</source>
         <translation type="unfinished"></translation>
@@ -4539,8 +4557,18 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="179"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Black parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="183"/>
         <source>Select Black Edge Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="191"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Dark parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4601,109 +4629,134 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
 <context>
     <name>lcInstructionsDialog</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="527"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="532"/>
         <source>Instructions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="542"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="547"/>
         <source>Page Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="552"/>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="554"/>
+        <source>Vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="557"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="571"/>
+        <source>Page %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPageListWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="174"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="179"/>
         <source>Pages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="189"/>
+        <source>Page Setup</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPropertiesWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="288"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="293"/>
         <source>Properties</source>
         <translation type="unfinished">Eigenschaften</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Forward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="296"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="301"/>
         <source>Scope:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="301"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="306"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="351"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="356"/>
         <source>Select Step Number Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="355"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="360"/>
         <source>Select Step Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="359"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="364"/>
         <source>Select Parts List Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="363"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="368"/>
         <source>Select Parts List Border Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="367"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="372"/>
         <source>Select Parts List Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="417"/>
-        <location filename="../common/lc_instructionsdialog.cpp" line="438"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="422"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="443"/>
         <source>Select Step Number Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="421"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="426"/>
         <source>Select Parts List Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="477"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="482"/>
         <source>Step Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="493"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="498"/>
         <source>Step Number Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="508"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="513"/>
         <source>Parts List Properties</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4711,108 +4764,103 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
 <context>
     <name>lcMainWindow</name>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="403"/>
-        <location filename="../common/lc_mainwindow.cpp" line="606"/>
-        <location filename="../common/lc_mainwindow.cpp" line="613"/>
+        <location filename="../common/lc_mainwindow.cpp" line="376"/>
+        <location filename="../common/lc_mainwindow.cpp" line="577"/>
+        <location filename="../common/lc_mainwindow.cpp" line="584"/>
         <source>Transform</source>
         <translation>Transformation</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="410"/>
+        <location filename="../common/lc_mainwindow.cpp" line="383"/>
         <source>C&amp;ameras</source>
         <translation>K&amp;ameras</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="456"/>
+        <location filename="../common/lc_mainwindow.cpp" line="426"/>
         <source>&amp;File</source>
         <translation>&amp;Datei</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="467"/>
+        <location filename="../common/lc_mainwindow.cpp" line="437"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportieren</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="488"/>
+        <location filename="../common/lc_mainwindow.cpp" line="458"/>
         <source>&amp;Edit</source>
         <translation>&amp;Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="512"/>
+        <location filename="../common/lc_mainwindow.cpp" line="482"/>
         <source>&amp;View</source>
         <translation>&amp;Ansicht</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="419"/>
+        <location filename="../common/lc_mainwindow.cpp" line="389"/>
         <source>&amp;Viewpoints</source>
         <translation>&amp;Ansichten</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="172"/>
+        <location filename="../common/lc_mainwindow.cpp" line="145"/>
         <source>New Model</source>
         <translation>Neues Modell</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="173"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
+        <location filename="../common/lc_mainwindow.cpp" line="146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
         <source>Open Model</source>
         <translation>Modell öffnen</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="174"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2507"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2434"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save Model</source>
         <translation>Modell speichern</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="398"/>
         <source>Projection</source>
         <translation>Projektion</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="432"/>
+        <location filename="../common/lc_mainwindow.cpp" line="402"/>
         <source>Sh&amp;ading</source>
         <translation>Sch&amp;atten</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="464"/>
+        <location filename="../common/lc_mainwindow.cpp" line="434"/>
         <source>&amp;Import</source>
         <translation>&amp;Import</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="521"/>
+        <location filename="../common/lc_mainwindow.cpp" line="491"/>
         <source>Ste&amp;p</source>
         <translation>Schrit&amp;te</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="506"/>
         <source>T&amp;oolbars</source>
         <translation>Werkz&amp;euge</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="549"/>
+        <location filename="../common/lc_mainwindow.cpp" line="519"/>
         <source>&amp;Piece</source>
         <translation>&amp;Teil</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="614"/>
+        <location filename="../common/lc_mainwindow.cpp" line="585"/>
         <source>Transform Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
-        <source>Part preview for &apos;%1&apos; failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_mainwindow.cpp" line="814"/>
-        <location filename="../common/lc_mainwindow.cpp" line="815"/>
+        <location filename="../common/lc_mainwindow.cpp" line="784"/>
+        <location filename="../common/lc_mainwindow.cpp" line="785"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../common/lc_mainwindow.cpp" line="2064"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1991"/>
         <source>%n Object(s) selected</source>
         <translation>
             <numerusform></numerusform>
@@ -4820,154 +4868,154 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
         </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Rel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Abs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2074"/>
         <source> M: %1 %2 R: %3 %4 </source>
         <translation type="unfinished"> M : %1 %2 R : %3  {1 %2 ?} {3 %4 ?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Merge Model</source>
         <translation>Modell zusammenführen</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
         <source>Merged 1 submodel.</source>
         <translation>Ein Untermodell zusammenführen.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>Merged %1 submodels.</source>
         <translation>%1 Untermodelle zusammengefügt.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>LEGO Diginal Designer Files (*.lxf);;All Files (*.*)</source>
         <translation>LEGO Diginal Designer Dateien (*.lxf);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="583"/>
+        <location filename="../common/lc_mainwindow.cpp" line="554"/>
         <source>&amp;Help</source>
         <translation>&amp;Hilfe</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="618"/>
+        <location filename="../common/lc_mainwindow.cpp" line="589"/>
         <source>Snap XY</source>
         <translation>Einrasten XY</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="622"/>
+        <location filename="../common/lc_mainwindow.cpp" line="593"/>
         <source>Snap Z</source>
         <translation>Einrasten Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="626"/>
+        <location filename="../common/lc_mainwindow.cpp" line="597"/>
         <source>Snap Menu</source>
         <translation>Schritte Menü</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="632"/>
+        <location filename="../common/lc_mainwindow.cpp" line="603"/>
         <source>Movement Snap</source>
         <translation>Einrasten für Bewegung</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="633"/>
+        <location filename="../common/lc_mainwindow.cpp" line="604"/>
         <source>Snap translations to fixed intervals</source>
         <translation>Einrasten der Bewegung in festen Intervallen</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="637"/>
+        <location filename="../common/lc_mainwindow.cpp" line="608"/>
         <source>Snap Angle Menu</source>
         <translation>Winkelschritte Menü</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="643"/>
+        <location filename="../common/lc_mainwindow.cpp" line="614"/>
         <source>Rotation Snap</source>
         <translation>Einrasten für Drehung</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="644"/>
+        <location filename="../common/lc_mainwindow.cpp" line="615"/>
         <source>Snap rotations to fixed intervals</source>
         <translation>Einrasten der Drehung in festen Intervallen</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="648"/>
+        <location filename="../common/lc_mainwindow.cpp" line="619"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="437"/>
-        <location filename="../common/lc_mainwindow.cpp" line="674"/>
+        <location filename="../common/lc_mainwindow.cpp" line="407"/>
+        <location filename="../common/lc_mainwindow.cpp" line="645"/>
         <source>Tools</source>
         <translation>Werkzeuge</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="575"/>
+        <location filename="../common/lc_mainwindow.cpp" line="546"/>
         <source>Sub&amp;model</source>
         <translation>Unter&amp;modell</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="597"/>
-        <location filename="../common/lc_mainwindow.cpp" line="601"/>
+        <location filename="../common/lc_mainwindow.cpp" line="568"/>
+        <location filename="../common/lc_mainwindow.cpp" line="572"/>
         <source>Selection Mode</source>
         <translation>Auswahlmodus</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="666"/>
+        <location filename="../common/lc_mainwindow.cpp" line="637"/>
         <source>Time</source>
         <translation>Zeit</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="696"/>
+        <location filename="../common/lc_mainwindow.cpp" line="667"/>
         <source>Parts</source>
         <translation>Teile</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="702"/>
+        <location filename="../common/lc_mainwindow.cpp" line="673"/>
         <source>Colors</source>
         <translation>Farben</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="731"/>
+        <location filename="../common/lc_mainwindow.cpp" line="702"/>
         <source>Properties</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="766"/>
+        <location filename="../common/lc_mainwindow.cpp" line="737"/>
         <source>Timeline</source>
         <translation>Zeitachse</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2058"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1985"/>
         <source>%1 (ID: %2)</source>
         <translation>%1 (ID : %2)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2068"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1995"/>
         <source> - %1 (ID: %2)</source>
         <translation> - %1 (ID : %2)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2072"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1999"/>
         <source> in group &apos;%1&apos;</source>
         <translation> in der Gruppe » %1 «</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2110"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2037"/>
         <source>Step %1</source>
         <translation>Schritt %1</translation>
     </message>
@@ -4976,44 +5024,44 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
         <translation type="vanished"> M : %1 %2 R : %3 </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2168"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2095"/>
         <source>&amp;Undo %1</source>
         <translation>%1 rück&amp;gängig machen</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2173"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2100"/>
         <source>&amp;Undo</source>
         <translation>Rückg&amp;ängig machen</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2179"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2106"/>
         <source>&amp;Redo %1</source>
         <translation>%1 &amp;wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2184"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2111"/>
         <source>&amp;Redo</source>
         <translation>&amp;Wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Supported Files (*.lcd *.ldr *.dat *.mpd);;All Files (*.*)</source>
         <translation>Unterstützte Dateien (*.lcd *.ldr *.dat *.mpd);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="602"/>
+        <location filename="../common/lc_mainwindow.cpp" line="573"/>
         <source>Change selection mode</source>
         <translation>Auswahlmodus wechseln</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1031"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1001"/>
         <source>Close Other Tabs</source>
         <translation>Andere Tabs schliessen</translation>
     </message>
@@ -5022,12 +5070,12 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
         <translation type="vanished">Ansicht zurücksetzten</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1113"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1083"/>
         <source>The file &apos;%1&apos; has been modified by another application, do you want to reload it?</source>
         <translation>Die Datei &apos;%1&apos; wurde von einer anderen Anwwendung verändert, erneut laden?</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1119"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1089"/>
         <source>File Changed</source>
         <translation>Datei verändert</translation>
     </message>
@@ -5036,111 +5084,110 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
         <translation type="vanished">Fehler beim Laden von » %1 «.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.mpd);;All Files (*.*)</source>
         <translation>Unterstützte Dateien (*.mpd);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.ldr *.dat *.mpd);;All Files (*.*)</source>
         <translation>Unterstützte Dateien (*.ldr *.dat *.mpd);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Saving files in LCD format is no longer supported, please use the LDR or MPD formats instead.</source>
         <translation>Speichern als LCD Format wird nicht mehr unterstützt, bitte LDR oder MPD Format verwenden.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save changes to &apos;%1&apos;?</source>
         <translation>Änderungen an » %1 « speichern?</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/20S</source>
         <translation>1/20T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/4S</source>
         <translation>1/4T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1F</source>
         <translation>1P</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/2S</source>
         <translation>1/2T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1S</source>
         <translation>1T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>2S</source>
         <translation>2T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>3S</source>
         <translation>3T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>4S</source>
         <translation>4T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>8S</source>
         <translation>8T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="152"/>
-        <location filename="../common/lc_mainwindow.h" line="158"/>
-        <location filename="../common/lc_mainwindow.h" line="163"/>
+        <location filename="../common/lc_mainwindow.h" line="131"/>
+        <location filename="../common/lc_mainwindow.h" line="137"/>
+        <location filename="../common/lc_mainwindow.h" line="142"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1B</source>
         <translation>1B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>2B</source>
         <translation>2B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>4B</source>
         <translation>4B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>8B</source>
         <translation>8B</translation>
     </message>
@@ -5252,119 +5299,119 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
 <context>
     <name>lcModel</name>
     <message>
-        <location filename="../common/lc_model.cpp" line="1146"/>
+        <location filename="../common/lc_model.cpp" line="1143"/>
         <source>Pasting</source>
         <translation>Pasting</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="2531"/>
-        <location filename="../common/lc_model.cpp" line="4307"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
         <source>Error creating images.</source>
         <translation>Fehler beim Bilder Erstellen.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1765"/>
+        <location filename="../common/lc_model.cpp" line="1768"/>
         <source>Inserting Step</source>
         <translation>Schritt einfügen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1784"/>
+        <location filename="../common/lc_model.cpp" line="1787"/>
         <source>Removing Step</source>
         <translation>Schritt löschen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
         <source>No pieces selected.</source>
         <translation>Kein Teil ausgewählt.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="957"/>
-        <location filename="../common/lc_model.cpp" line="1831"/>
+        <location filename="../common/lc_model.cpp" line="954"/>
+        <location filename="../common/lc_model.cpp" line="1834"/>
         <source>Group #</source>
         <translation>Gruppe #</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1100"/>
+        <location filename="../common/lc_model.cpp" line="1097"/>
         <source>Cutting</source>
         <translation>Schneiden</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1219"/>
+        <location filename="../common/lc_model.cpp" line="1216"/>
         <source>Duplicating Pieces</source>
         <translation>Teile duplizieren</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation>Fehler beim Schreiben der Datei » %1 « :
 %2</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1850"/>
-        <location filename="../common/lc_model.cpp" line="1916"/>
+        <location filename="../common/lc_model.cpp" line="1853"/>
+        <location filename="../common/lc_model.cpp" line="1919"/>
         <source>Grouping</source>
         <translation>Gruppieren</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1886"/>
-        <location filename="../common/lc_model.cpp" line="1931"/>
+        <location filename="../common/lc_model.cpp" line="1889"/>
+        <location filename="../common/lc_model.cpp" line="1934"/>
         <source>Ungrouping</source>
         <translation>Gruppierung aufheben</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1977"/>
+        <location filename="../common/lc_model.cpp" line="1980"/>
         <source>Editing Groups</source>
         <translation>Gruppen bearbeiten</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2176"/>
+        <location filename="../common/lc_model.cpp" line="2179"/>
         <source>Adding Piece</source>
         <translation>Teil hinzufügen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2218"/>
+        <location filename="../common/lc_model.cpp" line="2221"/>
         <source>Resetting Cameras</source>
         <translation>Kameras zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2258"/>
+        <location filename="../common/lc_model.cpp" line="2261"/>
         <source>Removing Key Frames</source>
         <translation>Keyframes entfernen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2275"/>
-        <location filename="../common/lc_model.cpp" line="2292"/>
-        <location filename="../common/lc_model.cpp" line="2334"/>
-        <location filename="../common/lc_model.cpp" line="2379"/>
-        <location filename="../common/lc_model.cpp" line="2414"/>
+        <location filename="../common/lc_model.cpp" line="2278"/>
+        <location filename="../common/lc_model.cpp" line="2295"/>
+        <location filename="../common/lc_model.cpp" line="2337"/>
+        <location filename="../common/lc_model.cpp" line="2382"/>
+        <location filename="../common/lc_model.cpp" line="2417"/>
         <source>Modifying</source>
         <translation>Verändernd</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2482"/>
+        <location filename="../common/lc_model.cpp" line="2485"/>
         <source>New Model</source>
         <translation>Neues Modell</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2535"/>
+        <location filename="../common/lc_model.cpp" line="2538"/>
         <source>Inlining</source>
         <translation>In eine Reihe</translation>
     </message>
@@ -5389,89 +5436,89 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
         <translation>Teil setzen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3723"/>
-        <location filename="../common/lc_model.cpp" line="3746"/>
+        <location filename="../common/lc_model.cpp" line="3741"/>
+        <location filename="../common/lc_model.cpp" line="3764"/>
         <source>Hide</source>
         <translation>Ausblenden</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3769"/>
-        <location filename="../common/lc_model.cpp" line="3792"/>
+        <location filename="../common/lc_model.cpp" line="3787"/>
+        <location filename="../common/lc_model.cpp" line="3810"/>
         <source>Unhide</source>
         <translation>Einblenden</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3834"/>
+        <location filename="../common/lc_model.cpp" line="3852"/>
         <source>Replacing Part</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3939"/>
+        <location filename="../common/lc_model.cpp" line="3957"/>
         <source>New SpotLight</source>
         <translation>Neues Scheinwerferlicht</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3944"/>
+        <location filename="../common/lc_model.cpp" line="3962"/>
         <source>New Camera</source>
         <translation>Neue Kamera</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3951"/>
+        <location filename="../common/lc_model.cpp" line="3969"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3955"/>
+        <location filename="../common/lc_model.cpp" line="3973"/>
         <source>Rotate</source>
         <translation>Drehen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3965"/>
-        <location filename="../common/lc_model.cpp" line="4206"/>
-        <location filename="../common/lc_model.cpp" line="4266"/>
-        <location filename="../common/lc_model.cpp" line="4278"/>
+        <location filename="../common/lc_model.cpp" line="3983"/>
+        <location filename="../common/lc_model.cpp" line="4224"/>
+        <location filename="../common/lc_model.cpp" line="4284"/>
+        <location filename="../common/lc_model.cpp" line="4296"/>
         <source>Zoom</source>
         <translation>Zoomen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3970"/>
+        <location filename="../common/lc_model.cpp" line="3988"/>
         <source>Pan</source>
         <translation>Verschieben</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3975"/>
+        <location filename="../common/lc_model.cpp" line="3993"/>
         <source>Orbit</source>
         <translation>Umkreisen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3980"/>
+        <location filename="../common/lc_model.cpp" line="3998"/>
         <source>Roll</source>
         <translation>Rollen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4002"/>
+        <location filename="../common/lc_model.cpp" line="4020"/>
         <source>Insert</source>
         <translation>Einfügen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4012"/>
+        <location filename="../common/lc_model.cpp" line="4030"/>
         <source>New Light</source>
         <translation>Neues Licht</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2229"/>
-        <location filename="../common/lc_model.cpp" line="4131"/>
+        <location filename="../common/lc_model.cpp" line="2232"/>
+        <location filename="../common/lc_model.cpp" line="4149"/>
         <source>Deleting</source>
         <translation>Löschen</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2844"/>
-        <location filename="../common/lc_model.cpp" line="4145"/>
+        <location filename="../common/lc_model.cpp" line="4163"/>
         <source>Painting</source>
         <translation>Farbgebung</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2531"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
         <source>No models selected.</source>
         <translation>Kein Modell ausgewählt.</translation>
     </message>
@@ -5503,42 +5550,42 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
         <translation>Kamera umbenennen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4229"/>
+        <location filename="../common/lc_model.cpp" line="4247"/>
         <source>Look At</source>
         <translation>Modell betrachten</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4239"/>
+        <location filename="../common/lc_model.cpp" line="4257"/>
         <source>Moving Camera</source>
         <translation>Kamera bewegen</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4300"/>
+        <location filename="../common/lc_model.cpp" line="4319"/>
         <source>Changing Properties</source>
         <translation>Eigenschaften ändern</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4307"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
         <source>Nothing to select.</source>
         <translation>Nichts auszuwählen.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>Array only has 1 element or less, no pieces added.</source>
         <translation>Das Array hat nur 1 Element oder weniger, keine Teile zugefügt.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4390"/>
+        <location filename="../common/lc_model.cpp" line="4409"/>
         <source>Array</source>
         <translation>Array</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4402"/>
+        <location filename="../common/lc_model.cpp" line="4421"/>
         <source>Minifig #</source>
         <translation>Minifig #</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4424"/>
+        <location filename="../common/lc_model.cpp" line="4443"/>
         <source>Minifig</source>
         <translation>Minifig</translation>
     </message>
@@ -5704,17 +5751,17 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
         <translation type="vanished">Vorschaufarbe sperren</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="524"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="551"/>
         <source>Add to Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="535"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="562"/>
         <source>None</source>
         <translation type="unfinished">Keine</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="539"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="566"/>
         <source>Remove from Palette</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5722,77 +5769,82 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
 <context>
     <name>lcPartSelectionWidget</name>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="719"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="746"/>
         <source>Search Parts</source>
         <translation>Teile suchen</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="726"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="753"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="884"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="902"/>
+        <source>Edit Palettes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_partselectionwidget.cpp" line="911"/>
         <source>No Icons</source>
         <translation type="unfinished">Keine Symbole</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="889"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="916"/>
         <source>Small Icons</source>
         <translation type="unfinished">Kleine Symbole</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="894"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="921"/>
         <source>Medium Icons</source>
         <translation type="unfinished">Mittelgroße Symbole</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="899"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="926"/>
         <source>Large Icons</source>
         <translation type="unfinished">Große Symbole</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="904"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="931"/>
         <source>Extra Large Icons</source>
         <translation type="unfinished">Extragroße Symbole</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="914"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="941"/>
         <source>Show Part Names</source>
         <translation type="unfinished">Zeige Teilenamen</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="919"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="946"/>
         <source>Show Decorated Parts</source>
         <translation type="unfinished">Zeige verzierte Teile</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="923"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="950"/>
         <source>Show Part Aliases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="929"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="956"/>
         <source>List Mode</source>
         <translation type="unfinished">Listenmodus</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="933"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="960"/>
         <source>Lock Preview Color</source>
         <translation type="unfinished">Vorschaufarbe sperren</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="975"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1002"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1091"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1118"/>
         <source>All Parts</source>
         <translation>Alle Teile</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1097"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1124"/>
         <source>In Use</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5801,7 +5853,7 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
         <translation type="vanished">Teile in Verwendung</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1103"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1130"/>
         <source>Submodels</source>
         <translation>Untermodelle</translation>
     </message>
@@ -5809,12 +5861,12 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
 <context>
     <name>lcPiecesLibrary</name>
     <message>
-        <location filename="../common/lc_library.cpp" line="775"/>
+        <location filename="../common/lc_library.cpp" line="782"/>
         <source>Initializing</source>
         <translation>Initialisiere</translation>
     </message>
     <message>
-        <location filename="../common/lc_library.cpp" line="776"/>
+        <location filename="../common/lc_library.cpp" line="783"/>
         <source>Loading Parts Library</source>
         <translation>Lade Teile Bibliothek</translation>
     </message>
@@ -5823,6 +5875,7 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
     <name>lcPreviewDockWidget</name>
     <message>
         <location filename="../common/lc_previewwidget.cpp" line="19"/>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
         <source>Lock Preview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5847,23 +5900,18 @@ Bitte lesen sie unter https://www.leocad.org nach wie man eine Bibliothek herunt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Unlock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Lock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../common/lc_previewwidget.cpp" line="78"/>
-        <source>%1 the preview display to %2 updates</source>
+        <source>Unlock the preview display to enable updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="80"/>
-        <source>%1 Preview</source>
+        <location filename="../common/lc_previewwidget.cpp" line="79"/>
+        <source>Lock the preview display to disable updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
+        <source>Unlock Preview</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6562,77 +6610,77 @@ Anisotropic: %5
         <translation>Öffne die zuletzt verwendete Datei beim Start</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1498"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1767"/>
         <source>Mouse</source>
         <translation>Maus</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1506"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1775"/>
         <source>Mouse Shortcuts</source>
         <translation>Maus-Kurzbefehle</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1521"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1790"/>
         <source>Action</source>
         <translation>Aktion</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1526"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1795"/>
         <source>Shortcut 1</source>
         <translation>Tastenkürzel 1</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1531"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1800"/>
         <source>Shortcut 2</source>
         <translation>Tastenkürzel 2</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1592"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1861"/>
         <source>Button:</source>
         <translation>Maustaste:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1600"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1869"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1605"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1874"/>
         <source>Left</source>
         <translation>Links</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1610"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1879"/>
         <source>Middle</source>
         <translation>Mitte</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1615"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1884"/>
         <source>Right</source>
         <translation>Rechts</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1623"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1892"/>
         <source>Modifiers:</source>
         <translation>Sondertaste:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1630"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1899"/>
         <source>Control</source>
         <translation>Strg</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1637"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1906"/>
         <source>Alt</source>
         <translation>Alt</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1644"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1913"/>
         <source>Shift</source>
         <translation>Shift</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1672"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1941"/>
         <source>Mouse sensitivity:</source>
         <translation>Mausempfindlichkeit:</translation>
     </message>
@@ -6676,9 +6724,8 @@ Anisotropic: %5
         <translation>Rendern</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="359"/>
         <source>Edge lines</source>
-        <translation>Randlinien</translation>
+        <translation type="vanished">Randlinien</translation>
     </message>
     <message>
         <source>Axis icon</source>
@@ -6689,96 +6736,96 @@ Anisotropic: %5
         <translation type="vanished">Breite</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="436"/>
         <source>Anti-aliasing</source>
         <translation>Anti-aliasing</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="439"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
         <source>2x</source>
         <translation>2x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
         <source>4x</source>
         <translation>4x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="454"/>
         <source>8x</source>
         <translation>8x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="409"/>
         <source>Shading Mode:</source>
         <translation>Schattenmodus:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="546"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="347"/>
         <source>Wireframe</source>
         <translation>Drahtmodell</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="551"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="352"/>
         <source>Flat Shading</source>
         <translation>Einfache Schatten</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="357"/>
         <source>Default Lights</source>
         <translation>Voreingestellte Beleuchtung</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="678"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="745"/>
         <source>Base Grid</source>
         <translation>Grundraster</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="728"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="795"/>
         <source>Draw studs</source>
         <translation>Noppen darstellen</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="751"/>
         <source>studs</source>
         <translation>Noppen</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="704"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="771"/>
         <source>Draw lines every</source>
         <translation>Linien zeichnen alle</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1111"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1052"/>
         <source>View Sphere</source>
         <translation>Ansichtskugel</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="615"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="783"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="850"/>
         <source>Disabled</source>
         <translation>Deaktiviert</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="620"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="656"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="855"/>
         <source>Small</source>
         <translation>Klein</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="625"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="793"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="661"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="860"/>
         <source>Medium</source>
         <translation>Mittel</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="630"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="798"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="666"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="865"/>
         <source>Large</source>
         <translation>Groß</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1145"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1118"/>
         <source>Highlight Color:</source>
         <translation>Hervorhebungsfarbe:</translation>
     </message>
@@ -6787,18 +6834,19 @@ Anisotropic: %5
         <translation type="vanished">Größe:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1117"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1058"/>
         <source>Color:</source>
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1131"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1088"/>
         <source>Text Color:</source>
         <translation>Textfarbe:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="600"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="775"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="636"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="711"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="842"/>
         <source>Location:</source>
         <translation>Position:</translation>
     </message>
@@ -6893,374 +6941,437 @@ Anisotropic: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="429"/>
         <source>Stud Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="394"/>
-        <source>Fade previous steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="476"/>
         <source>Mesh LOD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="431"/>
         <source>Highlight new parts</source>
-        <translation type="unfinished">Neue Teile Markieren</translation>
+        <translation type="obsolete">Neue Teile Markieren</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="465"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="366"/>
         <source>Plain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="470"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="371"/>
         <source>Thin Lines Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="475"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="376"/>
         <source>Outline Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="381"/>
         <source>Sharp Top Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="386"/>
         <source>Rounded Top Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="490"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="391"/>
         <source>Flattened Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="495"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="396"/>
         <source>High Contrast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="500"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
         <source>High Contrast with Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="524"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
         <source>Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="531"/>
-        <source>Automate edge color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="538"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
         <source>Contrast Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="581"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="617"/>
         <source>Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="587"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="623"/>
         <source>Model Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="744"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="629"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="811"/>
         <source>Axis Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="607"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="806"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="643"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="873"/>
         <source>View Sphere:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="639"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="752"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="675"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="819"/>
         <source>Top Left</source>
         <translation>Oben links</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="644"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="757"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="680"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="724"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="824"/>
         <source>Top Right</source>
         <translation>Oben rechts</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="649"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="762"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="685"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="729"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="829"/>
         <source>Bottom Left</source>
         <translation>Unten links</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="654"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="767"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="690"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="734"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="834"/>
         <source>Bottom Right</source>
         <translation>Oben rechts</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="721"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
         <source>Draw origin lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="805"/>
         <source>Part Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="843"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="910"/>
         <source>Colors</source>
         <translation type="unfinished">Farben</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="849"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1227"/>
         <source>Background</source>
         <translation type="unfinished">Hintergrund</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="857"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1235"/>
         <source>Top Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="871"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1265"/>
         <source>Bottom Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="900"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
         <source>So&amp;lid Color</source>
         <translation type="unfinished">F&amp;lächenfarbe</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="907"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1301"/>
         <source>&amp;Gradient</source>
         <translation type="unfinished">&amp;Gradient</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="941"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="916"/>
         <source>Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="947"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="936"/>
         <source>Inactive View Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="961"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="978"/>
         <source>Overlay Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="968"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1026"/>
         <source>Active View Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="989"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="950"/>
         <source>Camera Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1016"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="985"/>
         <source>Axis Icon Labels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1030"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="922"/>
         <source>Marquee Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1044"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="469"/>
+        <source>Highlight New Parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="506"/>
+        <source>Fade Previous Steps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="523"/>
+        <source>Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="536"/>
+        <source>Conditional Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <source>Line Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="579"/>
+        <source>Edge Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="586"/>
+        <source>Automate Edge Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="964"/>
         <source>Marquee Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1061"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1161"/>
         <source>Grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1067"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1167"/>
         <source>Lines:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1197"/>
         <source>Studs:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1189"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1230"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1335"/>
+        <source>Objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1341"/>
+        <source>Light:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1371"/>
+        <source>Focused:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1385"/>
+        <source>Control Point Focused:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1420"/>
+        <source>Control Point:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1427"/>
+        <source>Selected:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1434"/>
+        <source>Camera:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1458"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1499"/>
         <source>Categories</source>
         <translation>Kategorie</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1195"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1464"/>
         <source>Parts Library Categories</source>
         <translation>Kategorie der Teilebibliothek</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1264"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1533"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1538"/>
         <source>Number</source>
         <translation>Nummer</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1280"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1408"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1541"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1549"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1677"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1810"/>
         <source>Import...</source>
         <translation>Importieren…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1287"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1415"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1548"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1817"/>
         <source>Export...</source>
         <translation>Exportieren…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1422"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1555"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1563"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1691"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1824"/>
         <source>Reset...</source>
         <translation>Zurücksetzen…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1319"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1588"/>
         <source>Category</source>
         <translation>Kategorie</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1325"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1594"/>
         <source>New...</source>
         <translation>Neu…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1332"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1601"/>
         <source>Edit...</source>
         <translation>Bearbeiten…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1608"/>
         <source>Delete...</source>
         <translation>Löschen…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1363"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1632"/>
         <source>Keyboard</source>
         <translation>Tastatur</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1642"/>
         <source>Keyboard Shortcuts</source>
         <translation>Tastenkürzel</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1386"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1655"/>
         <source>Command</source>
         <translation>Befehl</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1391"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1450"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1584"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1660"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1853"/>
         <source>Shortcut</source>
         <translation>Kürzel</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1399"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1668"/>
         <source>Search shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1456"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1725"/>
         <source>Key se&amp;quence:</source>
         <translation>Tasten&amp;folge:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1469"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1920"/>
         <source>Assign</source>
         <translation>Zuweisen</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1476"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1658"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1745"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1927"/>
         <source>Remove</source>
         <translation>Entfernen</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="242"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="263"/>
         <source>Grid spacing must be greater than 0.</source>
         <translation>Rasterweite muss grösser als 0 sein.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="331"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="354"/>
         <source>Select Parts Library Folder</source>
         <translation>Wähle Teilebibliothek Ordner</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Supported Archives (*.zip *.bin);;All Files (*.*)</source>
         <translation>Unterstütze Bibliotheken (*.zip *.bin);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Select Parts Library Archive</source>
         <translation>Wähle Teilebibliothek Archiv</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Select Color Configuration File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Settings Files (*.ldr);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Select Minifig Settings File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Settings Files (*.ini);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="364"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
         <source>Executable Files (*.exe);;All Files (*.*)</source>
         <translation>Asuführbare Dateien (*.exe);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="366"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="389"/>
         <source>All Files (*.*)</source>
         <translation>Alle Dateien (*.*)</translation>
     </message>
@@ -7269,235 +7380,265 @@ Anisotropic: %5
         <translation type="vanished">Asuführbares POV-Ray öffnen</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="377"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="400"/>
         <source>Open LGEO Folder</source>
         <translation>LGEO Ordner öffnen</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Reset Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Would you like to also reset the interface colors to match the color theme?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="424"/>
         <source>Select Background Color</source>
         <translation type="unfinished">Hintergrundfarbe wählen</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="406"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="429"/>
         <source>Select Gradient Top Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="411"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="434"/>
         <source>Select Gradient Bottom Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="416"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="439"/>
         <source>Select Axes Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="421"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="444"/>
         <source>Select Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="426"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="449"/>
         <source>Select Marquee Border Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="431"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="454"/>
         <source>Select Marquee Fill Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="437"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="460"/>
         <source>Select Overlay Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="442"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="465"/>
         <source>Select Active View Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="447"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="470"/>
         <source>Select Inactive View Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="452"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="475"/>
         <source>Select Fade Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="458"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="481"/>
         <source>Select Highlight Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="464"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="487"/>
         <source>Select Grid Stud Color</source>
         <translation>Farbe der Noppen im Gitter wählen</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="470"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="493"/>
         <source>Select Grid Line Color</source>
         <translation>Farbe der Gitterlinien wählen</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="475"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="498"/>
         <source>Select View Sphere Color</source>
         <translation>Wähle Ansichtskugelfarbe</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="503"/>
         <source>Select View Sphere Text Color</source>
         <translation>Wähle Ansichtskugel Textfarbe</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="508"/>
         <source>Select View Sphere Highlight Color</source>
         <translation>Wähle Ansichtskugel Hervorhebungsfarbe</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="596"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="513"/>
+        <source>Select Object Selected Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="518"/>
+        <source>Select Object Focused Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="523"/>
+        <source>Select Camera Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="528"/>
+        <source>Select Light Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="533"/>
+        <source>Select Control Point Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="539"/>
+        <source>Select Control Point Focused Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="661"/>
         <source>Unassigned</source>
         <translation>Unbestimmt</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="710"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="775"/>
         <source>Are you sure you want to delete the category &apos;%1&apos;?</source>
         <translation>Sind sie sicher dass sie die Kategorie » %1 « löschen möchten?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
         <source>Import Categories</source>
         <translation>Kategorien importieren</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Text Files (*.txt);;All Files (*.*)</source>
         <translation>Textdateien (*.txt);;Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="731"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="796"/>
         <source>Error loading categories file.</source>
         <translation>Fehler beim Laden der Kategoriedatei.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
         <source>Export Categories</source>
         <translation>Kategorien exportieren</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="749"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="814"/>
         <source>Error saving categories file.</source>
         <translation>Fehler beim Speichern der Kategoriendatei.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="756"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="821"/>
         <source>Are you sure you want to load the default categories?</source>
         <translation>Sind sie sicher dass sie die voreingestellten Kategorien laden möchten?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="957"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1022"/>
         <source>The shortcut &apos;%1&apos; is already assigned to &apos;%2&apos;. Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
         <source>Import shortcuts</source>
         <translation>Tastenkürzel laden</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1020"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1085"/>
         <source>Error loading keyboard shortcuts file.</source>
         <translation>Fehler beim Laden der Tastaturkürzel-Datei.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
         <source>Export shortcuts</source>
         <translation>Tastaturkürzel exportieren</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1039"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1104"/>
         <source>Error saving keyboard shortcuts file.</source>
         <translation>Fehler beim Speichern der Tastaturkürzel-Datei.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1046"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1111"/>
         <source>Are you sure you want to load the default keyboard shortcuts?</source>
         <translation>Sind sie sicher dass sie die voreingestellten Tastaturkürzel laden möchten?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1073"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1138"/>
         <source>Left Button</source>
         <translation>Linke Maustaste</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1142"/>
         <source>Middle Button</source>
         <translation>Mittlere Maustaste</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1146"/>
         <source>Right Button</source>
         <translation>Rechte Maustaste</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="959"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1024"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>Override Shortcut</source>
         <translation>Tastaturkürzel ändern</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="369"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="392"/>
         <source>Select POV-Ray Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>This shortcut is already assigned to &apos;%1&apos;, do you want to replace it?</source>
         <translation>Dieses Tastaturkürzel ist bereits » %1 « zugewiesen, möchten sie es ersetzen?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
         <source>Import Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1212"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1277"/>
         <source>Error loading mouse shortcuts file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Export Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1231"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1296"/>
         <source>Error saving mouse shortcuts file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1236"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1301"/>
         <source>Are you sure you want to load the default mouse shortcuts?</source>
         <translation>Sind sie sicher dass sie die voreingestellten Mauskürzel laden möchten?</translation>
     </message>
@@ -7528,6 +7669,11 @@ Anisotropic: %5
         <location filename="../qt/lc_qpropertiesdialog.ui" line="56"/>
         <source>Comments:</source>
         <translation>Kommentare:</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="76"/>
+        <source>Measurements:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scene</source>
@@ -7562,7 +7708,7 @@ Anisotropic: %5
         <translation type="vanished">Voreinstellungen der Optionen für neue Projekte</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.ui" line="77"/>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="91"/>
         <source>Parts Used</source>
         <translation>Verwendete Teile</translation>
     </message>
@@ -7572,13 +7718,20 @@ Anisotropic: %5
         <translation>%1 Eigenschaften</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="62"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="51"/>
+        <source>%1 x %2 x %3 cm
+%4 x %5 x %6 inches
+%7 x %8 x %9 LDU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="70"/>
         <source>Part</source>
         <translation>Teil</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="73"/>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="110"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="81"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="118"/>
         <source>Total</source>
         <translation>Gesamt</translation>
     </message>
@@ -7616,40 +7769,40 @@ Anisotropic: %5
         <translation>Wert</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="886"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1018"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="895"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1027"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="887"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="892"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1019"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1024"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="888"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="893"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1020"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1025"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1039"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="889"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="894"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1021"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1026"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1031"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="903"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1040"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="891"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
         <source>Rotation</source>
         <translation>Drehung</translation>
     </message>
@@ -7658,73 +7811,73 @@ Anisotropic: %5
         <translation type="vanished">Sichtbarkeit</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="905"/>
         <source>Visible Steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="906"/>
         <source>Show</source>
         <translation>Zeige</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="907"/>
         <source>Hide</source>
         <translation>Ausblenden</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="909"/>
         <source>Appearance</source>
         <translation>Erscheinungsbild</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="910"/>
         <source>Color</source>
         <translation>Farbe</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="911"/>
         <source>Part</source>
         <translation>Teil</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1023"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1032"/>
         <source>Target</source>
         <translation>Ziel</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1042"/>
         <source>Up</source>
         <translation>Hoch</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1043"/>
         <source>Orthographic</source>
         <translation>Orhografisch</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1044"/>
         <source>FOV</source>
         <translation>FOV</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1036"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1045"/>
         <source>Near</source>
         <translation>Nah</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1046"/>
         <source>Far</source>
         <translation>Fern</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1047"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1118"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1127"/>
         <source>Multiple Objects Selected</source>
         <translation>Mehrere Objekre ausgewählt</translation>
     </message>
@@ -8016,22 +8169,22 @@ Anisotropic: %5
 <context>
     <name>lcView</name>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>LeoCAD</source>
         <translation type="unfinished">LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>Error creating images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error</source>
         <translation type="unfinished">Fehler</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation type="unfinished">Fehler beim Schreiben der Datei » %1 « :

--- a/resources/leocad_es.ts
+++ b/resources/leocad_es.ts
@@ -6,97 +6,97 @@
     <message>
         <location filename="../common/lc_commands.cpp" line="8"/>
         <source>File.New</source>
-        <translation>Archivo.Nuevo</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="15"/>
         <source>File.Open</source>
-        <translation>Archivo.Abrir</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="22"/>
         <source>File.Merge</source>
-        <translation>Archivo.Fusionar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="29"/>
         <source>File.Save</source>
-        <translation>Archivo.Guardar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="36"/>
         <source>File.SaveAs</source>
-        <translation>Archivo.Guardar como</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="43"/>
         <source>File.SaveImage</source>
-        <translation>Archivo.Guardar Imagen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="50"/>
         <source>File.Import.LDD</source>
-        <translation>Archivo.Importar LDD</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="57"/>
         <source>File.Import.Inventory</source>
-        <translation>Archivo.Importar.Inventario</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="64"/>
         <source>File.Export.3DS</source>
-        <translation>Archivo.Exportar.3DS</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="71"/>
         <source>File.Export.COLLADA</source>
-        <translation>Archivo.Exportar.COLLADA</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="78"/>
         <source>File.Export.HTML</source>
-        <translation>Archivo.Exportar.HTML</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="85"/>
         <source>File.Export.BrickLink</source>
-        <translation>Archivo.Exportar.BrickLink</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="92"/>
         <source>File.Export.CSV</source>
-        <translation>Archivo.Exportar.CSV</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="99"/>
         <source>File.Export.POVRay</source>
-        <translation>Archivo.Exportar.POVRay</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="106"/>
         <source>File.Export.Wavefront</source>
-        <translation>Archivo.Exportar.Wavefront</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="113"/>
         <source>File.Render</source>
-        <translation>Archivo.Renderizado</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="120"/>
         <source>File.Instructions</source>
-        <translation>Archivo.Instrucciones</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="127"/>
         <source>File.Print</source>
-        <translation>Archivo.Imprimir</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="134"/>
         <source>File.PrintPreview</source>
-        <translation>Archivo.Imprimir Previa</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>File.PrintBOM</source>
@@ -105,1195 +105,1182 @@
     <message>
         <location filename="../common/lc_commands.cpp" line="141"/>
         <source>File.Recent1</source>
-        <translation>Archivo.Reciente1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="148"/>
         <source>File.Recent2</source>
-        <translation>Archivo.Reciente2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="155"/>
         <source>File.Recent3</source>
-        <translation>Archivo.Reciente3</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="162"/>
         <source>File.Recent4</source>
-        <translation>Archivo.Reciente4</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="169"/>
         <source>File.Exit</source>
-        <translation>Archivo.Salir</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="176"/>
         <source>Edit.Undo</source>
-        <translation>Editar.Deshacer</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="183"/>
         <source>Edit.Redo</source>
-        <translation>Editar.Rehacer</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="190"/>
         <source>Edit.Cut</source>
-        <translation>Editar.Cortar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="197"/>
         <source>Edit.Copy</source>
-        <translation>Editar.Copiar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="204"/>
         <source>Edit.Paste</source>
-        <translation>Editar.Pegar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="211"/>
         <source>Edit.PasteSteps</source>
-        <translation>Editar.CopiarPasos</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="218"/>
         <source>Edit.Find</source>
-        <translation>Editar.Buscar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="225"/>
         <source>Edit.FindNext</source>
-        <translation>Editar.Buscar Siguiente</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="232"/>
         <source>Edit.FindPrevious</source>
-        <translation>Editar.Buscar Previo</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="239"/>
         <source>Edit.FindAll</source>
-        <translation>Editar.EncontrarTodos</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="246"/>
         <source>Edit.Replace</source>
-        <translation>Editar.Reemplazar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="253"/>
         <source>Edit.ReplaceNext</source>
-        <translation>Editar.ReemplazarSiguiente</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="260"/>
         <source>Edit.ReplaceAll</source>
-        <translation>Editar.ReemplazarTodos</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="267"/>
         <source>Edit.SelectAll</source>
-        <translation>Editar.Seleccionar Todos</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="274"/>
         <source>Edit.SelectNone</source>
-        <translation>Editar.Seleccionar Ninguno</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="281"/>
         <source>Edit.SelectInvert</source>
-        <translation>Editar.Seleccionar Invertir</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="288"/>
         <source>Edit.SelectByName</source>
-        <translation>Editar.Seleccionar Por Nombre</translation>
-    </message>
-    <message>
-        <source>Edit.SelectByColor</source>
-        <translation type="vanished">Editar.Seleccionar Por Color</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="295"/>
         <source>Edit.SelectSingle</source>
-        <translation>Editar.Seleccionar Unico</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="302"/>
         <source>Edit.SelectPiece</source>
-        <translation>Editar.Seleccionar Pieza</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="309"/>
         <source>Edit.SelectColor</source>
-        <translation>Editar.Seleccionar Color</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="316"/>
         <source>Edit.SelectPieceColor</source>
-        <translation>Editar.Seleccionar Color de Pieza</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="323"/>
         <source>Edit.TransformRelative</source>
-        <translation>Editar.Tranformacion Relativa</translation>
-    </message>
-    <message>
-        <source>Edit.TransformLocal</source>
-        <translation type="vanished">Editar.TransformacionLocal</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="330"/>
         <source>Edit.TransformAbsolute</source>
-        <translation>Editar.TransformacionAbsoluta</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="337"/>
         <source>Edit.TransformToggleRelative</source>
-        <translation>Editar.CambioTransformacionRelativa</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="344"/>
         <source>Edit.TransformSeparately</source>
-        <translation>Editar.TransformacionSeparadamente</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="351"/>
         <source>Edit.TransformTogether</source>
-        <translation>Editar.TransformacionJuntos</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="358"/>
         <source>Edit.TransformToggleSeparate</source>
-        <translation>Editar.CambioTransformacionSeparada</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="365"/>
         <source>Edit.Snap.Toggle</source>
-        <translation>Editar.Acople Activar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="372"/>
         <source>Edit.SnapMove.XY0</source>
-        <translation>Editar.Acople Mover.XY0</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="379"/>
         <source>Edit.SnapMove.XY1</source>
-        <translation>Editar.Acople Mover.XY1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="386"/>
         <source>Edit.SnapMove.XY2</source>
-        <translation>Editar.Acople Mover.XY2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="393"/>
         <source>Edit.SnapMove.XY3</source>
-        <translation>Editar.Acople Mover.XY3</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="400"/>
         <source>Edit.SnapMove.XY4</source>
-        <translation>Editar.Acople Mover.XY4</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="407"/>
         <source>Edit.SnapMove.XY5</source>
-        <translation>Editar.Acople Mover.XY5</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="414"/>
         <source>Edit.SnapMove.XY6</source>
-        <translation>Editar.Acople Mover.XY6</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="421"/>
         <source>Edit.SnapMove.XY7</source>
-        <translation>Editar.Acople Mover.XY7</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="428"/>
         <source>Edit.SnapMove.XY8</source>
-        <translation>Editar.Acople Mover.XY8</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="435"/>
         <source>Edit.SnapMove.XY9</source>
-        <translation>Editar.Acople Mover.XY9</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="442"/>
         <source>Edit.SnapMove.Z0</source>
-        <translation>Editar.Acople Mover.Z0</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="449"/>
         <source>Edit.SnapMove.Z1</source>
-        <translation>Editar.Acople Mover.Z1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="456"/>
         <source>Edit.SnapMove.Z2</source>
-        <translation>Editar.Acople Mover.Z2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="463"/>
         <source>Edit.SnapMove.Z3</source>
-        <translation>Editar.Acople Mover.Z3</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="470"/>
         <source>Edit.SnapMove.Z4</source>
-        <translation>Editar.Acople Mover.Z4</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="477"/>
         <source>Edit.SnapMove.Z5</source>
-        <translation>Editar.Acople Mover.Z5</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="484"/>
         <source>Edit.SnapMove.Z6</source>
-        <translation>Editar.Acople Mover.Z6</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="491"/>
         <source>Edit.SnapMove.Z7</source>
-        <translation>Editar.Acople Mover.Z7</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="498"/>
         <source>Edit.SnapMove.Z8</source>
-        <translation>Editar.Acople Mover.Z8</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="505"/>
         <source>Edit.SnapMove.Z9</source>
-        <translation>Editar.Acople Mover.Z9</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="512"/>
         <source>Edit.SnapAngle.Toggle</source>
-        <translation>Editar.Acople Angulo.Activar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="519"/>
         <source>Edit.SnapAngle.Angle0</source>
-        <translation>Editar.Acople Angulo.Angulo0</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="526"/>
         <source>Edit.SnapAngle.Angle1</source>
-        <translation>Editar.Acople Angulo.Angulo1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="533"/>
         <source>Edit.SnapAngle.Angle2</source>
-        <translation>Editar.Acople Angulo.Angulo2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="540"/>
         <source>Edit.SnapAngle.Angle3</source>
-        <translation>Editar.Acople Angulo.Angulo3</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="547"/>
         <source>Edit.SnapAngle.Angle4</source>
-        <translation>Editar.Acople Angulo.Angulo4</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="554"/>
         <source>Edit.SnapAngle.Angle5</source>
-        <translation>Editar.Acople Angulo.Angulo5</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="561"/>
         <source>Edit.SnapAngle.Angle6</source>
-        <translation>Editar.Acople Angulo.Angulo6</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="568"/>
         <source>Edit.SnapAngle.Angle7</source>
-        <translation>Editar.Acople Angulo.Angulo7</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="575"/>
         <source>Edit.SnapAngle.Angle8</source>
-        <translation>Editar.Acople Angulo.Angulo8</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="582"/>
         <source>Edit.SnapAngle.Angle9</source>
-        <translation>Editar.Acople Angulo.Angulo9</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="589"/>
         <source>Edit.Transform</source>
-        <translation>Editar.Transformacion</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="596"/>
         <source>Edit.TransformAbsoluteTranslation</source>
-        <translation>Editar.TransformacionAbsolutaTranslacion</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="603"/>
         <source>Edit.TransformRelativeTranslation</source>
-        <translation>Editar.TransformacionRelativaTranslacion</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="610"/>
         <source>Edit.TransformAbsoluteRotation</source>
-        <translation>Editar.TransformacionAbsolutaRotacion</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="617"/>
         <source>Edit.TransformRelativeRotation</source>
-        <translation>Editar.TransformacionRelativaRotacion</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="624"/>
         <source>Edit.Tool.Insert</source>
-        <translation>Editar.Herramienta.Insertar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="631"/>
         <source>Edit.Tool.Light</source>
-        <translation>Editar.Herramienta.Luz</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="638"/>
         <source>Edit.Tool.Spotlight</source>
-        <translation>Editar.Herramienta.Foco</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="645"/>
         <source>Edit.Tool.Camera</source>
-        <translation>Editar.Herramienta.Camara</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="652"/>
         <source>Edit.Tool.Select</source>
-        <translation>Editar.Herramienta.Seleccionar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="659"/>
         <source>Edit.Tool.Move</source>
-        <translation>Editar.Herramienta.Mover</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="666"/>
         <source>Edit.Tool.Rotate</source>
-        <translation>Editar.Herramienta.Rotar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="673"/>
         <source>Edit.Tool.Delete</source>
-        <translation>Editar.Herramienta.Borrar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="680"/>
         <source>Edit.Tool.Paint</source>
-        <translation>Editar.Herramienta.Pintar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="687"/>
         <source>Edit.Tool.ColorPicker</source>
-        <translation>Editar.Herramienta.Selector de Color</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="694"/>
         <source>Edit.Tool.Zoom</source>
-        <translation>Editar.Herramienta.Ampliacion</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="701"/>
         <source>Edit.Tool.Pan</source>
-        <translation>Editar.Herramienta.Desplazar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="708"/>
         <source>Edit.Tool.RotateView</source>
-        <translation>Editar.Herramienta.RotarVista</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="715"/>
         <source>Edit.Tool.Roll</source>
-        <translation>Editar.Herramienta.Rodar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="722"/>
         <source>Edit.Tool.ZoomRegion</source>
-        <translation>Editar.Herramienta.AmpliarRegion</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="729"/>
         <source>Edit.Cancel</source>
-        <translation>Editar.Cancelar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="736"/>
         <source>View.Preferences</source>
-        <translation>Ver.Preferencias</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="743"/>
         <source>View.ZoomIn</source>
-        <translation>Ver.Ampliar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="750"/>
         <source>View.ZoomOut</source>
-        <translation>Ver.Reducir</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="757"/>
         <source>View.ZoomExtents</source>
-        <translation>Ver.AmpliarTodo</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="764"/>
         <source>View.LookAt</source>
-        <translation>Ver.Modelo</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="771"/>
         <source>View.MoveForward</source>
-        <translation>Ver.MoverAdelante</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="778"/>
         <source>View.MoveBackward</source>
-        <translation>Ver.MoverAtras</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="785"/>
         <source>View.MoveLeft</source>
-        <translation>Ver.MoverIzquierda</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="792"/>
         <source>View.MoveRight</source>
-        <translation>Ver.MoverDerecha</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="799"/>
         <source>View.MoveUp</source>
-        <translation>Ver.MoverArriba</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="806"/>
         <source>View.MoveDown</source>
-        <translation>Ver.MoverAbajo</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="813"/>
         <source>View.Viewpoint.Front</source>
-        <translation>Ver.Puntadevista.Frente</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="820"/>
         <source>View.Viewpoint.Back</source>
-        <translation>Ver.Puntadevista.Detras</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="827"/>
         <source>View.Viewpoint.Top</source>
-        <translation>Ver.Puntadevista.Arriba</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="834"/>
         <source>View.Viewpoint.Bottom</source>
-        <translation>Ver.Puntadevista.Abajo</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="841"/>
         <source>View.Viewpoint.Left</source>
-        <translation>Ver.Puntadevista.Izquierda</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="848"/>
         <source>View.Viewpoint.Right</source>
-        <translation>Ver.Puntadevista.Derecha</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="855"/>
         <source>View.Viewpoint.Home</source>
-        <translation>Ver.Puntadevista.Inicio</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="862"/>
         <source>View.Cameras.None</source>
-        <translation>Ver.Camaras.Ninguna</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="869"/>
         <source>View.Cameras.Camera01</source>
-        <translation>Ver.Camaras.Camara01</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="876"/>
         <source>View.Cameras.Camera02</source>
-        <translation>Ver.Camaras.Camara02</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="883"/>
         <source>View.Cameras.Camera03</source>
-        <translation>Ver.Camaras.Camara03</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="890"/>
         <source>View.Cameras.Camera04</source>
-        <translation>Ver.Camaras.Camara04</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="897"/>
         <source>View.Cameras.Camera05</source>
-        <translation>Ver.Camaras.Camara05</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="904"/>
         <source>View.Cameras.Camera06</source>
-        <translation>Ver.Camaras.Camara06</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="911"/>
         <source>View.Cameras.Camera07</source>
-        <translation>Ver.Camaras.Camara07</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="918"/>
         <source>View.Cameras.Camera08</source>
-        <translation>Ver.Camaras.Camara08</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="925"/>
         <source>View.Cameras.Camera09</source>
-        <translation>Ver.Camaras.Camara09</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="932"/>
         <source>View.Cameras.Camera10</source>
-        <translation>Ver.Camaras.Camara10</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="939"/>
         <source>View.Cameras.Camera11</source>
-        <translation>Ver.Camaras.Camara11</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="946"/>
         <source>View.Cameras.Camera12</source>
-        <translation>Ver.Camaras.Camara12</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="953"/>
         <source>View.Cameras.Camera13</source>
-        <translation>Ver.Camaras.Camara13</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="960"/>
         <source>View.Cameras.Camera14</source>
-        <translation>Ver.Camaras.Camara14</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="967"/>
         <source>View.Cameras.Camera15</source>
-        <translation>Ver.Camaras.Camara15</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="974"/>
         <source>View.Cameras.Camera16</source>
-        <translation>Ver.Camaras.Camara16</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="981"/>
-        <source>View.Cameras.Reset</source>
-        <translation>Ver.Camaras.Reiniciar</translation>
+        <source>View.Time.First</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="988"/>
-        <source>View.Time.First</source>
-        <translation>Ver.Tiempo.Primero</translation>
+        <source>View.Time.Previous</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="995"/>
-        <source>View.Time.Previous</source>
-        <translation>Ver.Tiempo.Previo</translation>
+        <source>View.Time.Next</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1002"/>
-        <source>View.Time.Next</source>
-        <translation>Ver.Tiempo.Siguiente</translation>
+        <source>View.Time.Last</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1009"/>
-        <source>View.Time.Last</source>
-        <translation>Ver.Tiempo.Ultimo</translation>
+        <source>View.Time.InsertBefore</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1016"/>
-        <source>View.Time.InsertBefore</source>
-        <translation>Ver.Tiempo.InsertarAntes</translation>
+        <source>View.Time.InsertAfter</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1023"/>
-        <source>View.Time.InsertAfter</source>
-        <translation>Ver.Tiempo.InsertarDespues</translation>
+        <source>View.Time.Delete</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1030"/>
-        <source>View.Time.Delete</source>
-        <translation>Ver.Tiempo.Borrar</translation>
+        <source>View.Time.AddKeys</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1037"/>
-        <source>View.Time.AddKeys</source>
-        <translation>Ver.Tiempo.AñadirClaves</translation>
+        <source>View.SplitHorizontal</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1044"/>
-        <source>View.SplitHorizontal</source>
-        <translation>Ver.DivisionHorizontal</translation>
+        <source>View.SplitVertical</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1051"/>
-        <source>View.SplitVertical</source>
-        <translation>Ver.DivisionVertical</translation>
+        <source>View.RemoveView</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1058"/>
-        <source>View.RemoveView</source>
-        <translation>Ver.RemotaVista</translation>
+        <source>View.ResetViews</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1065"/>
-        <source>View.ResetViews</source>
-        <translation>Ver.ReinicioVistas</translation>
+        <source>View.Toolbars.Standard</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1072"/>
-        <source>View.Toolbars.Standard</source>
-        <translation>Ver.Barrasdeherramientas.Estandar</translation>
+        <source>View.Toolbars.Tools</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1079"/>
-        <source>View.Toolbars.Tools</source>
-        <translation>Ver.Barrasdeherramientas.Herramientas</translation>
+        <source>View.Toolbars.Time</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1086"/>
-        <source>View.Toolbars.Time</source>
-        <translation>Ver.Barrasdeherramientas.Tiempo</translation>
+        <source>View.Toolbars.Parts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1093"/>
-        <source>View.Toolbars.Parts</source>
-        <translation>Ver.Barrasdeherramientas.Partes</translation>
+        <source>View.Toolbars.Colors</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1100"/>
-        <source>View.Toolbars.Colors</source>
-        <translation>Ver.Barrasdeherramientas.Colores</translation>
+        <source>View.Toolbars.Properties</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1107"/>
-        <source>View.Toolbars.Properties</source>
-        <translation>Ver.Barrasdeherramientas.Propiedades</translation>
+        <source>View.Toolbars.Timeline</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1114"/>
-        <source>View.Toolbars.Timeline</source>
-        <translation>Ver.Barrasdeherramientas.Lineadetiempo</translation>
+        <source>View.Toolbars.Preview</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1121"/>
-        <source>View.Toolbars.Preview</source>
-        <translation>Ver.Barrasdeherramientas.Previa</translation>
+        <source>View.FullScreen</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1128"/>
-        <source>View.FullScreen</source>
-        <translation>Ver.PantallaCompleta</translation>
+        <source>View.CloseCurrentTab</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1135"/>
-        <source>View.CloseCurrentTab</source>
-        <translation>Ver.CerrarActualPestaña</translation>
+        <source>View.Shade.Wireframe</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1142"/>
-        <source>View.Shade.Wireframe</source>
-        <translation>Ver.Sombreado.Malla</translation>
+        <source>View.Shade.Flat</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1149"/>
-        <source>View.Shade.Flat</source>
-        <translation>Ver.Sombreado.Plano</translation>
+        <source>View.Shade.DefaultLights</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1156"/>
-        <source>View.Shade.DefaultLights</source>
-        <translation>Ver.Sombreado.DefectoLuces</translation>
+        <source>View.Projection.Perspective</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1163"/>
-        <source>View.Projection.Perspective</source>
-        <translation>Ver.Proyeccion.Perspectiva</translation>
+        <source>View.Projection.Orthographic</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1170"/>
-        <source>View.Projection.Orthographic</source>
-        <translation>Ver.Proyeccion.Ortografica</translation>
+        <source>View.ToggleViewSphere</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1177"/>
-        <source>View.ToggleViewSphere</source>
-        <translation>ActivarVerEsfera</translation>
+        <source>View.ToggleAxisIcon</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1184"/>
-        <source>View.ToggleAxisIcon</source>
-        <translation>Ver.CambioEjesIcono</translation>
+        <source>View.ToggleGrid</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1191"/>
-        <source>View.ToggleGrid</source>
-        <translation>Ver.CambioMalla</translation>
+        <source>View.FadePreviousSteps</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1198"/>
-        <source>View.FadePreviousSteps</source>
-        <translation>TransparentarPasosPrevios</translation>
+        <source>Piece.Insert</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1205"/>
-        <source>Piece.Insert</source>
-        <translation>Pieza.Insertar</translation>
+        <source>Piece.Delete</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1212"/>
-        <source>Piece.Delete</source>
-        <translation>Pieza.Borrar</translation>
+        <source>Piece.Duplicate</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1219"/>
-        <source>Piece.Duplicate</source>
-        <translation>Pieza.Duplicar</translation>
+        <source>Piece.PaintSelected</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1226"/>
-        <source>Piece.PaintSelected</source>
-        <translation>Pieza.PintarSeleccionado</translation>
+        <source>Piece.ResetPivotPoint</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1233"/>
-        <source>Piece.ResetPivotPoint</source>
-        <translation>Pieza.ReiniciarPivotePunto</translation>
+        <source>Piece.RemoveKeyFrames</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1240"/>
-        <source>Piece.RemoveKeyFrames</source>
-        <translation>Pieza.QuitarClaveFotogramas</translation>
+        <source>Piece.ControlPoint.Insert</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1247"/>
-        <source>Piece.ControlPoint.Insert</source>
-        <translation>Pieza.ControlPunto.Insertar</translation>
+        <source>Piece.ControlPoint.Remove</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1254"/>
-        <source>Piece.ControlPoint.Remove</source>
-        <translation>Pieza.ControlPunto.Quitar</translation>
+        <source>Piece.Move.PlusX</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1261"/>
-        <source>Piece.Move.PlusX</source>
-        <translation>Pieza.Mover.MasX</translation>
+        <source>Piece.Move.MinusX</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1268"/>
-        <source>Piece.Move.MinusX</source>
-        <translation>Pieza.Mover.MenosX</translation>
+        <source>Piece.Move.PlusY</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1275"/>
-        <source>Piece.Move.PlusY</source>
-        <translation>Pieza.Mover.MasY</translation>
+        <source>Piece.Move.MinusY</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1282"/>
-        <source>Piece.Move.MinusY</source>
-        <translation>Pieza.Mover.MenosY</translation>
+        <source>Piece.Move.PlusZ</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1289"/>
-        <source>Piece.Move.PlusZ</source>
-        <translation>Pieza.Mover.MasZ</translation>
+        <source>Piece.Move.MinusZ</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1296"/>
-        <source>Piece.Move.MinusZ</source>
-        <translation>Pieza.Mover.MenosZ</translation>
+        <source>Piece.Rotate.PlusX</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1303"/>
-        <source>Piece.Rotate.PlusX</source>
-        <translation>Pieza.Rotar.MasX</translation>
+        <source>Piece.Rotate.MinusX</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1310"/>
-        <source>Piece.Rotate.MinusX</source>
-        <translation>Pieza.Rotar.MenosX</translation>
+        <source>Piece.Rotate.PlusY</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1317"/>
-        <source>Piece.Rotate.PlusY</source>
-        <translation>Pieza.Rotar.MasY</translation>
+        <source>Piece.Rotate.MinusY</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1324"/>
-        <source>Piece.Rotate.MinusY</source>
-        <translation>Pieza.Rotar.MenosY</translation>
+        <source>Piece.Rotate.PlusZ</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1331"/>
-        <source>Piece.Rotate.PlusZ</source>
-        <translation>Pieza.Rotar.MasZ</translation>
+        <source>Piece.Rotate.MinusZ</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1338"/>
-        <source>Piece.Rotate.MinusZ</source>
-        <translation>Pieza.Rotar.MenosZ</translation>
+        <source>Piece.MinifigWizard</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1345"/>
-        <source>Piece.MinifigWizard</source>
-        <translation>Pieza.MinifigAsistente</translation>
+        <source>Piece.Array</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1352"/>
-        <source>Piece.Array</source>
-        <translation>Pieza.Conjunto</translation>
+        <source>Piece.ViewSelectedModel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1359"/>
-        <source>Piece.ViewSelectedModel</source>
-        <translation>Pieza.VerSeleccionadoModelo</translation>
+        <source>Piece.MoveSelectionToModel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1366"/>
-        <source>Piece.MoveSelectionToModel</source>
-        <translation>Pieza.MoverSeleccionaModelo</translation>
+        <source>Piece.InlineSelectedModels</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1373"/>
-        <source>Piece.InlineSelectedModels</source>
-        <translation>Pieza.InsertarSeleccionadosModelos</translation>
+        <source>Piece.EditSelectedSubmodel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1380"/>
-        <source>Piece.EditSelectedSubmodel</source>
-        <translation>Pieza.EditarSeleccionadosSubmodelos</translation>
+        <source>Piece.EditEndSubmodel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1387"/>
-        <source>Piece.EditEndSubmodel</source>
-        <translation>Pieza.EditarFinSubmodelo</translation>
+        <source>Piece.Group</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1394"/>
-        <source>Piece.Group</source>
-        <translation>Pieza.Agrupar</translation>
+        <source>Piece.Ungroup</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1401"/>
-        <source>Piece.Ungroup</source>
-        <translation>Pieza.Desagrupar</translation>
+        <source>Piece.GroupAdd</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1408"/>
-        <source>Piece.GroupAdd</source>
-        <translation>Pieza.GrupoAñadir</translation>
+        <source>Piece.GroupRemove</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1415"/>
-        <source>Piece.GroupRemove</source>
-        <translation>Pieza.GrupoQuitar</translation>
+        <source>Piece.GroupEdit</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1422"/>
-        <source>Piece.GroupEdit</source>
-        <translation>Pieza.GrupoEditar</translation>
+        <source>Piece.HideSelected</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1429"/>
-        <source>Piece.HideSelected</source>
-        <translation>Pieza.OcultarSeleccionado</translation>
+        <source>Piece.HideUnselected</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1436"/>
-        <source>Piece.HideUnselected</source>
-        <translation>Pieza.OcultarNoseleccionado</translation>
+        <source>Piece.UnhideSelected</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1443"/>
-        <source>Piece.UnhideSelected</source>
-        <translation>Pieza.MostrarSeleccionado</translation>
+        <source>Piece.UnhideAll</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1450"/>
-        <source>Piece.UnhideAll</source>
-        <translation>Pieza.MostrarTodo</translation>
+        <source>Piece.ShowEarlier</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1457"/>
-        <source>Piece.ShowEarlier</source>
-        <translation>Pieza.MostrarPrevio</translation>
+        <source>Piece.ShowLater</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1464"/>
-        <source>Piece.ShowLater</source>
-        <translation>Pieza.MostrarPosterior</translation>
+        <source>Model.New</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1471"/>
-        <source>Model.New</source>
-        <translation>Modelo.Nuevo</translation>
+        <source>Model.Properties</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1478"/>
-        <source>Model.Properties</source>
-        <translation>Modelo.Propiedades</translation>
+        <source>Model.List</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1485"/>
-        <source>Model.List</source>
-        <translation>Modelo.Lista</translation>
+        <source>Model.Model01</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1492"/>
-        <source>Model.Model01</source>
-        <translation>Modelo.Modelo01</translation>
+        <source>Model.Model02</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1499"/>
-        <source>Model.Model02</source>
-        <translation>Modelo.Modelo02</translation>
+        <source>Model.Model03</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1506"/>
-        <source>Model.Model03</source>
-        <translation>Modelo.Modelo03</translation>
+        <source>Model.Model04</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1513"/>
-        <source>Model.Model04</source>
-        <translation>Modelo.Modelo04</translation>
+        <source>Model.Model05</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1520"/>
-        <source>Model.Model05</source>
-        <translation>Modelo.Modelo05</translation>
+        <source>Model.Model06</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1527"/>
-        <source>Model.Model06</source>
-        <translation>Modelo.Modelo06</translation>
+        <source>Model.Model07</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1534"/>
-        <source>Model.Model07</source>
-        <translation>Modelo.Modelo07</translation>
+        <source>Model.Model08</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1541"/>
-        <source>Model.Model08</source>
-        <translation>Modelo.Modelo08</translation>
+        <source>Model.Model09</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1548"/>
-        <source>Model.Model09</source>
-        <translation>Modelo.Modelo09</translation>
+        <source>Model.Model10</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1555"/>
-        <source>Model.Model10</source>
-        <translation>Modelo.Modelo10</translation>
+        <source>Model.Model11</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1562"/>
-        <source>Model.Model11</source>
-        <translation>Modelo.Modelo11</translation>
+        <source>Model.Model12</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1569"/>
-        <source>Model.Model12</source>
-        <translation>Modelo.Modelo12</translation>
+        <source>Model.Model13</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1576"/>
-        <source>Model.Model13</source>
-        <translation>Modelo.Modelo13</translation>
+        <source>Model.Model14</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1583"/>
-        <source>Model.Model14</source>
-        <translation>Modelo.Modelo14</translation>
+        <source>Model.Model15</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1590"/>
-        <source>Model.Model15</source>
-        <translation>Modelo.Modelo15</translation>
+        <source>Model.Model16</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1597"/>
-        <source>Model.Model16</source>
-        <translation>Modelo.Modelo16</translation>
+        <source>Model.Model17</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1604"/>
-        <source>Model.Model17</source>
-        <translation>Modelo.Modelo17</translation>
+        <source>Model.Model18</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1611"/>
-        <source>Model.Model18</source>
-        <translation>Modelo.Modelo18</translation>
+        <source>Model.Model19</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1618"/>
-        <source>Model.Model19</source>
-        <translation>Modelo.Modelo19</translation>
+        <source>Model.Model20</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1625"/>
-        <source>Model.Model20</source>
-        <translation>Modelo.Modelo20</translation>
+        <source>Model.Model21</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1632"/>
-        <source>Model.Model21</source>
-        <translation>Modelo.Modelo21</translation>
+        <source>Model.Model22</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1639"/>
-        <source>Model.Model22</source>
-        <translation>Modelo.Modelo22</translation>
+        <source>Model.Model23</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1646"/>
-        <source>Model.Model23</source>
-        <translation>Modelo.Modelo23</translation>
+        <source>Model.Model24</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1653"/>
-        <source>Model.Model24</source>
-        <translation>Modelo.Modelo24</translation>
+        <source>Model.Model25</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1660"/>
-        <source>Model.Model25</source>
-        <translation>Modelo.Modelo25</translation>
+        <source>Model.Model26</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1667"/>
-        <source>Model.Model26</source>
-        <translation>Modelo.Modelo26</translation>
+        <source>Model.Model27</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1674"/>
-        <source>Model.Model27</source>
-        <translation>Modelo.Modelo27</translation>
+        <source>Model.Model28</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1681"/>
-        <source>Model.Model28</source>
-        <translation>Modelo.Modelo28</translation>
+        <source>Model.Model29</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1688"/>
-        <source>Model.Model29</source>
-        <translation>Modelo.Modelo29</translation>
+        <source>Model.Model30</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1695"/>
-        <source>Model.Model30</source>
-        <translation>Modelo.Modelo30</translation>
+        <source>Model.Model31</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1702"/>
-        <source>Model.Model31</source>
-        <translation>Modelo.Modelo31</translation>
+        <source>Model.Model32</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1709"/>
-        <source>Model.Model32</source>
-        <translation>Modelo.Modelo32</translation>
+        <source>Model.Model33</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1716"/>
-        <source>Model.Model33</source>
-        <translation>Modelo.Modelo33</translation>
+        <source>Model.Model34</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1723"/>
-        <source>Model.Model34</source>
-        <translation>Modelo.Modelo34</translation>
+        <source>Model.Model35</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1730"/>
-        <source>Model.Model35</source>
-        <translation>Modelo.Modelo35</translation>
+        <source>Model.Model36</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1737"/>
-        <source>Model.Model36</source>
-        <translation>Modelo.Modelo36</translation>
+        <source>Model.Model37</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1744"/>
-        <source>Model.Model37</source>
-        <translation>Modelo.Modelo37</translation>
+        <source>Model.Model38</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1751"/>
-        <source>Model.Model38</source>
-        <translation>Modelo.Modelo38</translation>
+        <source>Model.Model39</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1758"/>
-        <source>Model.Model39</source>
-        <translation>Modelo.Modelo39</translation>
+        <source>Model.Model40</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1765"/>
-        <source>Model.Model40</source>
-        <translation>Modelo.Modelo40</translation>
+        <source>Help.HomePage</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1772"/>
-        <source>Help.HomePage</source>
-        <translation>Ayuda.PaginaInicial</translation>
+        <source>Help.BugReport</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1779"/>
-        <source>Help.BugReport</source>
-        <translation>Ayuda.ReportarError</translation>
+        <source>Help.Updates</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1786"/>
-        <source>Help.Updates</source>
-        <translation>Ayuda.Actualizaciones</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1793"/>
         <source>Help.About</source>
-        <translation>Ayuda.Acercade</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1321,101 +1308,101 @@
     <message>
         <location filename="../common/lc_commands.cpp" line="37"/>
         <source>Save &amp;As...</source>
-        <translation>Guardar C&amp;omo...</translation>
+        <translation>Guardar c&amp;omo...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="44"/>
         <source>Save &amp;Image...</source>
-        <translation>Guardar la &amp;Imagen...</translation>
+        <translation>Guardar &amp;imagen...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="65"/>
         <source>3D &amp;Studio...</source>
-        <translation>3D &amp;Studio…</translation>
+        <translation>3D &amp;Studio...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="79"/>
         <source>&amp;HTML...</source>
-        <translation>&amp;HTML…</translation>
+        <translation>&amp;HTML...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="86"/>
         <source>&amp;BrickLink...</source>
-        <translation>&amp;BrickLink…</translation>
+        <translation>&amp;BrickLink...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="93"/>
         <source>&amp;CSV...</source>
-        <translation>&amp;CSV…</translation>
+        <translation>&amp;CSV...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="100"/>
         <source>&amp;POV-Ray...</source>
-        <translation>&amp;POV-Ray…</translation>
+        <translation>&amp;POV-Ray...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="107"/>
         <source>&amp;Wavefront...</source>
-        <translation>&amp;Wavefront…</translation>
+        <translation>&amp;Wavefront...</translation>
     </message>
     <message>
         <source>Select by Col&amp;or...</source>
-        <translation type="vanished">Seleccionar por Col&amp;or...</translation>
+        <translation type="vanished">Seleccionar por col&amp;or...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="296"/>
         <source>Single Selection</source>
-        <translation>Selección Única</translation>
+        <translation>Selección individual</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="303"/>
         <source>Piece Selection</source>
-        <translation>Seleccionar por Pieza</translation>
+        <translation>Selección por pieza</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="310"/>
         <source>Color Selection</source>
-        <translation>Seleccionar por Color</translation>
+        <translation>Selección por color</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="317"/>
         <source>Piece and Color Selection</source>
-        <translation>Pieza y Seleccionar Color</translation>
+        <translation>Selección por pieza y color</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="324"/>
         <source>Relative Transforms</source>
-        <translation>Transformaciones Relativas</translation>
+        <translation>Transformaciones relativas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="366"/>
         <source>Move Snap Enabled</source>
-        <translation>Movimiento por Acople Habilitado</translation>
+        <translation>Ajustar traslaciones a rejilla</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1360"/>
+        <location filename="../common/lc_commands.cpp" line="1353"/>
         <source>Open Selected Model</source>
-        <translation>Abrir Modelo Seleccionado</translation>
+        <translation>Abrir modelo seleccionado</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1374"/>
+        <source>Edit Selected Submodel</source>
+        <translation>Editar submodelo seleccionado</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1381"/>
-        <source>Edit Selected Submodel</source>
-        <translation>Editar Submodelo Seleccionado</translation>
+        <source>End Submodel Editing</source>
+        <translation>Finalizar edición de submodelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1388"/>
-        <source>End Submodel Editing</source>
-        <translation>Cerrar Edición del Submodelo</translation>
+        <location filename="../common/lc_commands.cpp" line="1465"/>
+        <source>New Submodel...</source>
+        <translation>Nuevo submodelo...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1472"/>
-        <source>New Submodel...</source>
-        <translation>Nuevo Submodelo...</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1479"/>
         <source>Prope&amp;rties...</source>
-        <translation>Prop&amp;iedades…</translation>
+        <translation>Prop&amp;iedades...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="128"/>
@@ -1430,7 +1417,7 @@
     <message>
         <location filename="../common/lc_commands.cpp" line="58"/>
         <source>Set &amp;Inventory...</source>
-        <translation>Escoger &amp;Inventario...</translation>
+        <translation>Escoger &amp;inventario...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="72"/>
@@ -1450,11 +1437,11 @@
     <message>
         <location filename="../common/lc_commands.cpp" line="135"/>
         <source>Print Pre&amp;view...</source>
-        <translation>Pre&amp;via de impresión...</translation>
+        <translation>Vista pre&amp;via...</translation>
     </message>
     <message>
         <source>Print &amp;Bill of Materials...</source>
-        <translation type="vanished">Imprimir &amp;lista de materiales…</translation>
+        <translation type="vanished">Imprimir &amp;lista de materiales...</translation>
     </message>
     <message>
         <source>&amp;Recent1</source>
@@ -1509,17 +1496,17 @@
     <message>
         <location filename="../common/lc_commands.cpp" line="226"/>
         <source>Find Ne&amp;xt</source>
-        <translation>Buscar Sig&amp;uiente</translation>
+        <translation>Buscar sig&amp;uiente</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="233"/>
         <source>Find Pre&amp;vious</source>
-        <translation>Buscar Pre&amp;vio</translation>
+        <translation>Buscar an&amp;terior</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="240"/>
         <source>Find All</source>
-        <translation>Encontrar.Todos</translation>
+        <translation>Buscar todo</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="247"/>
@@ -1529,57 +1516,57 @@
     <message>
         <location filename="../common/lc_commands.cpp" line="254"/>
         <source>Replace Next</source>
-        <translation>Reemplazar Siguiente</translation>
+        <translation>Reemplazar siguiente</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="261"/>
         <source>Replace All</source>
-        <translation>Replace Todos</translation>
+        <translation>Reemplazar todo</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="268"/>
         <source>Select &amp;All</source>
-        <translation>Seleccionar &amp;Todo</translation>
+        <translation>Seleccionar &amp;todo</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="275"/>
         <source>Select &amp;None</source>
-        <translation>Seleccionar &amp;Ninguno</translation>
+        <translation>Deseleccionar to&amp;do</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="282"/>
         <source>Select &amp;Invert</source>
-        <translation>&amp;Invertir la Selección</translation>
+        <translation>&amp;Invertir selección</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="289"/>
         <source>Select by Na&amp;me...</source>
-        <translation>Seleccionar por No&amp;mbre…</translation>
+        <translation>Seleccionar por no&amp;mbre...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="331"/>
         <source>Absolute Transforms</source>
-        <translation>Transformaciones Absolutas</translation>
+        <translation>Transformaciones absolutas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="338"/>
         <source>Toggle Relative Transforms</source>
-        <translation>Cambiar Tranformaciones Relativas</translation>
+        <translation>Alternar transformaciones relativas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="345"/>
         <source>Rotate Separately</source>
-        <translation>Rotar Separadamente</translation>
+        <translation>Rotar por separado</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="352"/>
         <source>Rotate Together</source>
-        <translation>Rotar Junto</translation>
+        <translation>Rotar juntas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="359"/>
         <source>Toggle Separate Transforms</source>
-        <translation>Cambiar Tranformaciones Separadas</translation>
+        <translation>Alternar transformaciones individuales</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="373"/>
@@ -1593,146 +1580,146 @@
         <location filename="../common/lc_commands.cpp" line="380"/>
         <location filename="../common/lc_commands.cpp" line="450"/>
         <source>1/20 Stud</source>
-        <translation>1/20 Tetón</translation>
+        <translation>1/20 tetón</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="387"/>
         <location filename="../common/lc_commands.cpp" line="457"/>
         <source>1/4 Stud</source>
-        <translation>1/4 Tetón</translation>
+        <translation>1/4 tetón</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="394"/>
         <location filename="../common/lc_commands.cpp" line="464"/>
         <source>1 Flat</source>
-        <translation>1 Placa</translation>
+        <translation>1 placa</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="401"/>
         <location filename="../common/lc_commands.cpp" line="471"/>
         <source>1/2 Stud</source>
-        <translation>1/2 Tetón</translation>
+        <translation>1/2 tetón</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="408"/>
         <location filename="../common/lc_commands.cpp" line="478"/>
         <source>1 Stud</source>
-        <translation>1 Tetón</translation>
+        <translation>1 tetón</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="415"/>
         <source>2 Studs</source>
-        <translation>2 Tetones</translation>
+        <translation>2 tetones</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="422"/>
         <source>3 Studs</source>
-        <translation>3 Tetones</translation>
+        <translation>3 tetones</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="429"/>
         <source>4 Studs</source>
-        <translation>4 Tetones</translation>
+        <translation>4 tetones</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="436"/>
         <source>8 Studs</source>
-        <translation>8 Tetones</translation>
+        <translation>8 tetones</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="485"/>
         <source>1 Brick</source>
-        <translation>1 Bloque</translation>
+        <translation>1 bloque</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="492"/>
         <source>2 Bricks</source>
-        <translation>2 Bloques</translation>
+        <translation>2 bloques</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="499"/>
         <source>4 Bricks</source>
-        <translation>4 Bloques</translation>
+        <translation>4 bloques</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="506"/>
         <source>8 Bricks</source>
-        <translation>8 Bloques</translation>
+        <translation>8 bloques</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="513"/>
         <source>Rotation Snap Enabled</source>
-        <translation>Rotación por Acople Habilitado</translation>
+        <translation>Ajustar rotaciones a rejilla</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="527"/>
         <source>1 Degree</source>
-        <translation>1 Grado</translation>
+        <translation>1 grado</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="534"/>
         <source>5 Degrees</source>
-        <translation>5 Grados</translation>
+        <translation>5 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="541"/>
         <source>15 Degrees</source>
-        <translation>15 Grados</translation>
+        <translation>15 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="548"/>
         <source>22.5 Degrees</source>
-        <translation>22.5 Grados</translation>
+        <translation>22.5 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="555"/>
         <source>30 Degrees</source>
-        <translation>30 Grados</translation>
+        <translation>30 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="562"/>
         <source>45 Degrees</source>
-        <translation>45 Grados</translation>
+        <translation>45 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="569"/>
         <source>60 Degrees</source>
-        <translation>60 Grados</translation>
+        <translation>60 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="576"/>
         <source>90 Degrees</source>
-        <translation>90 Grados</translation>
+        <translation>90 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="583"/>
         <source>180 Degrees</source>
-        <translation>180 Grados</translation>
+        <translation>180 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="590"/>
         <source>Transform</source>
-        <translation>Transformación</translation>
+        <translation>Transformaciones</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="597"/>
         <source>Absolute Translation</source>
-        <translation>Translación Absoluta</translation>
+        <translation>Traslación absoluta</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="604"/>
         <source>Relative Translation</source>
-        <translation>Translación Relativa</translation>
+        <translation>Traslación relativa</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="611"/>
         <source>Absolute Rotation</source>
-        <translation>Rotación Absoluta</translation>
+        <translation>Rotación absoluta</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="618"/>
         <source>Relative Rotation</source>
-        <translation>Rotación Relativa</translation>
+        <translation>Rotación relativa</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="625"/>
@@ -1782,12 +1769,12 @@
     <message>
         <location filename="../common/lc_commands.cpp" line="688"/>
         <source>Color Picker</source>
-        <translation>Selector de Color</translation>
+        <translation>Selector de color</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="695"/>
         <source>Zoom</source>
-        <translation>Ampliación</translation>
+        <translation>Ampliar</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="702"/>
@@ -1797,27 +1784,27 @@
     <message>
         <location filename="../common/lc_commands.cpp" line="709"/>
         <source>Rotate View</source>
-        <translation>Rotar Vista</translation>
+        <translation>Rotar vista</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="716"/>
         <source>Roll</source>
-        <translation>Pivotar la Vista</translation>
+        <translation>Pivotar vista</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="723"/>
         <source>Zoom Region</source>
-        <translation>Ampliar Región</translation>
+        <translation>Ampliar región</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="730"/>
         <source>Cancel Action</source>
-        <translation>Cancelar Acción</translation>
+        <translation>Cancelar acción</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="737"/>
         <source>P&amp;references...</source>
-        <translation>P&amp;referencias…</translation>
+        <translation>P&amp;referencias...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="744"/>
@@ -1832,42 +1819,42 @@
     <message>
         <location filename="../common/lc_commands.cpp" line="758"/>
         <source>Zoom E&amp;xtents</source>
-        <translation>&amp;Ver Todo</translation>
+        <translation>&amp;Ver todo</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="765"/>
         <source>Look At</source>
-        <translation>Ver el Modelo</translation>
+        <translation>Ver modelo</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="772"/>
         <source>Move Forward</source>
-        <translation>Mover Adelante</translation>
+        <translation>Mover adelante</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="779"/>
         <source>Move Backward</source>
-        <translation>Mover Atrás</translation>
+        <translation>Mover atrás</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="786"/>
         <source>Move Left</source>
-        <translation>Mover Izquierda</translation>
+        <translation>Mover a la izquierda</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="793"/>
         <source>Move Right</source>
-        <translation>Mover Derecha</translation>
+        <translation>Mover a la derecha</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="800"/>
         <source>Move Up</source>
-        <translation>Mover Arriba</translation>
+        <translation>Mover arriba</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="807"/>
         <source>Move Down</source>
-        <translation>Mover Abajo</translation>
+        <translation>Mover abajo</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="814"/>
@@ -1985,579 +1972,578 @@
         <translation>Cámara 16</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="982"/>
         <source>Reset</source>
-        <translation>Reiniciar</translation>
+        <translation type="vanished">Reiniciar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="989"/>
+        <location filename="../common/lc_commands.cpp" line="982"/>
         <source>First</source>
         <translation>Primero</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="996"/>
+        <location filename="../common/lc_commands.cpp" line="989"/>
         <source>Previous</source>
-        <translation>Previo</translation>
+        <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1003"/>
+        <location filename="../common/lc_commands.cpp" line="996"/>
         <source>Next</source>
         <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1010"/>
+        <location filename="../common/lc_commands.cpp" line="1003"/>
         <source>Last</source>
         <translation>Último</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1017"/>
+        <location filename="../common/lc_commands.cpp" line="1010"/>
         <source>Insert Before</source>
-        <translation>Insertar Antes</translation>
+        <translation>Insertar antes</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1017"/>
         <source>Insert After</source>
-        <translation>Insertar Después</translation>
+        <translation>Insertar después</translation>
     </message>
     <message>
         <source>Insert Step</source>
-        <translation type="vanished">Insertar Paso</translation>
+        <translation type="vanished">Insertar paso</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1808"/>
+        <source>Remove Step</source>
+        <translation>Quitar paso</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1031"/>
-        <location filename="../common/lc_commands.cpp" line="1815"/>
-        <source>Remove Step</source>
-        <translation>Quitar Paso</translation>
+        <source>Add Keys</source>
+        <translation>Añadir claves</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1038"/>
-        <source>Add Keys</source>
-        <translation>Añadir Claves</translation>
+        <source>Split &amp;Horizontal</source>
+        <translation>Dividir &amp;horizontalmente</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1045"/>
-        <source>Split &amp;Horizontal</source>
-        <translation>Dividir &amp;Horizontalmente</translation>
+        <source>Split &amp;Vertical</source>
+        <translation>Dividir &amp;verticalmente</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1052"/>
-        <source>Split &amp;Vertical</source>
-        <translation>Dividir &amp;Verticalmente</translation>
+        <source>Re&amp;move View</source>
+        <translation>Qui&amp;tar vista</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1059"/>
-        <source>Re&amp;move View</source>
-        <translation>Qui&amp;tar Vista</translation>
+        <source>Rese&amp;t Views</source>
+        <translation>Reiniciar &amp;vistas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1066"/>
-        <source>Rese&amp;t Views</source>
-        <translation>Resetear &amp;Vistas</translation>
+        <source>Standard</source>
+        <translation>Estándar</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1073"/>
-        <source>Standard</source>
-        <translation>Estandar</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1080"/>
         <source>Tools</source>
         <translation>Herramientas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1087"/>
+        <location filename="../common/lc_commands.cpp" line="1080"/>
         <source>Time</source>
         <translation>Tiempo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1094"/>
+        <location filename="../common/lc_commands.cpp" line="1087"/>
         <source>Parts</source>
         <translation>Piezas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1101"/>
+        <location filename="../common/lc_commands.cpp" line="1094"/>
         <source>Colors</source>
         <translation>Colores</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1108"/>
+        <location filename="../common/lc_commands.cpp" line="1101"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1115"/>
+        <location filename="../common/lc_commands.cpp" line="1108"/>
         <source>Timeline</source>
-        <translation>Línea de Tiempo</translation>
+        <translation>Línea de tiempo</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1115"/>
+        <source>Preview</source>
+        <translation>Vista previa</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1122"/>
-        <source>Preview</source>
-        <translation>Previa</translation>
+        <source>&amp;Full Screen</source>
+        <translation>&amp;Pantalla completa</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1129"/>
-        <source>&amp;Full Screen</source>
-        <translation>&amp;Pantalla Completa</translation>
+        <source>Close &amp;Tab</source>
+        <translation>Cerrar &amp;pestaña</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1136"/>
-        <source>Close &amp;Tab</source>
-        <translation>Cerrar &amp;Pestaña</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1143"/>
         <source>&amp;Wireframe</source>
         <translation>&amp;Malla</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1150"/>
+        <location filename="../common/lc_commands.cpp" line="1143"/>
         <source>&amp;Flat Shading</source>
-        <translation>&amp;Sombreado Plano</translation>
+        <translation>&amp;Sombreado plano</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1150"/>
+        <source>&amp;Default Lights</source>
+        <translation>&amp;Luces predeterminadas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1157"/>
-        <source>&amp;Default Lights</source>
-        <translation>&amp;Luces por Defecto</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1164"/>
         <source>&amp;Perspective</source>
         <translation>&amp;Perspectiva</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1171"/>
+        <location filename="../common/lc_commands.cpp" line="1164"/>
         <source>&amp;Orthographic</source>
-        <translation>&amp;Ortográfico</translation>
+        <translation>&amp;Ortográfica</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1171"/>
+        <source>View Sphere</source>
+        <translation>Ver esfera</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1178"/>
-        <source>View Sphere</source>
-        <translation>Ver Esfera</translation>
+        <source>Axis Icon</source>
+        <translation>Icono de ejes</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1185"/>
-        <source>Axis Icon</source>
-        <translation>Icono de los Ejes</translation>
+        <source>Base Grid</source>
+        <translation>Cuadrícula base</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1192"/>
-        <source>Base Grid</source>
-        <translation>Malla Base</translation>
+        <source>Fade Previous Steps</source>
+        <translation>Atenuar pasos previos</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1199"/>
-        <source>Fade Previous Steps</source>
-        <translation>Desvanecer Pasos Previos</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1206"/>
         <source>&amp;Insert</source>
         <translation>&amp;Insertar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1213"/>
+        <location filename="../common/lc_commands.cpp" line="1206"/>
         <source>&amp;Delete</source>
         <translation>&amp;Borrar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1220"/>
+        <location filename="../common/lc_commands.cpp" line="1213"/>
         <source>&amp;Duplicate</source>
         <translation>&amp;Duplicar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1227"/>
+        <location filename="../common/lc_commands.cpp" line="1220"/>
         <source>&amp;Paint Selected</source>
-        <translation>&amp;Pintar Seleccionado</translation>
+        <translation>&amp;Pintar selección</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1227"/>
+        <source>Reset &amp;Pivot Point</source>
+        <translation>Reiniciar &amp;punto de pivote</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1234"/>
-        <source>Reset &amp;Pivot Point</source>
-        <translation>Reiniciar el &amp;Punto de Pivote</translation>
+        <source>Remove &amp;Key Frames</source>
+        <translation>Quitar &amp;fotogramas clave</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1241"/>
-        <source>Remove &amp;Key Frames</source>
-        <translation>Quitar &amp;Fotogramas Clave</translation>
+        <source>Insert Control Point</source>
+        <translation>Insertar punto de control</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1248"/>
-        <source>Insert Control Point</source>
-        <translation>Insertar un Punto de Control</translation>
+        <source>Remove Control Point</source>
+        <translation>Quitar punto de control</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1255"/>
-        <source>Remove Control Point</source>
-        <translation>Quitar el Punto de Control</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1262"/>
         <source>Move +X</source>
         <translation>Mover +X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1269"/>
+        <location filename="../common/lc_commands.cpp" line="1262"/>
         <source>Move -X</source>
         <translation>Mover -X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1276"/>
+        <location filename="../common/lc_commands.cpp" line="1269"/>
         <source>Move +Y</source>
         <translation>Mover +Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1283"/>
+        <location filename="../common/lc_commands.cpp" line="1276"/>
         <source>Move -Y</source>
         <translation>Mover -Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1290"/>
+        <location filename="../common/lc_commands.cpp" line="1283"/>
         <source>Move +Z</source>
         <translation>Mover +Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1297"/>
+        <location filename="../common/lc_commands.cpp" line="1290"/>
         <source>Move -Z</source>
         <translation>Mover -Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1304"/>
+        <location filename="../common/lc_commands.cpp" line="1297"/>
         <source>Rotate +X</source>
         <translation>Rotar +X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1311"/>
+        <location filename="../common/lc_commands.cpp" line="1304"/>
         <source>Rotate -X</source>
         <translation>Rotar -X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1318"/>
+        <location filename="../common/lc_commands.cpp" line="1311"/>
         <source>Rotate +Y</source>
         <translation>Rotar +Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1325"/>
+        <location filename="../common/lc_commands.cpp" line="1318"/>
         <source>Rotate -Y</source>
         <translation>Rotar -Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1332"/>
+        <location filename="../common/lc_commands.cpp" line="1325"/>
         <source>Rotate +Z</source>
         <translation>Rotar +Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1339"/>
+        <location filename="../common/lc_commands.cpp" line="1332"/>
         <source>Rotate -Z</source>
         <translation>Rotar -Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1346"/>
+        <location filename="../common/lc_commands.cpp" line="1339"/>
         <source>Minifig &amp;Wizard...</source>
-        <translation>&amp;Asistente de Minifig…</translation>
+        <translation>&amp;Asistente de Minifig...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1353"/>
+        <location filename="../common/lc_commands.cpp" line="1346"/>
         <source>A&amp;rray...</source>
-        <translation>&amp;Conjunto…</translation>
+        <translation>&amp;Secuencia...</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1360"/>
+        <source>Move to New Model...</source>
+        <translation>Mover a modelo nuevo...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1367"/>
-        <source>Move to New Model...</source>
-        <translation>Mover al Nuevo Modelo…</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1374"/>
         <source>Inline Selected Models</source>
-        <translation>Fusionar los Modelos Seleccionados</translation>
+        <translation>Fusionar modelos seleccionados</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1395"/>
+        <location filename="../common/lc_commands.cpp" line="1388"/>
         <source>&amp;Group...</source>
         <translation>&amp;Agrupar...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1402"/>
+        <location filename="../common/lc_commands.cpp" line="1395"/>
         <source>&amp;Ungroup</source>
         <translation>&amp;Desagrupar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1409"/>
+        <location filename="../common/lc_commands.cpp" line="1402"/>
         <source>&amp;Add to Group</source>
-        <translation>&amp;Añadir al Grupo</translation>
+        <translation>&amp;Añadir a grupo</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1409"/>
+        <source>Re&amp;move from Group</source>
+        <translation>Qui&amp;tar del grupo</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1416"/>
-        <source>Re&amp;move from Group</source>
-        <translation>Qui&amp;tar del Grupo</translation>
+        <source>&amp;Edit Groups...</source>
+        <translation>&amp;Editar grupos...</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1423"/>
-        <source>&amp;Edit Groups...</source>
-        <translation>&amp;Editar Grupos…</translation>
+        <source>&amp;Hide Selected</source>
+        <translation>&amp;Ocultar seleccionadas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1430"/>
-        <source>&amp;Hide Selected</source>
-        <translation>&amp;Ocultar la Selección</translation>
+        <source>Hide &amp;Unselected</source>
+        <translation>Ocultar no &amp;seleccionadas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1437"/>
-        <source>Hide &amp;Unselected</source>
-        <translation>Ocultar los no &amp;Seleccionados</translation>
+        <source>&amp;Unhide Selected</source>
+        <translation>&amp;Mostrar seleccionadas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1444"/>
-        <source>&amp;Unhide Selected</source>
-        <translation>&amp;Mostrar los Seleccionados</translation>
+        <source>U&amp;nhide All</source>
+        <translation>Mostrar &amp;todas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1451"/>
-        <source>U&amp;nhide All</source>
-        <translation>Mostrar &amp;Todo</translation>
+        <source>Show Earlier</source>
+        <translation>Mostrar en paso anterior</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1458"/>
-        <source>Show Earlier</source>
-        <translation>Mostrar Anterior</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1465"/>
         <source>Show Later</source>
-        <translation>Mostrar Posterior</translation>
+        <translation>Mostrar en paso siguiente</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1486"/>
+        <location filename="../common/lc_commands.cpp" line="1479"/>
         <source>Submodels...</source>
         <translation>Submodelos...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1493"/>
+        <location filename="../common/lc_commands.cpp" line="1486"/>
         <source>Model 1</source>
         <translation>Modelo 1</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1500"/>
+        <location filename="../common/lc_commands.cpp" line="1493"/>
         <source>Model 2</source>
         <translation>Modelo 2</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1507"/>
+        <location filename="../common/lc_commands.cpp" line="1500"/>
         <source>Model 3</source>
         <translation>Modelo 3</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1514"/>
+        <location filename="../common/lc_commands.cpp" line="1507"/>
         <source>Model 4</source>
         <translation>Modelo 4</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1521"/>
+        <location filename="../common/lc_commands.cpp" line="1514"/>
         <source>Model 5</source>
         <translation>Modelo 5</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1528"/>
+        <location filename="../common/lc_commands.cpp" line="1521"/>
         <source>Model 6</source>
         <translation>Modelo 6</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1535"/>
+        <location filename="../common/lc_commands.cpp" line="1528"/>
         <source>Model 7</source>
         <translation>Modelo 7</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1542"/>
+        <location filename="../common/lc_commands.cpp" line="1535"/>
         <source>Model 8</source>
         <translation>Modelo 8</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1549"/>
+        <location filename="../common/lc_commands.cpp" line="1542"/>
         <source>Model 9</source>
         <translation>Modelo 9</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1556"/>
+        <location filename="../common/lc_commands.cpp" line="1549"/>
         <source>Model 10</source>
         <translation>Modelo 10</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1563"/>
+        <location filename="../common/lc_commands.cpp" line="1556"/>
         <source>Model 11</source>
         <translation>Modelo 11</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1570"/>
+        <location filename="../common/lc_commands.cpp" line="1563"/>
         <source>Model 12</source>
         <translation>Modelo 12</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1577"/>
+        <location filename="../common/lc_commands.cpp" line="1570"/>
         <source>Model 13</source>
         <translation>Modelo 13</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1584"/>
+        <location filename="../common/lc_commands.cpp" line="1577"/>
         <source>Model 14</source>
         <translation>Modelo 14</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1591"/>
+        <location filename="../common/lc_commands.cpp" line="1584"/>
         <source>Model 15</source>
         <translation>Modelo 15</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1598"/>
+        <location filename="../common/lc_commands.cpp" line="1591"/>
         <source>Model 16</source>
         <translation>Modelo 16</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1605"/>
+        <location filename="../common/lc_commands.cpp" line="1598"/>
         <source>Model 17</source>
         <translation>Modelo 17</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1612"/>
+        <location filename="../common/lc_commands.cpp" line="1605"/>
         <source>Model 18</source>
         <translation>Modelo 18</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1619"/>
+        <location filename="../common/lc_commands.cpp" line="1612"/>
         <source>Model 19</source>
         <translation>Modelo 19</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1626"/>
+        <location filename="../common/lc_commands.cpp" line="1619"/>
         <source>Model 20</source>
         <translation>Modelo 20</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1633"/>
+        <location filename="../common/lc_commands.cpp" line="1626"/>
         <source>Model 21</source>
         <translation>Modelo 21</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1640"/>
+        <location filename="../common/lc_commands.cpp" line="1633"/>
         <source>Model 22</source>
         <translation>Modelo 22</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1647"/>
+        <location filename="../common/lc_commands.cpp" line="1640"/>
         <source>Model 23</source>
         <translation>Modelo 23</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1654"/>
+        <location filename="../common/lc_commands.cpp" line="1647"/>
         <source>Model 24</source>
         <translation>Modelo 24</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1661"/>
+        <location filename="../common/lc_commands.cpp" line="1654"/>
         <source>Model 25</source>
         <translation>Modelo 25</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1668"/>
+        <location filename="../common/lc_commands.cpp" line="1661"/>
         <source>Model 26</source>
         <translation>Modelo 26</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1675"/>
+        <location filename="../common/lc_commands.cpp" line="1668"/>
         <source>Model 27</source>
         <translation>Modelo 27</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1682"/>
+        <location filename="../common/lc_commands.cpp" line="1675"/>
         <source>Model 28</source>
         <translation>Modelo 28</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1689"/>
+        <location filename="../common/lc_commands.cpp" line="1682"/>
         <source>Model 29</source>
         <translation>Modelo 29</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1696"/>
+        <location filename="../common/lc_commands.cpp" line="1689"/>
         <source>Model 30</source>
         <translation>Modelo 30</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1703"/>
+        <location filename="../common/lc_commands.cpp" line="1696"/>
         <source>Model 31</source>
         <translation>Modelo 31</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1710"/>
+        <location filename="../common/lc_commands.cpp" line="1703"/>
         <source>Model 32</source>
         <translation>Modelo 32</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1717"/>
+        <location filename="../common/lc_commands.cpp" line="1710"/>
         <source>Model 33</source>
         <translation>Modelo 33</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1724"/>
+        <location filename="../common/lc_commands.cpp" line="1717"/>
         <source>Model 34</source>
         <translation>Modelo 34</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1731"/>
+        <location filename="../common/lc_commands.cpp" line="1724"/>
         <source>Model 35</source>
         <translation>Modelo 35</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1738"/>
+        <location filename="../common/lc_commands.cpp" line="1731"/>
         <source>Model 36</source>
         <translation>Modelo 36</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1745"/>
+        <location filename="../common/lc_commands.cpp" line="1738"/>
         <source>Model 37</source>
         <translation>Modelo 37</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1752"/>
+        <location filename="../common/lc_commands.cpp" line="1745"/>
         <source>Model 38</source>
         <translation>Modelo 38</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1759"/>
+        <location filename="../common/lc_commands.cpp" line="1752"/>
         <source>Model 39</source>
         <translation>Modelo 39</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1766"/>
+        <location filename="../common/lc_commands.cpp" line="1759"/>
         <source>Model 40</source>
         <translation>Modelo 40</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1780"/>
+        <location filename="../common/lc_commands.cpp" line="1773"/>
         <source>Report a Bug</source>
-        <translation>Reportar un Error</translation>
+        <translation>Reportar un error</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1794"/>
+        <source>Insert Step Before</source>
+        <translation>Insertar paso antes</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1801"/>
-        <source>Insert Step Before</source>
-        <translation>Insertar Paso Antes</translation>
+        <source>Insert Step After</source>
+        <translation>Insertar paso después</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1808"/>
-        <source>Insert Step After</source>
-        <translation>Insertar Paso Despues</translation>
+        <location filename="../common/lc_commands.cpp" line="1815"/>
+        <source>Move Selection Here</source>
+        <translation>Mover selección aquí</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1822"/>
-        <source>Move Selection Here</source>
-        <translation>Mover la Selección Aquí</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1829"/>
         <source>Set Current Step</source>
-        <translation>Escoger el Paso Actual</translation>
+        <translation>Usar como paso actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1773"/>
+        <location filename="../common/lc_commands.cpp" line="1766"/>
         <source>LeoCAD &amp;Home Page</source>
-        <translation>&amp;Pagina Principal de LeoCAD</translation>
+        <translation>&amp;Pagina principal de LeoCAD</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="142"/>
@@ -2582,7 +2568,7 @@
     <message>
         <location filename="../common/lc_commands.cpp" line="212"/>
         <source>Paste with Steps</source>
-        <translation>Pegar con Pasos</translation>
+        <translation>Pegar con pasos</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="219"/>
@@ -2590,12 +2576,12 @@
         <translation>&amp;Buscar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1787"/>
+        <location filename="../common/lc_commands.cpp" line="1780"/>
         <source>Check for &amp;Updates...</source>
-        <translation>&amp;Verificar Actualizaciones…</translation>
+        <translation>&amp;Comprobar actualizaciones...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1794"/>
+        <location filename="../common/lc_commands.cpp" line="1787"/>
         <source>&amp;About...</source>
         <translation>&amp;Acerca de...</translation>
     </message>
@@ -2603,282 +2589,280 @@
 <context>
     <name>Mouse</name>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1839"/>
+        <location filename="../common/lc_commands.cpp" line="1832"/>
         <source>NewPiece</source>
-        <translation>NuevaPieza</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1840"/>
+        <location filename="../common/lc_commands.cpp" line="1833"/>
         <source>NewPointLight</source>
-        <translation>NuevoPuntodeLuz</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1841"/>
+        <location filename="../common/lc_commands.cpp" line="1834"/>
         <source>NewSpotLight</source>
-        <translation>NuevoFoco</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1842"/>
+        <location filename="../common/lc_commands.cpp" line="1835"/>
         <source>NewCamera</source>
-        <translation>NuevaCámara</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1843"/>
+        <location filename="../common/lc_commands.cpp" line="1836"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1844"/>
+        <location filename="../common/lc_commands.cpp" line="1837"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1845"/>
+        <location filename="../common/lc_commands.cpp" line="1838"/>
         <source>Rotate</source>
         <translation>Rotar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1846"/>
+        <location filename="../common/lc_commands.cpp" line="1839"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1847"/>
+        <location filename="../common/lc_commands.cpp" line="1840"/>
         <source>Paint</source>
         <translation>Pintar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1848"/>
+        <location filename="../common/lc_commands.cpp" line="1841"/>
         <source>ColorPicker</source>
-        <translation>Selector de Color</translation>
+        <translation>Selector de color</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1849"/>
+        <location filename="../common/lc_commands.cpp" line="1842"/>
         <source>Zoom</source>
         <translation>Ampliación</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1850"/>
+        <location filename="../common/lc_commands.cpp" line="1843"/>
         <source>Pan</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1851"/>
+        <location filename="../common/lc_commands.cpp" line="1844"/>
         <source>Orbit</source>
         <translation>Orbitar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1852"/>
+        <location filename="../common/lc_commands.cpp" line="1845"/>
         <source>Roll</source>
-        <translation>Pivotar la Vista</translation>
+        <translation>Pivotar la vista</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1853"/>
+        <location filename="../common/lc_commands.cpp" line="1846"/>
         <source>ZoomRegion</source>
-        <translation>AmpliarRegión</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Project</name>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>Empty Name</source>
-        <translation>Nombre Vacío</translation>
+        <translation>Nombre vacío</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
-        <location filename="../common/project.cpp" line="449"/>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="378"/>
+        <location filename="../common/project.cpp" line="457"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
+        <location filename="../common/project.cpp" line="378"/>
         <source>Error reading file &apos;%1&apos;:
 %2</source>
-        <translation>Error leyendo fichero &apos;%1&apos;:
+        <translation>Error leyendo archivo &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="449"/>
+        <location filename="../common/project.cpp" line="457"/>
         <source>Error loading file &apos;%1&apos;:
 File format is not recognized.</source>
-        <translation>Error cargando fichero &apos;%1&apos;:
-Formato de fichero no reconocido.</translation>
+        <translation>Error cargando archivo &apos;%1&apos;:
+Formato de archivo no reconocido.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="544"/>
+        <location filename="../common/project.cpp" line="552"/>
         <source>Merged </source>
         <translation>Fusionado </translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
-        <location filename="../common/project.cpp" line="2060"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
+        <location filename="../common/project.cpp" line="2025"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="2060"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="2025"/>
         <source>Nothing to export.</source>
-        <translation>Nada para Exportar.</translation>
+        <translation>Nada que exportar.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>Export 3D Studio</source>
         <translation>Exportar a 3D Studio</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>3DS Files (*.3ds);;All Files (*.*)</source>
-        <translation>Archivos 3DS (*.3ds);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos 3DS (*.3ds);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>Could not open file &apos;%1&apos; for writing.</source>
-        <translation>No se pudo abrir el archivo « %1 » para guardar.</translation>
+        <translation>No se pudo abrir el archivo &apos;%1&apos; para escritura.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>Export BrickLink</source>
         <translation>Exportar a BrickLink</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>XML Files (*.xml);;All Files (*.*)</source>
-        <translation>Archivos XML (*.xml);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos XML (*.xml);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>Export COLLADA</source>
         <translation>Exportar COLLADA</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>COLLADA Files (*.dae);;All Files (*.*)</source>
-        <translation>Archivos COLLADA (*.dae);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos COLLADA (*.dae);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>Export CSV</source>
         <translation>Exportar a CSV</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>CSV Files (*.csv);;All Files (*.*)</source>
-        <translation>Archivos CSV (*.csv);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos CSV (*.csv);;Todos los archivos (*.*)</translation>
     </message>
     <message>
         <source>Error creating images.</source>
         <translation type="vanished">Error creando imágenes.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>Export POV-Ray</source>
         <translation>Exportar a POV-Ray</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>POV-Ray Files (*.pov);;All Files (*.*)</source>
-        <translation>Archivos POV-Ray (*.pov);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos POV-Ray (*.pov);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
         <source>Could not find LGEO files in folder &apos;%1&apos;.</source>
-        <translation>No se pudo encontrar los archivos LGEO en la carpeta « %1 ».</translation>
+        <translation>No se pudo encontrar los archivos LGEO en la carpeta &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Export Wavefront</source>
         <translation>Exportar a Wavefront</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Wavefront Files (*.obj);;All Files (*.*)</source>
         <translation>Archivos Wavefront (*.obj);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
-        <translation>Error guardando el archivo « %1 » :
+        <translation>Error escribiendo el archivo &apos;%1&apos; :
 %2</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.ldr</source>
-        <translation>Nuevo Modelo.ldr</translation>
+        <translation>Nuevo modelo.ldr</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.mpd</source>
-        <translation>Nuevo Modelo.mpd</translation>
+        <translation>Nuevo modelo.mpd</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="177"/>
+        <location filename="../common/project.cpp" line="178"/>
         <source>Submodel #</source>
         <translation>Submodelo #</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="201"/>
+        <location filename="../common/project.cpp" line="202"/>
         <source>Submodel Name:</source>
-        <translation>Nombre del Submodelo:</translation>
+        <translation>Nombre de submodelo:</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>The submodel name cannot be empty.</source>
         <translation>El nombre del submodelo no puede estar vacío.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>Duplicate Submodel</source>
-        <translation>Duplicar Submodelo</translation>
+        <translation>Duplicar submodelo</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>A submodel named &apos;%1&apos; already exists, please enter a unique name.</source>
-        <translation>Un submodelo llamado &apos;%1&apos; ya existe, por favor ponga un nombre único.</translation>
+        <translation>Ya existe un submodelo llamado &apos;%1&apos;. Por favor, utiliza otro nombre.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="245"/>
+        <location filename="../common/project.cpp" line="246"/>
         <source>New Submodel</source>
-        <translation>Nuevo Submodelo</translation>
+        <translation>Nuevo submodelo</translation>
     </message>
 </context>
 <context>
@@ -2886,37 +2870,37 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/group.cpp" line="43"/>
         <source>Group #</source>
-        <translation>Grupo n°</translation>
+        <translation>Grupo #</translation>
     </message>
     <message>
         <source>Solid Colors</source>
         <comment>Colors</comment>
-        <translation type="vanished">Colores Sólidos</translation>
+        <translation type="vanished">Colores sólidos</translation>
     </message>
     <message>
         <source>Translucent Colors</source>
         <comment>Colors</comment>
-        <translation type="vanished">Colores Translúcidos</translation>
+        <translation type="vanished">Colores translúcidos</translation>
     </message>
     <message>
         <source>Special Colors</source>
         <comment>Colors</comment>
-        <translation type="vanished">Colores Especiales</translation>
+        <translation type="vanished">Colores especiales</translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="507"/>
+        <location filename="../common/lc_colors.cpp" line="318"/>
         <source>Solid</source>
         <comment>Colors</comment>
-        <translation>Solido</translation>
+        <translation>Sólido</translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="508"/>
+        <location filename="../common/lc_colors.cpp" line="319"/>
         <source>Translucent</source>
         <comment>Colors</comment>
-        <translation>Translucido</translation>
+        <translation>Translúcido</translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="509"/>
+        <location filename="../common/lc_colors.cpp" line="320"/>
         <source>Special</source>
         <comment>Colors</comment>
         <translation>Especial</translation>
@@ -2925,14 +2909,25 @@ Formato de fichero no reconocido.</translation>
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
         <source>Error</source>
-        <translation>Error</translation>
+        <translation type="vanished">Error</translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
         <source>Failed to load &apos;%1&apos;.</source>
-        <translation>Fallo al cargar &apos;%1&apos;.</translation>
+        <translation type="vanished">Fallo al cargar &apos;%1&apos;.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>LeoCAD</source>
+        <translation>LeoCAD</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>Could not open file &apos;%1&apos; for writing.</source>
+        <translation>No se pudo abrir el archivo &apos;%1&apos; para escritura.</translation>
     </message>
 </context>
 <context>
@@ -2940,21 +2935,21 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="45"/>
         <source>Save a picture of the current view</source>
-        <translation>Guardar una imagen de la vista actual</translation>
+        <translation>Guarda una imagen de la vista actual</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="87"/>
         <source>Export a list of parts used in BrickLink XML format</source>
-        <translation>Exportar una lista de las piezas usadas en formato XML de BrickLink</translation>
+        <translation>Exporta una lista de las piezas usadas en formato XML de BrickLink</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="94"/>
         <source>Export a list of parts used in comma delimited file format</source>
-        <translation>Exportar una lista de las piezas usadas en formato de coma delimitada</translation>
+        <translation>Exporta una lista de las piezas usadas en formato delimitado por comas</translation>
     </message>
     <message>
         <source>Print a list of parts used</source>
-        <translation type="vanished">Imprimir una lista de piezas usadas</translation>
+        <translation type="vanished">Imprime una lista de piezas usadas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="178"/>
@@ -2982,11 +2977,11 @@ Formato de fichero no reconocido.</translation>
     </message>
     <message>
         <source>Find object</source>
-        <translation type="vanished">Buscar objecto</translation>
+        <translation type="vanished">Buscar un objeto</translation>
     </message>
     <message>
         <source>Find next object</source>
-        <translation type="vanished">Buscar el siguiente objecto</translation>
+        <translation type="vanished">Buscar el siguiente objeto</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="276"/>
@@ -2996,137 +2991,137 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="283"/>
         <source>Invert the current selection set</source>
-        <translation>Invertir el conjunto de selección actual</translation>
+        <translation>Invertir la selección actual</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="290"/>
         <source>Select objects by name</source>
-        <translation>Seleccionar objetos por su nombre</translation>
+        <translation>Seleccionar objetos por nombre</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="367"/>
         <source>Toggle snap axes</source>
-        <translation>Cambiar los ejes de acoplado</translation>
+        <translation>Alternar el ajuste a la rejilla para traslaciones</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="514"/>
         <source>Snap rotations to fixed intervals</source>
-        <translation>Acoplar rotaciones a intervalos fijos</translation>
+        <translation>Ajustar rotaciones a intervalos fijos</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="374"/>
         <source>Do not snap movement along the XY plane</source>
-        <translation>No acoplar el movimiento a lo largo del plano XY</translation>
+        <translation>No ajustar traslaciones en el plano XY</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="381"/>
         <source>Snap movement along the XY plane to 1/20 stud</source>
-        <translation>Acoplar el movimiento a lo largo del plano XY al Tetón de 1/20</translation>
+        <translation>Ajustar 1/20 tetón las traslaciones en el plano XY</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="388"/>
         <source>Snap movement along the XY plane to 1/4 stud</source>
-        <translation>Acoplar el movimiento a lo largo del plano XY al Tetón de 1/4</translation>
+        <translation>Ajustar 1/4 tetón las traslaciones en el plano XY</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="395"/>
         <source>Snap movement along the XY plane to 1 flat</source>
-        <translation>Acoplar el movimiento a lo largo del plano XY a la placa 1</translation>
+        <translation>Ajustar 1 placa las traslaciones en el plano XY</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="402"/>
         <source>Snap movement along the XY plane to 1/2 stud</source>
-        <translation>Acoplar el movimiento a lo largo del plano XY al Tetón de 1/2</translation>
+        <translation>Ajustar 1/2 tetón las traslaciones en el plano XY</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="409"/>
         <source>Snap movement along the XY plane to 1 stud</source>
-        <translation>Acoplar el movimiento a lo largo del plano XY al Tetón de 1</translation>
+        <translation>Ajustar 1 tetón las traslaciones en el plano XY</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="416"/>
         <source>Snap movement along the XY plane to 2 studs</source>
-        <translation>Acoplar el movimiento a lo largo del plano XY al Tetón de 2</translation>
+        <translation>Ajustar 2 tetones las traslaciones en el plano XY</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="423"/>
         <source>Snap movement along the XY plane to 3 studs</source>
-        <translation>Acoplar el movimiento a lo largo del plano XY al Tetón de 3</translation>
+        <translation>Ajustar 3 tetones las traslaciones en el plano XY</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="430"/>
         <source>Snap movement along the XY plane to 4 studs</source>
-        <translation>Acoplar el movimiento a lo largo del plano XY al Tetón de 4</translation>
+        <translation>Ajustar 4 tetones las traslaciones en el plano XY</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="437"/>
         <source>Snap movement along the XY plane to 8 studs</source>
-        <translation>Acoplar el movimiento a lo largo del plano XY al Tetón de 8</translation>
+        <translation>Ajustar 8 tetones las traslaciones en el plano XY</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="444"/>
         <source>Do not snap movement along the Z axis</source>
-        <translation>No acoplar el movimiento a lo largo del eje Z</translation>
+        <translation>No ajustar traslaciones en el eje Z</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="451"/>
         <source>Snap movement along the Z axis to 1/20 stud</source>
-        <translation>Acoplar el movimiento a lo largo del eje Z al Tetón de 1/20</translation>
+        <translation>Ajustar 1/20 tetón las traslaciones en el eje Z</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="458"/>
         <source>Snap movement along the Z axis to 1/4 stud</source>
-        <translation>Acoplar el movimiento a lo largo del eje Z al Tetón de 1/4</translation>
+        <translation>Ajustar 1/4 tetón las traslaciones en el eje Z</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="465"/>
         <source>Snap movement along the Z axis to 1 flat</source>
-        <translation>Acoplar el movimiento a lo largo del eje Z a la placa de 1</translation>
+        <translation>Ajustar 1 placa las traslaciones en el eje Z</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="472"/>
         <source>Snap movement along the Z axis to 1/2 stud</source>
-        <translation>Acoplar el movimiento a lo largo del eje Z al Tetón de 1/2</translation>
+        <translation>Ajustar 1/2 tetón las traslaciones en el eje Z</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="479"/>
         <source>Snap movement along the Z axis to 1 stud</source>
-        <translation>Acoplar el movimiento a lo largo del eje Z al Tetón de 1</translation>
+        <translation>Ajustar 1 tetón las traslaciones en el eje Z</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="486"/>
         <source>Snap movement along the Z axis to 1 brick</source>
-        <translation>Acoplar el movimiento a lo largo del eje Z al Bloque de 1</translation>
+        <translation>Ajustar 1 bloque las traslaciones en el eje Z</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="493"/>
         <source>Snap movement along the Z axis to 2 bricks</source>
-        <translation>Acoplar el movimiento a lo largo del eje Z al Bloque de 2</translation>
+        <translation>Ajustar 2 bloques las traslaciones en el eje Z</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="500"/>
         <source>Snap movement along the Z axis to 4 bricks</source>
-        <translation>Acoplar el movimiento a lo largo del eje Z al Bloque de 4</translation>
+        <translation>Ajustar 4 bloques las traslaciones en el eje Z</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="507"/>
         <source>Snap movement along the Z axis to 8 bricks</source>
-        <translation>Acoplar el movimiento a lo largo del eje Z al Bloque de 8</translation>
+        <translation>Ajustar 8 bloques las traslaciones en el eje Z</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="521"/>
         <source>Do not snap rotations</source>
-        <translation>No acoplar rotaciones</translation>
+        <translation>No ajustar rotaciones</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="528"/>
         <source>Snap rotations to 1 degree</source>
-        <translation>Acoplar rotaciones a 1 grado</translation>
+        <translation>Ajustar rotaciones a 1 grado</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="535"/>
         <source>Snap rotations to 5 degrees</source>
-        <translation>Acoplar rotaciones a 5 grados</translation>
+        <translation>Ajustar rotaciones a 5 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="10"/>
@@ -3156,7 +3151,7 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="52"/>
         <source>Import a file in LEGO Digital Designer LXF format</source>
-        <translation>Importar un archivo de LEGO-Digital Designer formato LXF</translation>
+        <translation>Importar un archivo en formato LXF de LEGO-Digital Designer</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="59"/>
@@ -3166,12 +3161,12 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="66"/>
         <source>Export the current model in 3D Studio 3DS format</source>
-        <translation>Exportar el modelo actual en formato 3D Studio Formato 3DS</translation>
+        <translation>Exportar el modelo actual en formato 3DS de 3D Studio</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="73"/>
         <source>Export the current model in COLLADA DAE format</source>
-        <translation>Exportar el modelo actual en formato COLLADA Formato DAE</translation>
+        <translation>Exportar el modelo actual en formato DAE de COLLADA</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="80"/>
@@ -3186,7 +3181,7 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="108"/>
         <source>Export the current model in Wavefront OBJ format</source>
-        <translation>Exportar el modelo actual en formato Wavefront Formato OBJ</translation>
+        <translation>Exportar el modelo actual en formato OBJ de Wavefront</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="115"/>
@@ -3201,7 +3196,7 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="136"/>
         <source>Display how the model would look if printed</source>
-        <translation>Mostrar como ser veria el modelo imprimido</translation>
+        <translation>Mostrar cómo ser vería el modelo imprimido</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="143"/>
@@ -3214,7 +3209,7 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="171"/>
         <source>Quit the application; prompts to save model</source>
-        <translation>Salir del programa; notificacion para guardar el modelo</translation>
+        <translation>Salir del programa; notificación para guardar el modelo</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="269"/>
@@ -3228,7 +3223,7 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="297"/>
         <source>Select one piece at a time</source>
-        <translation>Seleccionar una pieza a la vez</translation>
+        <translation>Seleccionar piezas de una en una</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="304"/>
@@ -3248,7 +3243,7 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="325"/>
         <source>Move and rotate objects relative to the one that has focus</source>
-        <translation>Mover y rotar objectos relativos al que tiene el foco</translation>
+        <translation>Mover y rotar objetos relativos al que tiene el foco</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="332"/>
@@ -3258,17 +3253,17 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="339"/>
         <source>Toggle moving and rotating objects relative to the one that has focus</source>
-        <translation>Cambiar mover y rotar objetos relativos al que tiene el foco</translation>
+        <translation>Alternar mover y rotar objetos relativos al que tiene el foco</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="346"/>
         <source>Rotate selected pieces separately</source>
-        <translation>Rotar piezas seleccionadas separadamente</translation>
+        <translation>Rotar cada pieza seleccionada individualmente</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="353"/>
         <source>Rotate selected pieces together</source>
-        <translation>Rotar piezas seleccionadas juntas</translation>
+        <translation>Rotar piezas seleccionadas como si fueran una sola</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="360"/>
@@ -3278,52 +3273,52 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="542"/>
         <source>Snap rotations to 15 degrees</source>
-        <translation>Acoplar rotaciones a 15 grados</translation>
+        <translation>Ajustar rotaciones a 15 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="549"/>
         <source>Snap rotations to 22.5 degrees</source>
-        <translation>Acoplar rotaciones a 22.5 grados</translation>
+        <translation>Ajustar rotaciones a 22.5 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="556"/>
         <source>Snap rotations to 30 degrees</source>
-        <translation>Acoplar rotaciones a 30 grados</translation>
+        <translation>Ajustar rotaciones a 30 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="563"/>
         <source>Snap rotations to 45 degrees</source>
-        <translation>Acoplar rotaciones a 45 grados</translation>
+        <translation>Ajustar rotaciones a 45 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="570"/>
         <source>Snap rotations to 60 degrees</source>
-        <translation>Acoplar rotaciones a 60 grados</translation>
+        <translation>Ajustar rotaciones a 60 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="577"/>
         <source>Snap rotations to 90 degrees</source>
-        <translation>Acoplar rotaciones a 90 grados</translation>
+        <translation>Ajustar rotaciones a 90 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="584"/>
         <source>Snap rotations to 180 degrees</source>
-        <translation>Acoplar rotaciones a 180 grados</translation>
+        <translation>Ajustar rotaciones a 180 grados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="591"/>
         <source>Apply transform to selected objects</source>
-        <translation>Aplicar tranformaciones a los objetos seleccionados</translation>
+        <translation>Aplicar transformaciones a los objetos seleccionados</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="598"/>
         <source>Switch to absolute translation mode when applying transforms</source>
-        <translation>Cambiar al modo de translación absoluta cuando se apliquen transformaciones</translation>
+        <translation>Cambiar al modo de traslación absoluta cuando se apliquen transformaciones</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="605"/>
         <source>Switch to relative translation mode when applying transforms</source>
-        <translation>Cambiar al modo de translación relativa cuando se apliquen transformaciones</translation>
+        <translation>Cambiar al modo de traslación relativa cuando se apliquen transformaciones</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="612"/>
@@ -3358,7 +3353,7 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="654"/>
         <source>Select objects (hold the CTRL key down or drag the mouse to select multiple objects)</source>
-        <translation>Seleccionar objetos (mantener pulsado Ctrl o arrastrar el ratón para seleccionar multiples objetos)</translation>
+        <translation>Seleccionar objetos (mantener pulsado Ctrl o arrastrar el ratón para seleccionar múltiples objetos)</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="661"/>
@@ -3383,12 +3378,12 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="689"/>
         <source>Get piece color</source>
-        <translation>Coger color de la pieza</translation>
+        <translation>Obtener el color de una pieza</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="696"/>
         <source>Zoom in or out</source>
-        <translation>Ampliar o Reducir</translation>
+        <translation>Ampliar o reducir</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="703"/>
@@ -3438,7 +3433,7 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="766"/>
         <source>Rotate view so selected pieces are at center</source>
-        <translation>Rotar vista para que las piezas seleccionadas esten centradas</translation>
+        <translation>Rotar vista para que las piezas seleccionadas estén centradas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="773"/>
@@ -3448,7 +3443,7 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="780"/>
         <source>Move the current view backward</source>
-        <translation>Mover la vista actual hacia atras</translation>
+        <translation>Mover la vista actual hacia atrás</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="787"/>
@@ -3478,7 +3473,7 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="822"/>
         <source>View model from the back</source>
-        <translation>Ver el modelo desde detras</translation>
+        <translation>Ver el modelo desde atrás</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="829"/>
@@ -3503,12 +3498,12 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="857"/>
         <source>View model from the default position</source>
-        <translation>Ver el modelo desde la posición por defecto</translation>
+        <translation>Ver el modelo desde la posición predeterminada</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="864"/>
         <source>Do not use a camera</source>
-        <translation>No usar cámara</translation>
+        <translation>No usar ninguna cámara</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="871"/>
@@ -3531,27 +3526,26 @@ Formato de fichero no reconocido.</translation>
         <translation>Usar esta cámara</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="983"/>
         <source>Reset views to their default positions</source>
-        <translation>Reinicializar las vistas a sus posiciones por defecto</translation>
+        <translation type="vanished">Reiniciar las vistas a sus posiciones predeterminadas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="990"/>
+        <location filename="../common/lc_commands.cpp" line="983"/>
         <source>Go to the first step of the model</source>
         <translation>Ir al primer paso del modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="997"/>
+        <location filename="../common/lc_commands.cpp" line="990"/>
         <source>Go to the previous step</source>
-        <translation>Ir al paso previo del modelo</translation>
+        <translation>Ir al anterior paso</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1004"/>
+        <location filename="../common/lc_commands.cpp" line="997"/>
         <source>Go to the next step</source>
         <translation>Ir al siguiente paso</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1004"/>
         <source>Go to the last step of the model</source>
         <translation>Ir al último paso del modelo</translation>
     </message>
@@ -3560,47 +3554,48 @@ Formato de fichero no reconocido.</translation>
         <translation type="vanished">Insertar nuevo paso</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1032"/>
-        <location filename="../common/lc_commands.cpp" line="1816"/>
+        <location filename="../common/lc_commands.cpp" line="1025"/>
+        <location filename="../common/lc_commands.cpp" line="1809"/>
         <source>Remove current step</source>
         <translation>Quitar el paso actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1137"/>
+        <location filename="../common/lc_commands.cpp" line="1130"/>
         <source>Close current tab</source>
         <translation>Cerrar la pestaña actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1256"/>
+        <location filename="../common/lc_commands.cpp" line="1249"/>
         <source>Remove the selected control point</source>
-        <translation>Quitar la seleccion del punto de control</translation>
+        <translation>Quitar la selección del punto de control</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1361"/>
+        <location filename="../common/lc_commands.cpp" line="1354"/>
         <source>Open the model referenced by the selected piece in a new tab</source>
         <translation>Abrir el modelo referenciado por la pieza seleccionada en la nueva pestaña</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1368"/>
+        <location filename="../common/lc_commands.cpp" line="1361"/>
         <source>Move the selected pieces to a new model and replace them with a reference to the model</source>
         <translation>Mover las piezas seleccionadas a un nuevo modelo y reemplazarlas con una referencia al modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1473"/>
+        <location filename="../common/lc_commands.cpp" line="1466"/>
         <source>Create a new submodel</source>
         <translation>Crear un nuevo submodelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1480"/>
+        <location filename="../common/lc_commands.cpp" line="1473"/>
         <source>Display the properties of the current submodel</source>
         <translation>Mostrar las propiedades del submodelo actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1487"/>
+        <location filename="../common/lc_commands.cpp" line="1480"/>
         <source>Show a list of all submodels</source>
         <translation>Mostrar una lista de todos los submodelos</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1487"/>
         <location filename="../common/lc_commands.cpp" line="1494"/>
         <location filename="../common/lc_commands.cpp" line="1501"/>
         <location filename="../common/lc_commands.cpp" line="1508"/>
@@ -3640,44 +3635,43 @@ Formato de fichero no reconocido.</translation>
         <location filename="../common/lc_commands.cpp" line="1746"/>
         <location filename="../common/lc_commands.cpp" line="1753"/>
         <location filename="../common/lc_commands.cpp" line="1760"/>
-        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Switch to this submodel</source>
         <translation>Cambiar a este submodelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1781"/>
+        <location filename="../common/lc_commands.cpp" line="1774"/>
         <source>Open LeoCAD&apos;s bug report form on your default web browser</source>
-        <translation>Abrir la página de reporte de errores de LeoCAD en tu navegador por defecto</translation>
+        <translation>Abrir la página de reporte de errores de LeoCAD en tu navegador predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1816"/>
+        <source>Move the selected parts into this step</source>
+        <translation>Mover las piezas seleccionadas a este paso</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1823"/>
-        <source>Move the selected parts into this step</source>
-        <translation>Mover las piezas seleccionadas en este paso</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1830"/>
         <source>View the model at this point in the timeline</source>
         <translation>Ver el modelo actual en la línea de tiempo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1039"/>
+        <location filename="../common/lc_commands.cpp" line="1032"/>
         <source>Toggle adding new animation keys</source>
-        <translation>Activar añadir nuevas claves de animación</translation>
+        <translation>Alternar añadir nuevas claves de animación</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="122"/>
         <source>Configure instructions layout</source>
-        <translation>Configurar composicion de las instrucciones</translation>
+        <translation>Configurar diseño de instrucciones</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="206"/>
         <source>Insert Clipboard contents in the current step</source>
-        <translation>Insertar contenido del Portapapeles en el paso actual</translation>
+        <translation>Insertar contenido del portapapeles en el paso actual</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="213"/>
         <source>Insert Clipboard contents in their original steps</source>
-        <translation>Insertar contenido del Portapapeles en los pasos originales</translation>
+        <translation>Insertar contenido del portapapeles en sus pasos originales</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="220"/>
@@ -3692,12 +3686,12 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="234"/>
         <source>Find previous piece</source>
-        <translation>Buscar pieza anterior</translation>
+        <translation>Buscar anterior pieza</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="241"/>
         <source>Find all pieces that match the search criteria</source>
-        <translation>Encontrar todas las piezas que concuerden con el criterio de busqueda</translation>
+        <translation>Buscar todas las piezas que coincidan con el criterio de búsqueda</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="248"/>
@@ -3712,295 +3706,295 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_commands.cpp" line="262"/>
         <source>Replace all pieces that match the search criteria</source>
-        <translation>Reemplazar todas las piezas que concuerden con el criterio de busqueda</translation>
+        <translation>Reemplazar todas las piezas que coincidan con el criterio de búsqueda</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1795"/>
+        <source>Insert a new step before the current step</source>
+        <translation>Insertar nuevo paso antes del paso actual</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1018"/>
         <location filename="../common/lc_commands.cpp" line="1802"/>
-        <source>Insert a new step before the current step</source>
-        <translation>Insertar un nuevo paso antes del paso actual</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1025"/>
-        <location filename="../common/lc_commands.cpp" line="1809"/>
         <source>Insert a new step after the current step</source>
-        <translation>Insertar un nuevo paso despues del paso actual</translation>
+        <translation>Insertar nuevo paso después del paso actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1046"/>
+        <location filename="../common/lc_commands.cpp" line="1039"/>
         <source>Split the current view horizontally</source>
         <translation>Dividir la vista actual horizontalmente</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1053"/>
+        <location filename="../common/lc_commands.cpp" line="1046"/>
         <source>Split the current view vertically</source>
         <translation>Dividir la vista actual verticalmente</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1060"/>
+        <location filename="../common/lc_commands.cpp" line="1053"/>
         <source>Remove the current view</source>
         <translation>Quitar la vista actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1067"/>
+        <location filename="../common/lc_commands.cpp" line="1060"/>
         <source>Reset all views</source>
         <translation>Reiniciar todas las vistas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1074"/>
+        <location filename="../common/lc_commands.cpp" line="1067"/>
         <source>Toggle the Standard Toolbar</source>
-        <translation>Cambiar la Barra de Herramientas Estandar</translation>
+        <translation>Alternar barra de herramientas estándar</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1074"/>
+        <source>Toggle the Tools Toolbar</source>
+        <translation>Alternar barra de herramientas de utilidades</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1081"/>
-        <source>Toggle the Tools Toolbar</source>
-        <translation>Cambiar Barra de Herramientas de Utilidades</translation>
+        <source>Toggle the Time Toolbar</source>
+        <translation>Alternar barra de herramientas de tiempo</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1088"/>
-        <source>Toggle the Time Toolbar</source>
-        <translation>Cambiar Barra de Herramientas de Tiempo</translation>
+        <source>Toggle the Parts Toolbar</source>
+        <translation>Alternar barra de herramientas de piezas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1095"/>
-        <source>Toggle the Parts Toolbar</source>
-        <translation>Cambiar Barra de Herramientas de Partes</translation>
+        <source>Toggle the Colors Toolbar</source>
+        <translation>Alternar barra de herramientas de colores</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1102"/>
-        <source>Toggle the Colors Toolbar</source>
-        <translation>Cambiar Barra de Herramientas de Colores</translation>
+        <source>Toggle the Properties Toolbar</source>
+        <translation>Alternar barra de herramientas de propiedades</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1109"/>
-        <source>Toggle the Properties Toolbar</source>
-        <translation>Cambiar Barra de Herramientas de Propiedades</translation>
+        <source>Toggle the Timeline Toolbar</source>
+        <translation>Alternar barra de herramientas de línea de tiempo</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1116"/>
-        <source>Toggle the Timeline Toolbar</source>
-        <translation>Cambiar Barra de Herramientas de Linea de tiempo</translation>
+        <source>Toggle the Preview Toolbar</source>
+        <translation>Alternar barra de herramientas de vista previa</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1123"/>
-        <source>Toggle the Preview Toolbar</source>
-        <translation>Cambiar Barra de Herramientas de Previa</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1130"/>
         <source>Toggle fullscreen mode</source>
-        <translation>Activar modo de pantalla completa</translation>
+        <translation>Alternar el modo pantalla completa</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1144"/>
+        <location filename="../common/lc_commands.cpp" line="1137"/>
         <source>Display the scene as wireframe</source>
         <translation>Mostrar la escena como malla</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1151"/>
+        <location filename="../common/lc_commands.cpp" line="1144"/>
         <source>Display the scene without any shading or lights</source>
-        <translation>Mostrar las escena sin sombreados o luces</translation>
+        <translation>Mostrar la escena sin sombreados ni luces</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1151"/>
+        <source>Display the scene with the default lights</source>
+        <translation>Mostrar la escena con las luces predeterminadas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1158"/>
-        <source>Display the scene with the default lights</source>
-        <translation>Mostrar la escena con las luces por defecto</translation>
+        <source>Set the current camera to use a perspective projection</source>
+        <translation>Asignar a la cámara actual la proyección de perspectiva</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1165"/>
-        <source>Set the current camera to use a perspective projection</source>
-        <translation>Asignar a la cámara actual la perspectiva de proyección</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1172"/>
         <source>Set the current camera to use an orthographic projection</source>
         <translation>Asignar a la cámara actual la proyección ortográfica</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1179"/>
+        <location filename="../common/lc_commands.cpp" line="1172"/>
         <source>Toggle the view sphere</source>
-        <translation>Cambiar la vista de esfera</translation>
+        <translation>Alternar la esfera de la vista</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1179"/>
+        <source>Toggle axis icon</source>
+        <translation>Alternar icono de ejes</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1186"/>
-        <source>Toggle axis icon</source>
-        <translation>Cambiar icono del eje</translation>
+        <source>Toggle grid</source>
+        <translation>Alternar cuadrícula</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1193"/>
-        <source>Toggle grid</source>
-        <translation>Cambiar Malla</translation>
+        <source>Toggle fading previous model steps</source>
+        <translation>Alternar atenuar pasos previos</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1200"/>
-        <source>Toggle fading previous model steps</source>
-        <translation>Cambiar Desvanecer pasos previos</translation>
+        <source>Add a new piece to the model</source>
+        <translation>Añadir nueva pieza al modelo</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1207"/>
-        <source>Add a new piece to the model</source>
-        <translation>Añadir una pieza al modelo</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1214"/>
         <source>Delete selected objects</source>
         <translation>Borrar objetos seleccionados</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1221"/>
+        <location filename="../common/lc_commands.cpp" line="1214"/>
         <source>Create a copy of the selected pieces</source>
-        <translation>Crear una copia de las piezas seleccionadas</translation>
+        <translation>Crear copia de las piezas seleccionadas</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1221"/>
+        <source>Change the color of the selected pieces</source>
+        <translation>Cambiar color de las piezas seleccionadas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1228"/>
-        <source>Change the color of the selected pieces</source>
-        <translation>Cambiar el color de las piezas seleccionadas</translation>
+        <source>Reset the pivot point of the selected pieces to their origin</source>
+        <translation>Reiniciar punto de pivote de las piezas seleccionadas a su origen</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1235"/>
-        <source>Reset the pivot point of the selected pieces to their origin</source>
-        <translation>Reicinializar el punto de pivote de las piezas seleccionadas a su origen</translation>
+        <source>Remove all key frames from the selected pieces</source>
+        <translation>Quitar todos los fotogramas clave de las piezas seleccionadas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1242"/>
-        <source>Remove all key frames from the selected pieces</source>
-        <translation>Quitar todos los fotogramas claves de las piezas seleccionadas</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1249"/>
         <source>Insert a new control point</source>
         <translation>Insertar un nuevo punto de control</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1256"/>
         <location filename="../common/lc_commands.cpp" line="1263"/>
-        <location filename="../common/lc_commands.cpp" line="1270"/>
         <source>Move selected objects along the X axis</source>
         <translation>Mover los objetos seleccionados a lo largo del eje X</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1270"/>
         <location filename="../common/lc_commands.cpp" line="1277"/>
-        <location filename="../common/lc_commands.cpp" line="1284"/>
         <source>Move selected objects along the Y axis</source>
         <translation>Mover los objetos seleccionados a lo largo del eje Y</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1284"/>
         <location filename="../common/lc_commands.cpp" line="1291"/>
-        <location filename="../common/lc_commands.cpp" line="1298"/>
         <source>Move selected objects along the Z axis</source>
         <translation>Mover los objetos seleccionados a lo largo del eje Z</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1298"/>
         <location filename="../common/lc_commands.cpp" line="1305"/>
-        <location filename="../common/lc_commands.cpp" line="1312"/>
         <source>Rotate selected objects along the X axis</source>
         <translation>Rotar los objetos seleccionados a lo largo del eje X</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1312"/>
         <location filename="../common/lc_commands.cpp" line="1319"/>
-        <location filename="../common/lc_commands.cpp" line="1326"/>
         <source>Rotate selected objects along the Y axis</source>
         <translation>Rotar los objetos seleccionados a lo largo del eje Y</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1326"/>
         <location filename="../common/lc_commands.cpp" line="1333"/>
-        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Rotate selected objects along the Z axis</source>
         <translation>Rotar los objetos seleccionados a lo largo del eje Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1347"/>
+        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Add a new minifig to the model</source>
         <translation>Añadir un nuevo minifig al modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1354"/>
+        <location filename="../common/lc_commands.cpp" line="1347"/>
         <source>Make copies of the selected pieces</source>
         <translation>Hacer copias de las piezas seleccionadas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1375"/>
+        <location filename="../common/lc_commands.cpp" line="1368"/>
         <source>Insert the contents of the selected model references into the current model</source>
         <translation>Insertar los contenidos de las referencias del modelo seleccionado en modelo actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1382"/>
+        <location filename="../common/lc_commands.cpp" line="1375"/>
         <source>Edit the currently selected submodel in-place</source>
-        <translation>Editar el submodelo seleccinado actual en el lugar</translation>
+        <translation>Editar el submodelo seleccionado actual in-situ</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1382"/>
+        <source>End in-place submodel editing</source>
+        <translation>Finalizar la edición del submodelo in-situ</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1389"/>
-        <source>End in-place submodel editing</source>
-        <translation>Finalizar la edición del submodelo en su lugar</translation>
+        <source>Group selected pieces together</source>
+        <translation>Agrupar las piezas seleccionadas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1396"/>
-        <source>Group selected pieces together</source>
-        <translation>Agrupar las piezas seleccionadas juntas</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1403"/>
         <source>Ungroup selected group</source>
         <translation>Desagrupar el grupo seleccionado</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1410"/>
+        <location filename="../common/lc_commands.cpp" line="1403"/>
         <source>Add focused piece to selected group</source>
         <translation>Añadir la pieza enfocada al grupo seleccionado</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1417"/>
+        <location filename="../common/lc_commands.cpp" line="1410"/>
         <source>Remove focused piece from group</source>
         <translation>Quitar la pieza enfocada del grupo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1424"/>
+        <location filename="../common/lc_commands.cpp" line="1417"/>
         <source>Edit groups</source>
         <translation>Editar grupos</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1431"/>
+        <location filename="../common/lc_commands.cpp" line="1424"/>
         <source>Hide selected objects</source>
         <translation>Ocultar los objetos seleccionados</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1438"/>
+        <location filename="../common/lc_commands.cpp" line="1431"/>
         <source>Hide objects that are not selected</source>
         <translation>Ocultar objetos que no han sido seleccionados</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1445"/>
+        <location filename="../common/lc_commands.cpp" line="1438"/>
         <source>Show hidden objects that are selected</source>
-        <translation>Mostrar los objetos ocultos que estan seleccionados</translation>
+        <translation>Mostrar los objetos ocultos que están seleccionados</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1452"/>
+        <location filename="../common/lc_commands.cpp" line="1445"/>
         <source>Show all hidden objects</source>
         <translation>Mostrar todos los objetos ocultos</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1459"/>
+        <location filename="../common/lc_commands.cpp" line="1452"/>
         <source>Show selected pieces one step earlier</source>
-        <translation>Montrer les pièces sélectionnées une étape plus tôt</translation>
+        <translation>Mover piezas seleccionadas un paso atrás</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1466"/>
+        <location filename="../common/lc_commands.cpp" line="1459"/>
         <source>Show selected pieces one step later</source>
-        <translation>Montrer les pièces sélectionnées une étape plus tard</translation>
+        <translation>Mover piezas seleccionadas un paso después</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1774"/>
+        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Open LeoCAD&apos;s home page on the internet using your default web browser</source>
-        <translation>Ouvrir la page d’accueil de LeoCAD avec votre navigateur web par défaut</translation>
+        <translation>Abrir la página de LeoCAD en internet usando tu navegador predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1781"/>
+        <source>Check if a newer LeoCAD version or parts library has been released</source>
+        <translation>Comprobar si hay nuevas versiones de LeoCAD o de la biblioteca de piezas</translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1788"/>
-        <source>Check if a newer LeoCAD version or parts library has been released</source>
-        <translation>Vérifier si une nouvelle version de LeoCAD ou de la bibliothèque de pièces est disponible</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1795"/>
         <source>Display program version number and system information</source>
-        <translation>Voir la version du programme et des informations sur le système</translation>
+        <translation>Mostrar versión del programa e información del sistema</translation>
     </message>
 </context>
 <context>
@@ -4018,7 +4012,7 @@ Formato de fichero no reconocido.</translation>
     <message>
         <location filename="../common/lc_viewsphere.cpp" line="68"/>
         <source>Back</source>
-        <translation>Detras</translation>
+        <translation>Detrás</translation>
     </message>
     <message>
         <location filename="../common/lc_viewsphere.cpp" line="69"/>
@@ -4039,450 +4033,506 @@ Formato de fichero no reconocido.</translation>
 <context>
     <name>lcApplication</name>
     <message>
-        <location filename="../common/lc_application.cpp" line="934"/>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="954"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="929"/>
+        <location filename="../common/lc_application.cpp" line="949"/>
         <source>LeoCAD could not find a compatible Parts Library so only a small number of parts will be available.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
-        <translation>LeoCAD no pudo encontrar una biblioteca de piezas compatible con lo que solo un reducido número de piezas estaran disponibles.
+        <translation>LeoCAD no pudo encontrar ninguna biblioteca de piezas compatible por lo que solo un reducido número de piezas estará disponible.
 
-Por favor Visita https://www.leocad.org para aprender como descargar e instalar una biblioteca.</translation>
+Por favor, visita https://www.leocad.org para saber cómo descargar e instalar una biblioteca.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="401"/>
-        <location filename="../common/lc_application.cpp" line="426"/>
-        <location filename="../common/lc_application.cpp" line="449"/>
-        <location filename="../common/lc_application.cpp" line="472"/>
-        <location filename="../common/lc_application.cpp" line="482"/>
-        <location filename="../common/lc_application.cpp" line="505"/>
-        <location filename="../common/lc_application.cpp" line="530"/>
-        <source>Not enough parameters for the &apos;%1&apos; option.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="423"/>
+        <location filename="../common/lc_application.cpp" line="421"/>
         <location filename="../common/lc_application.cpp" line="446"/>
         <location filename="../common/lc_application.cpp" line="469"/>
+        <location filename="../common/lc_application.cpp" line="492"/>
         <location filename="../common/lc_application.cpp" line="502"/>
-        <location filename="../common/lc_application.cpp" line="527"/>
-        <location filename="../common/lc_application.cpp" line="580"/>
-        <location filename="../common/lc_application.cpp" line="734"/>
-        <location filename="../common/lc_application.cpp" line="745"/>
-        <source>Invalid parameter value specified for the &apos;%1&apos; option: &apos;%2&apos;.
+        <location filename="../common/lc_application.cpp" line="525"/>
+        <location filename="../common/lc_application.cpp" line="550"/>
+        <source>Not enough parameters for the &apos;%1&apos; option.
 </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="541"/>
-        <source>The file &apos;%1&apos; is not readable.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="589"/>
-        <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: limits are +/- 360.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="601"/>
-        <source>Invalid parameter value(s) specified for the &apos;%1&apos; option.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="620"/>
-        <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: requirements are: 1 &lt;= &lt;near&gt; &lt; &lt;far&gt;.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="630"/>
-        <location filename="../common/lc_application.cpp" line="641"/>
-        <location filename="../common/lc_application.cpp" line="652"/>
-        <location filename="../common/lc_application.cpp" line="663"/>
-        <source>High contrast stud style is required for the &apos;%1&apos; option but is not enabled.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="678"/>
-        <location filename="../common/lc_application.cpp" line="689"/>
-        <source>Automate edge color is required for the &apos;%1&apos; option but is not enabled.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="779"/>
-        <source>LeoCAD Continuous Build %1
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="781"/>
-        <source>LeoCAD Version %1
-</source>
-        <translation type="unfinished">Version de LeoCAD %1
+        <translation>No hay suficientes parámetros para la opción &apos;%1&apos;.
 </translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="783"/>
-        <source>Compiled %1
+        <location filename="../common/lc_application.cpp" line="443"/>
+        <location filename="../common/lc_application.cpp" line="466"/>
+        <location filename="../common/lc_application.cpp" line="489"/>
+        <location filename="../common/lc_application.cpp" line="522"/>
+        <location filename="../common/lc_application.cpp" line="547"/>
+        <location filename="../common/lc_application.cpp" line="600"/>
+        <location filename="../common/lc_application.cpp" line="754"/>
+        <location filename="../common/lc_application.cpp" line="765"/>
+        <source>Invalid parameter value specified for the &apos;%1&apos; option: &apos;%2&apos;.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Especificado valor de parámetro inválido para la opción &apos;%1&apos; option: &apos;%2&apos;.
+</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="788"/>
-        <source>Usage: leocad [options] [file]
+        <location filename="../common/lc_application.cpp" line="561"/>
+        <source>The file &apos;%1&apos; is not readable.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>El archivo &apos;%1&apos; no se puede leer.
+</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="789"/>
-        <source>  [options] can be:
+        <location filename="../common/lc_application.cpp" line="609"/>
+        <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: limits are +/- 360.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Valores de parámetros inválidos especificados para la opción &apos;%1&apos;: los límites son +/- 360 </translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="790"/>
-        <source>  -l, --libpath &lt;path&gt;: Set the Parts Library location to path.
+        <location filename="../common/lc_application.cpp" line="621"/>
+        <source>Invalid parameter value(s) specified for the &apos;%1&apos; option.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Valores de parámetros inválidos especificados para la opción &apos;%1&apos;.
+</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="791"/>
-        <source>  -i, --image &lt;outfile.ext&gt;: Save a picture in the format specified by ext and exit.
+        <location filename="../common/lc_application.cpp" line="640"/>
+        <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: requirements are: 1 &lt;= &lt;near&gt; &lt; &lt;far&gt;.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Valores de parámetros inválidos especificados para la opción &apos;%1&apos;: se ha de cumplir: 1 &lt;= &lt;cerca&gt; &lt; &lt;lejos&gt;.
+</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="792"/>
-        <source>  -w, --width &lt;width&gt;: Set the picture width.
+        <location filename="../common/lc_application.cpp" line="650"/>
+        <location filename="../common/lc_application.cpp" line="661"/>
+        <location filename="../common/lc_application.cpp" line="672"/>
+        <location filename="../common/lc_application.cpp" line="683"/>
+        <source>High contrast stud style is required for the &apos;%1&apos; option but is not enabled.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>La opción &apos;%1&apos; necesita que esté activado el contraste alto para el estilo de tetón, pero no lo está.
+</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="793"/>
-        <source>  -h, --height &lt;height&gt;: Set the picture height.
+        <location filename="../common/lc_application.cpp" line="698"/>
+        <location filename="../common/lc_application.cpp" line="709"/>
+        <source>Automate edge color is required for the &apos;%1&apos; option but is not enabled.
 </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="794"/>
-        <source>  -f, --from &lt;step&gt;: Set the first step to save pictures.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="795"/>
-        <source>  -t, --to &lt;step&gt;: Set the last step to save pictures.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="796"/>
-        <source>  -s, --submodel &lt;submodel&gt;: Set the active submodel.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="797"/>
-        <source>  -c, --camera &lt;camera&gt;: Set the active camera.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="798"/>
-        <source>  -ss, --stud-style &lt;id&gt;: Set the stud style 0=No style, 1=LDraw single wire, 2=LDraw double wire, 3=LDraw raised floating, 4=LDraw raised rounded, 5=LDraw subtle rounded, 6=LEGO no logo, 7=LEGO single wire.
-</source>
-        <translation type="unfinished"></translation>
+        <translation>La opción &apos;%1&apos; necesita que esté activado el color de border automático, pero no lo está.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="799"/>
-        <source>  --viewpoint &lt;front|back|left|right|top|bottom|home&gt;: Set the viewpoint.
+        <source>LeoCAD Continuous Build %1
 </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="800"/>
-        <source>  --camera-angles &lt;latitude&gt; &lt;longitude&gt;: Set the camera angles in degrees around the model.
-</source>
-        <translation type="unfinished"></translation>
+        <translation>LeoCAD compilación continua %1
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="801"/>
-        <source>  --camera-position &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector.
+        <source>LeoCAD Version %1
 </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="802"/>
-        <source>  --camera-position-ldraw &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector using LDraw coordinates.
-</source>
-        <translation type="unfinished"></translation>
+        <translation>LeoCAD versión %1
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="803"/>
-        <source>  --orthographic: Render images using an orthographic projection.
+        <source>Compiled %1
 </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="804"/>
-        <source>  --fov &lt;degrees&gt;: Set the vertical field of view used to render images (&lt; 180).
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="805"/>
-        <source>  --zplanes &lt;near&gt; &lt;far&gt;: Set the near and far clipping planes used to render images (1 &lt;= &lt;near&gt; &lt; &lt;far&gt;).
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="806"/>
-        <source>  --fade-steps: Render parts from prior steps faded.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="807"/>
-        <source>  --no-fade-steps: Do not render parts from prior steps faded.
-</source>
-        <translation type="unfinished"></translation>
+        <translation>Compilado %1</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="808"/>
-        <source>  --fade-steps-color &lt;rgba&gt;: Renderinng color for prior step parts (#AARRGGBB).
+        <source>Usage: leocad [options] [file]
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Uso: leocad [opciones] [archivo]</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="809"/>
-        <source>  --highlight: Highlight parts in the steps they appear.
+        <source>  [options] can be:
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  [opciones] puede ser:</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="810"/>
-        <source>  --no-highlight: Do not highlight parts in the steps they appear.
+        <source>  -l, --libpath &lt;path&gt;: Set the Parts Library location to path.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -l, --libpath &lt;ruta&gt;: Establece la ubicación de la biblioteca de piezas a ruta.</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="811"/>
-        <source>  --highlight-color: Renderinng color for highlighted parts (#AARRGGBB).
+        <source>  -i, --image &lt;outfile.ext&gt;: Save a picture in the format specified by ext and exit.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -i, --image &lt;outfile.ext&gt;: Guarda una imagen en el formato especificado por ext y termina.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="812"/>
-        <source>  --shading &lt;wireframe|flat|default|full&gt;: Select shading mode for rendering.
+        <source>  -w, --width &lt;width&gt;: Set the picture width.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -w, --width &lt;ancho&gt;: Establece la anchura de la imagen.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="813"/>
-        <source>  --line-width &lt;width&gt;: Set the with of the edge lines.
+        <source>  -h, --height &lt;height&gt;: Set the picture height.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -h, --height &lt;altura&gt;: Establece la altura de la imagen.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="814"/>
-        <source>  --aa-samples &lt;count&gt;: AntiAliasing sample size (1, 2, 4, or 8).
+        <source>  -f, --from &lt;step&gt;: Set the first step to save pictures.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -f, --from &lt;paso&gt;: Establece el primer paso para guardar imágenes.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="815"/>
-        <source>  -scc, --stud-cylinder-color &lt;#AARRGGBB&gt;: High contrast stud cylinder color.
+        <source>  -t, --to &lt;step&gt;: Set the last step to save pictures.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -t, --to &lt;paso&gt;: Establece el último paso para guardar imágenes.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="816"/>
-        <source>  -ec, --edge-color &lt;#AARRGGBB&gt;: High contrast edge color.
+        <source>  -s, --submodel &lt;submodel&gt;: Set the active submodel.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -s, --submodel &lt;submodelo&gt;: Establece el submodelo activo.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="817"/>
-        <source>  -bec, --black-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for black parts.
+        <source>  -c, --camera &lt;camera&gt;: Set the active camera.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -c, --camera &lt;cámara&gt;: Establece la cámara activa.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="818"/>
-        <source>  -dec, --dark-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for dark color parts.
+        <source>  -ss, --stud-style &lt;id&gt;: Set the stud style 0=No style, 1=LDraw single wire, 2=LDraw double wire, 3=LDraw raised floating, 4=LDraw raised rounded, 5=LDraw subtle rounded, 6=LEGO no logo, 7=LEGO single wire.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -ss, --stud-style &lt;id&gt;: Establece el estilo de tetón 0=plano, 1=trazo único de LDraw, 2=trazo doble de LDraw, 3=flotante elevado de LDraw, 4=redondo elevado de LDraw, 5=rondeado suavo de LDraw, 6=LEGO sin logo, 7=LEGO trazo único.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="819"/>
-        <source>  -aec, --automate-edge-color: Enable automatically adjusted edge colors.
+        <source>  --viewpoint &lt;front|back|left|right|top|bottom|home&gt;: Set the viewpoint.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  --viewpoint &lt;front|back|left|right|top|bottom|home&gt;: Establece la vista.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="820"/>
-        <source>  -cc, --color-contrast &lt;float&gt;: Color contrast value between 0.0 and 1.0.
+        <source>  --camera-angles &lt;latitude&gt; &lt;longitude&gt;: Set the camera angles in degrees around the model.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  --camera-angles &lt;latitud&gt; &lt;longitud&gt;: Establece los ángulos de cámara en grados alrededor del modelo.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="821"/>
-        <source>  -ldv, --light-dark-value &lt;float&gt;: Light/Dark color value between 0.0 and 1.0.
+        <source>  --camera-position &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  --camera-position &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Establece la posición de la cámara, el objetivo y el vector vertical.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="822"/>
-        <source>  -obj, --export-wavefront &lt;outfile.obj&gt;: Export the model to Wavefront OBJ format.
+        <source>  --camera-position-ldraw &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector using LDraw coordinates.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  --camera-position-ldraw &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Establece la posición de la cámara, el objetivo y el vector vertical usando coordenadas de LDraw.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="823"/>
-        <source>  -3ds, --export-3ds &lt;outfile.3ds&gt;: Export the model to 3D Studio 3DS format.
+        <source>  --orthographic: Render images using an orthographic projection.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  --orthographic: Renderiza imágenes usando una proyección ortogonal.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="824"/>
-        <source>  -dae, --export-collada &lt;outfile.dae&gt;: Export the model to COLLADA DAE format.
+        <source>  --fov &lt;degrees&gt;: Set the vertical field of view used to render images (&lt; 180).
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  --fov &lt;grados&gt;: Establece el campo de visión vertical usado para renderizar imágenes (&lt; 180).
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="825"/>
-        <source>  -html, --export-html &lt;folder&gt;: Create an HTML page for the model.
+        <source>  --zplanes &lt;near&gt; &lt;far&gt;: Set the near and far clipping planes used to render images (1 &lt;= &lt;near&gt; &lt; &lt;far&gt;).
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  --zplanes &lt;cerca&gt; &lt;lejos&gt;: Establece los planos de recorte cercanos y lejanos usados para renderizar imágenes (1 &lt;= &lt;cerca&gt; &lt; &lt;lejos&gt;).
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="826"/>
-        <source>  -v, --version: Output version information and exit.
+        <source>  --fade-steps: Render parts from prior steps faded.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  --fade-steps: Renderiza piezas de pasos anteriores atenuadas.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="827"/>
-        <source>  -?, --help: Display this help message and exit.
+        <source>  --no-fade-steps: Do not render parts from prior steps faded.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  --no-fade-steps: No renderiza piezas de partes anteriores atenuadas.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="828"/>
+        <source>  --fade-steps-color &lt;rgba&gt;: Renderinng color for prior step parts (#AARRGGBB).
+</source>
+        <translation>  --fade-steps-color &lt;rgba&gt;: Color de renderizado para piezas de pasos anteriores (#AARRGGBB).
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="829"/>
+        <source>  --highlight: Highlight parts in the steps they appear.
+</source>
+        <translation>  --highlight: Resalta piezas en los pasos en los que aparecen.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="830"/>
+        <source>  --no-highlight: Do not highlight parts in the steps they appear.
+</source>
+        <translation>  --no-highlight: No resalta piezas en los pasos en los que aparecen.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="831"/>
+        <source>  --highlight-color: Renderinng color for highlighted parts (#AARRGGBB).
+</source>
+        <translation>  --highlight-color: Color de renderizado para piezas resaltadas (#AARRGGBB).
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="832"/>
+        <source>  --shading &lt;wireframe|flat|default|full&gt;: Select shading mode for rendering.
+</source>
+        <translation>  --shading &lt;wireframe|flat|default|full&gt;: Seleccionar modo de sombreado para renderizaciones.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="833"/>
-        <source>Unknown option: &apos;%1&apos;.
+        <source>  --line-width &lt;width&gt;: Set the width of the edge lines.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  --line-width &lt;width&gt;: Establece el grosor de los bordes.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="834"/>
+        <source>  --aa-samples &lt;count&gt;: AntiAliasing sample size (1, 2, 4, or 8).
+</source>
+        <translation>  --aa-samples &lt;cantidad&gt;: Tamaño de muestreo de anti-aliasing (1, 2, 4 u 8).
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="835"/>
+        <source>  -scc, --stud-cylinder-color &lt;#AARRGGBB&gt;: High contrast stud cylinder color.
+</source>
+        <translation>  -scc, --stud-cylinder-color &lt;#AARRGGBB&gt;: Color del tetón cilíndrico en alto contraste.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="836"/>
+        <source>  -ec, --edge-color &lt;#AARRGGBB&gt;: High contrast edge color.
+</source>
+        <translation>  -ec, --edge-color &lt;#AARRGGBB&gt;: Color del borde en alto contraste.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="837"/>
+        <source>  -bec, --black-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for black parts.
+</source>
+        <translation>  -bec, --black-edge-color &lt;#AARRGGBB&gt;: Color del borde para piezas negras en algo contraste.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="838"/>
+        <source>  -dec, --dark-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for dark color parts.
+</source>
+        <translation>  -dec, --dark-edge-color &lt;#AARRGGBB&gt;: Color de borde para piezas oscuras en alto contraste.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="839"/>
+        <source>  -aec, --automate-edge-color: Enable automatically adjusted edge colors.
+</source>
+        <translation>  -aec, --automate-edge-color: Habilitar ajuste automático de colores de borde.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="840"/>
-        <source>High contrast stud and edge color settings are ignored when -aec or --automate-edge-color is set.
+        <source>  -cc, --color-contrast &lt;float&gt;: Color contrast value between 0.0 and 1.0.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -cc, --color-contrast &lt;decimal&gt;: El color de contraste ha de estar comprendido entre 0.0 y 1.0.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="841"/>
+        <source>  -ldv, --light-dark-value &lt;float&gt;: Light/Dark color value between 0.0 and 1.0.
+</source>
+        <translation>  -ldv, --light-dark-value &lt;decimal&gt;: El color claro/oscuro ha de estar comprendido entre 0.0 y 1.0.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="842"/>
+        <source>  -obj, --export-wavefront &lt;outfile.obj&gt;: Export the model to Wavefront OBJ format.
+</source>
+        <translation>  -obj, --export-wavefront &lt;outfile.obj&gt;: Exporta el modelo al formato OBJ de Wavefront.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="843"/>
+        <source>  -3ds, --export-3ds &lt;outfile.3ds&gt;: Export the model to 3D Studio 3DS format.
+</source>
+        <translation>  -3ds, --export-3ds &lt;outfile.3ds&gt;: Exporta el modelo al formato 3ds de 3D Studio.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="844"/>
+        <source>  -dae, --export-collada &lt;outfile.dae&gt;: Export the model to COLLADA DAE format.
+</source>
+        <translation>  -dae, --export-collada &lt;outfile.dae&gt;: Exporta el modelo al formato DAE de COLLADA.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="845"/>
+        <source>  -html, --export-html &lt;folder&gt;: Create an HTML page for the model.
+</source>
+        <translation>  -html, --export-html &lt;carpeta&gt;: Crea una página HTML para el modelo.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="846"/>
-        <source>--viewpoint is ignored when --camera is set.
+        <source>  -v, --version: Output version information and exit.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -v, --version: Muestra información sobre la versión y termina.
+</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="849"/>
-        <source>--orthographic is ignored when --camera is set.
+        <location filename="../common/lc_application.cpp" line="847"/>
+        <source>  -?, --help: Display this help message and exit.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>  -?, --help: Muestra este mensaje de ayuda y termina.
+</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="852"/>
-        <source>--camera-angles is ignored when --camera is set.
+        <location filename="../common/lc_application.cpp" line="853"/>
+        <source>Unknown option: &apos;%1&apos;.
 </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_application.cpp" line="855"/>
-        <source>--camera-position is ignored when --camera is set.
-</source>
-        <translation type="unfinished"></translation>
+        <translation>Opción desconocida: &apos;%1&apos;.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="860"/>
-        <source>--camera-angles is ignored when --viewpoint is set.
+        <source>High contrast stud and edge color settings are ignored when -aec or --automate-edge-color is set.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Las opciones de tetón en alto contraste y color de borde se ignoran cuando se especifica -aec o --automate-edge-color.
+</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="863"/>
-        <source>--camera-position is ignored when --viewpoint is set.
+        <location filename="../common/lc_application.cpp" line="866"/>
+        <source>--viewpoint is ignored when --camera is set.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>--viewpoint se ignora cuando se especifica --camera.
+</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="868"/>
-        <source>--camera-position is ignored when --camera-angles is set.
+        <location filename="../common/lc_application.cpp" line="869"/>
+        <source>--orthographic is ignored when --camera is set.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>--orthographic se ignora cuando se especifica --camera.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="872"/>
+        <source>--camera-angles is ignored when --camera is set.
+</source>
+        <translation>--camera-angles se ignora cuando se especifica --camera.
+</translation>
     </message>
     <message>
         <location filename="../common/lc_application.cpp" line="875"/>
+        <source>--camera-position is ignored when --camera is set.
+</source>
+        <translation>--camera-position se ignora cuando se especifica --camera.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="880"/>
+        <source>--camera-angles is ignored when --viewpoint is set.
+</source>
+        <translation>--camera-angles se ignora cuando se especifica --viewpoint.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="883"/>
+        <source>--camera-position is ignored when --viewpoint is set.
+</source>
+        <translation>--camera-position se ignora cuando se especifica --viewpoint.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="888"/>
+        <source>--camera-position is ignored when --camera-angles is set.
+</source>
+        <translation>--camera-position se ignora cuando se especifica --camera-angles.
+</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_application.cpp" line="895"/>
         <source>No file name specified.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Nombre de archivo no especificado.
+</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="908"/>
+        <location filename="../common/lc_application.cpp" line="928"/>
         <source>Error creating OpenGL context.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Error creando contexto OpenGL.
+</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="931"/>
+        <location filename="../common/lc_application.cpp" line="951"/>
         <source>LeoCAD could not load Parts Library.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
-        <translation>LeoCAD no pudo cargar una biblioteca de piezas.
+        <translation>LeoCAD no pudo cargar la biblioteca de piezas.
 
-Por favor Visite https://www.leocad.org para aprender como descargar e instalar una librería.</translation>
+Por favor, visita https://www.leocad.org para saber cómo descargar e instalar una biblioteca.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1002"/>
+        <location filename="../common/lc_application.cpp" line="1022"/>
         <source>Error: model &apos;%1&apos; does not exist.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Error: el modelo &apos;%1&apos; no existe.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1093"/>
-        <location filename="../common/lc_application.cpp" line="1121"/>
-        <location filename="../common/lc_application.cpp" line="1146"/>
-        <location filename="../common/lc_application.cpp" line="1171"/>
+        <location filename="../common/lc_application.cpp" line="1113"/>
+        <location filename="../common/lc_application.cpp" line="1141"/>
+        <location filename="../common/lc_application.cpp" line="1166"/>
+        <location filename="../common/lc_application.cpp" line="1191"/>
         <source>Saved &apos;%1&apos;.
 </source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos; guardado.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>Some changes will only take effect the next time you start LeoCAD.</source>
-        <translation type="unfinished"></translation>
+        <translation>Algunos cambios no tendrán efecto hasta que reinicies LeoCAD.</translation>
     </message>
     <message>
         <source>Parts library and Anti-aliasing changes will only take effect the next time you start LeoCAD.</source>
-        <translation type="vanished">Los cambios en las Librerias de piezas y los cambios Anti-aliasing tendran efecto la próxima vez que inicie LeoCAD.</translation>
+        <translation type="vanished">Los cambios en la biblioteca de piezas y anti-aliasing no tendrán efecto hasta que reinicies LeoCAD.</translation>
     </message>
     <message>
         <source>Parts library changes will only take effect the next time you start LeoCAD.</source>
-        <translation type="vanished">Los cambios en las librerias de piezas solo tendran efecto la próxima vez que inicie LeoCAD.</translation>
+        <translation type="vanished">Los cambios en las biblioteca de piezas no tendrán efecto hasta que reinicies LeoCAD.</translation>
     </message>
     <message>
         <source>Anti-aliasing changes will only take effect the next time you start LeoCAD.</source>
-        <translation type="vanished">Los cambios de Anti-aliasing solo tendran efecto la próxima vez que inicie LeoCAD.</translation>
+        <translation type="vanished">Los cambios de anti-aliasing no tendrán efecto hasta que reinicies LeoCAD.</translation>
     </message>
 </context>
 <context>
@@ -4490,12 +4540,12 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="15"/>
         <source>Color Preferences</source>
-        <translation>Preferencias de Color</translation>
+        <translation>Preferencias de color</translation>
     </message>
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="18"/>
         <source>Edge Colors</source>
-        <translation>Color de los bordes</translation>
+        <translation>Color de bordes</translation>
     </message>
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="29"/>
@@ -4505,7 +4555,7 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="34"/>
         <source>Set the amount of contrast - 0.50 is midway.</source>
-        <translation>Introducir la cantidad de contraste - 0.50 es medio.</translation>
+        <translation>Establece la cantidad de contraste - 0.50 es la mitad.</translation>
     </message>
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="39"/>
@@ -4518,49 +4568,79 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
         <translation>Reiniciar</translation>
     </message>
     <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Light/Dark Value:</source>
+        <translation>Valor claro/oscuro:</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Saturation:</source>
+        <translation>Saturación:</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="54"/>
+        <source>Set to classify where color values are light or dark - e.g. Dark Bluish Gray (72) is light at 0.39.</source>
+        <translation>Establecer cuándo un color es claro u oscuro, por ejemplo, gris azulado oscuro (72) es claro a 0.39.</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="55"/>
+        <source>Set to specify amount of edge color tint or shade from the saturation adjusted part color</source>
+        <translation>Establecer la candidad de tinte o matiz de color de borde a partir de la saturación ajustada del color de la pieza.</translation>
+    </message>
+    <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="68"/>
         <source>High Contrast</source>
-        <translation>Alto Contraste</translation>
+        <translation>Alto contraste</translation>
     </message>
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="83"/>
         <source>Stud Cylinder Color:</source>
-        <translation>Color del Teton Cilindrico:</translation>
+        <translation>Color de tetón cilíndrico:</translation>
     </message>
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="96"/>
         <source>Parts Edge Color:</source>
-        <translation>Color de los Lados de las Partes:</translation>
+        <translation>Color de borde para piezas:</translation>
     </message>
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="109"/>
         <source>Black Parts Edge Color:</source>
-        <translation>Color de los Lados de las Partes Negras:</translation>
+        <translation>Color de borde para piezas negras:</translation>
     </message>
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="122"/>
         <source>Dark Parts Edge Color:</source>
-        <translation>Color de los Lados de las Partes Oscuras:</translation>
+        <translation>Color de borde para piezas oscuras:</translation>
     </message>
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="166"/>
         <source>Select Stud Cylinder Color</source>
-        <translation>Seleccionar Color del Teton Cilindrico</translation>
+        <translation>Seleccionar color para tetón cilíndrico</translation>
     </message>
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="171"/>
         <source>Select Part Edge Color</source>
-        <translation>Seleccionar Color del Lado de la Parte</translation>
+        <translation>Seleccionar color para borde de pieza</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="179"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Black parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
+        <translation>El color de borde automático está habilitado.&lt;br&gt;El color de borde de las piezas negras no será accesible.&lt;br&gt;¿Quieres continuar?</translation>
     </message>
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="183"/>
         <source>Select Black Edge Color</source>
-        <translation>Seleccionar Color de los Lados Negros</translation>
+        <translation>Seleccionar color para bordes negros</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="191"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Dark parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
+        <translation>El color de borde automático está habilitado.&lt;br&gt;El color de borde de las piezas oscuras no será accesible.&lt;br&gt;¿Quieres continuar?</translation>
     </message>
     <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="195"/>
         <source>Select Dark Edge Color</source>
-        <translation>Seleccionar Color de los Lados Oscuros</translation>
+        <translation>Seleccionar color para bordes oscuros</translation>
     </message>
 </context>
 <context>
@@ -4568,7 +4648,7 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../common/lc_findreplacewidget.cpp" line="22"/>
         <source>Find:</source>
-        <translation>Encontrar:</translation>
+        <translation>Buscar:</translation>
     </message>
     <message>
         <location filename="../common/lc_findreplacewidget.cpp" line="51"/>
@@ -4581,12 +4661,12 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../common/lc_instructions.cpp" line="46"/>
         <source>Show Step Number</source>
-        <translation>Mostrar Numero del Paso</translation>
+        <translation>Mostrar número del paso</translation>
     </message>
     <message>
         <location filename="../common/lc_instructions.cpp" line="48"/>
         <source>Show Parts List</source>
-        <translation>Mostrar Lista de Partes</translation>
+        <translation>Mostrar lista de piezas</translation>
     </message>
     <message>
         <location filename="../common/lc_instructions.cpp" line="50"/>
@@ -4598,563 +4678,586 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
         <location filename="../common/lc_instructions.cpp" line="52"/>
         <location filename="../common/lc_instructions.cpp" line="60"/>
         <source>Text Color:</source>
-        <translation>Color del Texto:</translation>
+        <translation>Color de texto:</translation>
     </message>
     <message>
         <location filename="../common/lc_instructions.cpp" line="54"/>
         <location filename="../common/lc_instructions.cpp" line="56"/>
         <source>Background Color:</source>
-        <translation>Color de Fondo:</translation>
+        <translation>Color de fondo:</translation>
     </message>
     <message>
         <location filename="../common/lc_instructions.cpp" line="62"/>
         <source>Border Color:</source>
-        <translation>Color del Borde:</translation>
+        <translation>Color de borde:</translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsDialog</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="527"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="532"/>
         <source>Instructions</source>
         <translation>Instrucciones</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="542"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="547"/>
         <source>Page Settings</source>
-        <translation>Preferencias de la Página</translation>
+        <translation>Preferencias de página</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="552"/>
+        <source>Print</source>
+        <translation>Imprimir</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="554"/>
+        <source>Vertical</source>
+        <translation>Vertical</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="557"/>
+        <source>Horizontal</source>
+        <translation>Horizontal</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="571"/>
+        <source>Page %1</source>
+        <translation>Página %1</translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPageListWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="174"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="179"/>
         <source>Pages</source>
         <translation>Páginas</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="189"/>
+        <source>Page Setup</source>
+        <translation>Configuración de página</translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPropertiesWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="288"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="293"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Default</source>
-        <translation>Sistema</translation>
+        <translation>Predeterminado</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Model</source>
-        <translation>Modelo Actual</translation>
+        <translation>Modelo actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Only</source>
-        <translation>Solo Paso Actual</translation>
+        <translation>Solo paso actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Forward</source>
-        <translation>Siguiente Paso</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="296"/>
-        <source>Scope:</source>
-        <translation>Alcance:</translation>
+        <translation>Paso siguiente</translation>
     </message>
     <message>
         <location filename="../common/lc_instructionsdialog.cpp" line="301"/>
+        <source>Scope:</source>
+        <translation>Ámbito:</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="306"/>
         <source>Preset:</source>
-        <translation>Preestablecido:</translation>
+        <translation>Ajustes prestablecidos:</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="351"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="356"/>
         <source>Select Step Number Color</source>
-        <translation>Seleccionar el Numero del Color del Paso</translation>
+        <translation>Seleccionar color para el número del paso</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="355"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="360"/>
         <source>Select Step Background Color</source>
-        <translation>Seleccionar el Color del Fondo del Paso</translation>
+        <translation>Seleccionar color de fondo para los pasos</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="359"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="364"/>
         <source>Select Parts List Background Color</source>
-        <translation>Seleccionar el Color de fondo de la Lista de Partes</translation>
+        <translation>Seleccionar color de fondo para la lista de piezas</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="363"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="368"/>
         <source>Select Parts List Border Color</source>
-        <translation>Seleccionar el Color del borde de la Lista de Partes</translation>
+        <translation>Seleccionar color de borde para la lista de piezas</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="367"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="372"/>
         <source>Select Parts List Text Color</source>
-        <translation>Seleccionar el Color del Texto de la Lista de Partes</translation>
+        <translation>Seleccionar color de texto para la lista de piezas</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="417"/>
-        <location filename="../common/lc_instructionsdialog.cpp" line="438"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="422"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="443"/>
         <source>Select Step Number Font</source>
-        <translation>Seleccionar el Numero de Fuente del Paso</translation>
+        <translation>Seleccionar fuente para el número de paso</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="421"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="426"/>
         <source>Select Parts List Font</source>
-        <translation>Seleccionar la Fuente de la Lista de Partes</translation>
+        <translation>Seleccionar fuente para la lista de piezas</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="477"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="482"/>
         <source>Step Properties</source>
-        <translation>Propiedades de los Pasos</translation>
+        <translation>Propiedades de pasos</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="493"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="498"/>
         <source>Step Number Properties</source>
-        <translation>Propiedades de los Numeros de los Pasos</translation>
+        <translation>Propiedades de números de pasos</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="508"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="513"/>
         <source>Parts List Properties</source>
-        <translation>Propiedades de la Lista de Partes</translation>
+        <translation>Propiedades de la lista de piezas</translation>
     </message>
 </context>
 <context>
     <name>lcMainWindow</name>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="403"/>
-        <location filename="../common/lc_mainwindow.cpp" line="606"/>
-        <location filename="../common/lc_mainwindow.cpp" line="613"/>
+        <location filename="../common/lc_mainwindow.cpp" line="376"/>
+        <location filename="../common/lc_mainwindow.cpp" line="577"/>
+        <location filename="../common/lc_mainwindow.cpp" line="584"/>
         <source>Transform</source>
         <translation>Transformación</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="410"/>
+        <location filename="../common/lc_mainwindow.cpp" line="383"/>
         <source>C&amp;ameras</source>
         <translation>Cá&amp;maras</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="456"/>
+        <location filename="../common/lc_mainwindow.cpp" line="426"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="467"/>
+        <location filename="../common/lc_mainwindow.cpp" line="437"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="488"/>
+        <location filename="../common/lc_mainwindow.cpp" line="458"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="512"/>
+        <location filename="../common/lc_mainwindow.cpp" line="482"/>
         <source>&amp;View</source>
         <translation>&amp;Ver</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="419"/>
+        <location filename="../common/lc_mainwindow.cpp" line="389"/>
         <source>&amp;Viewpoints</source>
-        <translation>&amp;Puntos de Vista</translation>
+        <translation>&amp;Puntos de vista</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="398"/>
         <source>Projection</source>
         <translation>Proyección</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="521"/>
+        <location filename="../common/lc_mainwindow.cpp" line="491"/>
         <source>Ste&amp;p</source>
         <translation>Pa&amp;so</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="506"/>
         <source>T&amp;oolbars</source>
-        <translation>Barras de &amp;Herramientas</translation>
+        <translation>Barras de &amp;herramientas</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="549"/>
+        <location filename="../common/lc_mainwindow.cpp" line="519"/>
         <source>&amp;Piece</source>
         <translation>&amp;Pieza</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="583"/>
+        <location filename="../common/lc_mainwindow.cpp" line="554"/>
         <source>&amp;Help</source>
         <translation>&amp;Ayuda</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="614"/>
+        <location filename="../common/lc_mainwindow.cpp" line="585"/>
         <source>Transform Options</source>
-        <translation>Opciones de Transformación</translation>
+        <translation>Opciones de transformación</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="618"/>
+        <location filename="../common/lc_mainwindow.cpp" line="589"/>
         <source>Snap XY</source>
-        <translation>Acoplar XY</translation>
+        <translation>Rejilla XY</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="622"/>
+        <location filename="../common/lc_mainwindow.cpp" line="593"/>
         <source>Snap Z</source>
-        <translation>Acoplar Z</translation>
+        <translation>Rejilla Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="626"/>
+        <location filename="../common/lc_mainwindow.cpp" line="597"/>
         <source>Snap Menu</source>
-        <translation>Menu de Acoplar</translation>
+        <translation>Menu de ajuste</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="632"/>
+        <location filename="../common/lc_mainwindow.cpp" line="603"/>
         <source>Movement Snap</source>
-        <translation>Movimiento de Acoplar</translation>
+        <translation>Ajustar traslaciones</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="633"/>
+        <location filename="../common/lc_mainwindow.cpp" line="604"/>
         <source>Snap translations to fixed intervals</source>
-        <translation>Utilizar intervalos fijos para el acople de translación</translation>
+        <translation>Ajustar traslaciones a intervalos fijos</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="637"/>
+        <location filename="../common/lc_mainwindow.cpp" line="608"/>
         <source>Snap Angle Menu</source>
-        <translation>Menú de Angulos de Acople</translation>
+        <translation>Menú de ángulos de ajuste</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="643"/>
+        <location filename="../common/lc_mainwindow.cpp" line="614"/>
         <source>Rotation Snap</source>
-        <translation>Rotación de Acople</translation>
+        <translation>Ajustar rotaciones</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="644"/>
+        <location filename="../common/lc_mainwindow.cpp" line="615"/>
         <source>Snap rotations to fixed intervals</source>
-        <translation>Utilizar intervalos fijos para el acople de rotación</translation>
+        <translation>Ajustar rotaciones a intervalos fijos</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="648"/>
+        <location filename="../common/lc_mainwindow.cpp" line="619"/>
         <source>Standard</source>
-        <translation>Estandar</translation>
+        <translation>Estándar</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="437"/>
-        <location filename="../common/lc_mainwindow.cpp" line="674"/>
+        <location filename="../common/lc_mainwindow.cpp" line="407"/>
+        <location filename="../common/lc_mainwindow.cpp" line="645"/>
         <source>Tools</source>
-        <translation>Utilidades</translation>
+        <translation>Herramientas</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="172"/>
+        <location filename="../common/lc_mainwindow.cpp" line="145"/>
         <source>New Model</source>
-        <translation>Nuevo Modelo</translation>
+        <translation>Nuevo modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="173"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
+        <location filename="../common/lc_mainwindow.cpp" line="146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
         <source>Open Model</source>
-        <translation>Abrir Modelo</translation>
+        <translation>Abrir modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="174"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2507"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2434"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save Model</source>
-        <translation>Guardar Modelo</translation>
+        <translation>Guardar modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="432"/>
+        <location filename="../common/lc_mainwindow.cpp" line="402"/>
         <source>Sh&amp;ading</source>
         <translation>S&amp;ombreado</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="464"/>
+        <location filename="../common/lc_mainwindow.cpp" line="434"/>
         <source>&amp;Import</source>
         <translation>&amp;Importar</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="575"/>
+        <location filename="../common/lc_mainwindow.cpp" line="546"/>
         <source>Sub&amp;model</source>
         <translation>Sub&amp;modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="597"/>
-        <location filename="../common/lc_mainwindow.cpp" line="601"/>
+        <location filename="../common/lc_mainwindow.cpp" line="568"/>
+        <location filename="../common/lc_mainwindow.cpp" line="572"/>
         <source>Selection Mode</source>
-        <translation>Modo de Selección</translation>
+        <translation>Modo de selección</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="602"/>
+        <location filename="../common/lc_mainwindow.cpp" line="573"/>
         <source>Change selection mode</source>
         <translation>Cambiar modo de selección</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="666"/>
+        <location filename="../common/lc_mainwindow.cpp" line="637"/>
         <source>Time</source>
         <translation>Tiempo</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="696"/>
+        <location filename="../common/lc_mainwindow.cpp" line="667"/>
         <source>Parts</source>
         <translation>Piezas</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="702"/>
+        <location filename="../common/lc_mainwindow.cpp" line="673"/>
         <source>Colors</source>
         <translation>Colores</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="731"/>
+        <location filename="../common/lc_mainwindow.cpp" line="702"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="766"/>
+        <location filename="../common/lc_mainwindow.cpp" line="737"/>
         <source>Timeline</source>
-        <translation>Línea de Tiempo</translation>
+        <translation>Línea de tiempo</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
         <source>Part preview for &apos;%1&apos; failed.</source>
-        <translation>Fallo la previa de la Parte &apos;%1&apos; .</translation>
+        <translation type="vanished">Falló la previsualización de la pieza &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="814"/>
-        <location filename="../common/lc_mainwindow.cpp" line="815"/>
+        <location filename="../common/lc_mainwindow.cpp" line="784"/>
+        <location filename="../common/lc_mainwindow.cpp" line="785"/>
         <source>Preview</source>
-        <translation>Previa</translation>
+        <translation>Vista previa</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1031"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1001"/>
         <source>Close Other Tabs</source>
-        <translation>Cerrar las Otras Pestañas</translation>
+        <translation>Cerrar otras pestañas</translation>
     </message>
     <message>
         <source>Reset Views</source>
-        <translation type="vanished">Reiniciar Vistas</translation>
+        <translation type="vanished">Reiniciar vistas</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1113"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1083"/>
         <source>The file &apos;%1&apos; has been modified by another application, do you want to reload it?</source>
-        <translation>El archivo &apos;%1&apos; ha sido modificado por otro programa, quieres volver a cargarlo?</translation>
+        <translation>El archivo &apos;%1&apos; ha sido modificado por otro programa. ¿Quieres volver a cargarlo?</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1119"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1089"/>
         <source>File Changed</source>
-        <translation>Archivo Cambiado</translation>
+        <translation>Archivo cambiado</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2058"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1985"/>
         <source>%1 (ID: %2)</source>
-        <translation>%1 (ID : %2)</translation>
+        <translation>%1 (ID: %2)</translation>
     </message>
     <message numerus="yes">
-        <location filename="../common/lc_mainwindow.cpp" line="2064"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1991"/>
         <source>%n Object(s) selected</source>
         <translation>
-            <numerusform>%n Objeto seleccionado</numerusform>
-            <numerusform>%n Objectos seleccionados</numerusform>
+            <numerusform>%n objeto seleccionado</numerusform>
+            <numerusform>%n objetos seleccionados</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Rel</source>
         <translation>Rel</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Abs</source>
         <translation>Abs</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2074"/>
         <source> M: %1 %2 R: %3 %4 </source>
         <translation> M: %1 %2 R: %3 %4 </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Merge Model</source>
-        <translation>Fusionar Modelo</translation>
+        <translation>Fusionar modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
         <source>Merged 1 submodel.</source>
-        <translation>Un submodelo Fusionado 1.</translation>
+        <translation>Fusionado 1 submodelo.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>Merged %1 submodels.</source>
-        <translation>Submodelos %1 fusionados.</translation>
+        <translation>Fusionados %1 submodelos.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>Import</source>
         <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>LEGO Diginal Designer Files (*.lxf);;All Files (*.*)</source>
-        <translation>Archivos LEGO Diginal Designer (*.lxf);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos LEGO Diginal Designer (*.lxf);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2068"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1995"/>
         <source> - %1 (ID: %2)</source>
-        <translation> - %1 (ID : %2)</translation>
+        <translation> - %1 (ID: %2)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2072"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1999"/>
         <source> in group &apos;%1&apos;</source>
-        <translation> dentro del grupo « %1 »</translation>
+        <translation> dentro del grupo &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2110"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2037"/>
         <source>Step %1</source>
         <translation>Paso %1</translation>
     </message>
     <message>
         <source> M: %1 %2 R: %3 </source>
-        <translation type="vanished"> M : %1 %2 R : %3 </translation>
+        <translation type="vanished"> M: %1 %2 R: %3 </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2168"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2095"/>
         <source>&amp;Undo %1</source>
         <translation>&amp;Deshacer %1</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2173"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2100"/>
         <source>&amp;Undo</source>
         <translation>Des&amp;hacer</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2179"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2106"/>
         <source>&amp;Redo %1</source>
         <translation>&amp;Rehacer %1</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2184"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2111"/>
         <source>&amp;Redo</source>
         <translation>&amp;Rehacer</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Supported Files (*.lcd *.ldr *.dat *.mpd);;All Files (*.*)</source>
-        <translation>Archivos Soportados (*.lcd *.ldr *.dat *.mpd);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos soportados (*.lcd *.ldr *.dat *.mpd);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
         <source>Error loading &apos;%1&apos;.</source>
-        <translation type="vanished">Error cargando « %1 ».</translation>
+        <translation type="vanished">Error cargando &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.mpd);;All Files (*.*)</source>
-        <translation>Archivos Soportados (*.mpd);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos soportados (*.mpd);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.ldr *.dat *.mpd);;All Files (*.*)</source>
-        <translation>Archivos Soportados (*.ldr *.dat *.mpd);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos soportados (*.ldr *.dat *.mpd);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Saving files in LCD format is no longer supported, please use the LDR or MPD formats instead.</source>
-        <translation>Guardar archivos con el formato LCD ya no esta soportado, Por favor utilizar los formatos LDR o MPD en su lugar.</translation>
+        <translation>Guardar archivos en formato LCD ya no está soportado, Por favor, utiliza los formatos LDR o MPD en su lugar.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save changes to &apos;%1&apos;?</source>
-        <translation>Guardar los cambios en « %1 » ?</translation>
+        <translation>¿Guardar los cambios en &apos;%1&apos;?</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/20S</source>
         <translation>1/20T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/4S</source>
         <translation>1/4T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1F</source>
         <translation>1P</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/2S</source>
         <translation>1/2T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1S</source>
         <translation>1T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>2S</source>
         <translation>2T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>3S</source>
         <translation>3T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>4S</source>
         <translation>4T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>8S</source>
         <translation>8T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="152"/>
-        <location filename="../common/lc_mainwindow.h" line="158"/>
-        <location filename="../common/lc_mainwindow.h" line="163"/>
+        <location filename="../common/lc_mainwindow.h" line="131"/>
+        <location filename="../common/lc_mainwindow.h" line="137"/>
+        <location filename="../common/lc_mainwindow.h" line="142"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1B</source>
         <translation>1B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>2B</source>
         <translation>2B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>4B</source>
         <translation>4B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>8B</source>
         <translation>8B</translation>
     </message>
@@ -5164,395 +5267,396 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../common/lc_minifigdialog.ui" line="14"/>
         <source>Minifig Wizard</source>
-        <translation type="unfinished">Asistente de Minifig</translation>
+        <translation>Asistente de Minifig</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.ui" line="686"/>
         <source>Templates</source>
-        <translation type="unfinished">Plantillas</translation>
+        <translation>Plantillas</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.ui" line="702"/>
         <source>Save...</source>
-        <translation type="unfinished">Guardar...</translation>
+        <translation>Guardar...</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.ui" line="709"/>
         <source>Delete...</source>
-        <translation type="unfinished">Borrar…</translation>
+        <translation>Borrar...</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.ui" line="716"/>
         <source>Import...</source>
-        <translation type="unfinished">Importar...</translation>
+        <translation>Importar...</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.ui" line="723"/>
         <source>Export...</source>
-        <translation type="unfinished">Exportar…</translation>
+        <translation>Exportar...</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="159"/>
         <location filename="../common/lc_minifigdialog.cpp" line="166"/>
         <source>Save Template</source>
-        <translation type="unfinished">Guardar Plantilla</translation>
+        <translation>Guardar plantilla</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="159"/>
         <source>Template Name:</source>
-        <translation type="unfinished">Nombre de Plantilla:</translation>
+        <translation>Nombre de plantilla:</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="166"/>
         <source>Template name cannot be empty.</source>
-        <translation type="unfinished">La plantilla no puede estar vacía.</translation>
+        <translation>El nombre de plantilla no puede estar vacío.</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="172"/>
         <source>Are you sure you want to overwrite the template &apos;%1&apos;?</source>
-        <translation type="unfinished">Estas seguro de querer sobreescribir la plantilla &apos;%1&apos;?</translation>
+        <translation>¿Seguro que quieres sobreescribir la plantilla &apos;%1&apos;?</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="173"/>
         <source>Overwrite Template</source>
-        <translation type="unfinished">Sobreescribir Plantilla</translation>
+        <translation>Sobreescribir plantilla</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="198"/>
         <source>Are you sure you want to delete the template &apos;%1&apos;?</source>
-        <translation type="unfinished">Estas seguro de querer borrar la plantilla &apos;%1&apos;?</translation>
+        <translation>¿Seguro que quieres borrar la plantilla &apos;%1&apos;?</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="200"/>
         <source>Delete Template</source>
-        <translation type="unfinished">Borrar Plantilla</translation>
+        <translation>Borrar plantilla</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="210"/>
         <source>Import Templates</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar plantillas</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="210"/>
         <location filename="../common/lc_minifigdialog.cpp" line="231"/>
         <source>Minifig Template Files (*.minifig);;All Files (*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivos de plantillas de Minifig (*.minifig);;Todos los archivos(*.*)</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="219"/>
         <location filename="../common/lc_minifigdialog.cpp" line="240"/>
         <source>Error</source>
-        <translation type="unfinished">Error</translation>
+        <translation>Error</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="219"/>
         <source>Error reading file &apos;%1&apos;:
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Error leyendo el archivo &apos;%1&apos;:
+%2</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="231"/>
         <source>Export Templates</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportar plantillas</translation>
     </message>
     <message>
         <location filename="../common/lc_minifigdialog.cpp" line="240"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
-        <translation type="unfinished">Error guardando el archivo « %1 » :
+        <translation>Error escribiendo el archivo &apos;%1&apos;:
 %2</translation>
     </message>
 </context>
 <context>
     <name>lcModel</name>
     <message>
-        <location filename="../common/lc_model.cpp" line="1146"/>
+        <location filename="../common/lc_model.cpp" line="1143"/>
         <source>Pasting</source>
-        <translation>Pegando</translation>
+        <translation>pegado</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="2531"/>
-        <location filename="../common/lc_model.cpp" line="4307"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
         <source>Error creating images.</source>
-        <translation>Error creando imagenes.</translation>
+        <translation>Error creando imágenes.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1765"/>
+        <location filename="../common/lc_model.cpp" line="1768"/>
         <source>Inserting Step</source>
-        <translation>Insertar Paso</translation>
+        <translation>inserción de paso</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1784"/>
+        <location filename="../common/lc_model.cpp" line="1787"/>
         <source>Removing Step</source>
-        <translation>Quitar Paso</translation>
+        <translation>eliminación de paso</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
         <source>No pieces selected.</source>
         <translation>Ninguna pieza seleccionada.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="957"/>
-        <location filename="../common/lc_model.cpp" line="1831"/>
+        <location filename="../common/lc_model.cpp" line="954"/>
+        <location filename="../common/lc_model.cpp" line="1834"/>
         <source>Group #</source>
-        <translation>Grupo n°</translation>
+        <translation>Grupo #</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1100"/>
+        <location filename="../common/lc_model.cpp" line="1097"/>
         <source>Cutting</source>
-        <translation>Cortando</translation>
+        <translation>cortado</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1219"/>
+        <location filename="../common/lc_model.cpp" line="1216"/>
         <source>Duplicating Pieces</source>
-        <translation>Duplicando Piezas</translation>
+        <translation>duplicación de piezas</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
-        <translation>Error guardando el archivo « %1 » :
+        <translation>Error escribiendo el archivo &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1850"/>
-        <location filename="../common/lc_model.cpp" line="1916"/>
+        <location filename="../common/lc_model.cpp" line="1853"/>
+        <location filename="../common/lc_model.cpp" line="1919"/>
         <source>Grouping</source>
-        <translation>Agrupado</translation>
+        <translation>agrupación</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1886"/>
-        <location filename="../common/lc_model.cpp" line="1931"/>
+        <location filename="../common/lc_model.cpp" line="1889"/>
+        <location filename="../common/lc_model.cpp" line="1934"/>
         <source>Ungrouping</source>
-        <translation>Desagrupado</translation>
+        <translation>desagrupación</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1977"/>
+        <location filename="../common/lc_model.cpp" line="1980"/>
         <source>Editing Groups</source>
-        <translation>Editar Grupos</translation>
+        <translation>edición de grupos</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2176"/>
+        <location filename="../common/lc_model.cpp" line="2179"/>
         <source>Adding Piece</source>
-        <translation>Añadiendo Pieza</translation>
+        <translation>adición de pieza</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2218"/>
+        <location filename="../common/lc_model.cpp" line="2221"/>
         <source>Resetting Cameras</source>
-        <translation>Reseteando Cámaras</translation>
+        <translation>reiniciado de cámaras</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2258"/>
+        <location filename="../common/lc_model.cpp" line="2261"/>
         <source>Removing Key Frames</source>
-        <translation>Quitando Fotogramas Clave</translation>
+        <translation>eliminación de fotogramas clave</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2275"/>
-        <location filename="../common/lc_model.cpp" line="2292"/>
-        <location filename="../common/lc_model.cpp" line="2334"/>
-        <location filename="../common/lc_model.cpp" line="2379"/>
-        <location filename="../common/lc_model.cpp" line="2414"/>
+        <location filename="../common/lc_model.cpp" line="2278"/>
+        <location filename="../common/lc_model.cpp" line="2295"/>
+        <location filename="../common/lc_model.cpp" line="2337"/>
+        <location filename="../common/lc_model.cpp" line="2382"/>
+        <location filename="../common/lc_model.cpp" line="2417"/>
         <source>Modifying</source>
-        <translation>Modificando</translation>
+        <translation>modificación</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2482"/>
+        <location filename="../common/lc_model.cpp" line="2485"/>
         <source>New Model</source>
-        <translation>Nuevo Modelo</translation>
+        <translation>nuevo modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2535"/>
+        <location filename="../common/lc_model.cpp" line="2538"/>
         <source>Inlining</source>
-        <translation>Insertando</translation>
+        <translation>fusión</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2677"/>
         <source>Moving</source>
-        <translation>Moviendo</translation>
+        <translation>movimiento</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2772"/>
         <source>Rotating</source>
-        <translation>Rotando</translation>
+        <translation>rotación</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2798"/>
         <source>Scaling</source>
-        <translation>Escalando</translation>
+        <translation>escalado</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2868"/>
         <source>Setting Part</source>
-        <translation>Mofificar una Pieza</translation>
+        <translation>cambio de pieza</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3723"/>
-        <location filename="../common/lc_model.cpp" line="3746"/>
+        <location filename="../common/lc_model.cpp" line="3741"/>
+        <location filename="../common/lc_model.cpp" line="3764"/>
         <source>Hide</source>
-        <translation>Ocultar</translation>
+        <translation>ocultación</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3769"/>
-        <location filename="../common/lc_model.cpp" line="3792"/>
+        <location filename="../common/lc_model.cpp" line="3787"/>
+        <location filename="../common/lc_model.cpp" line="3810"/>
         <source>Unhide</source>
-        <translation>Mostrar</translation>
+        <translation>mostrado</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3834"/>
+        <location filename="../common/lc_model.cpp" line="3852"/>
         <source>Replacing Part</source>
-        <translation>Reemplazar Parte</translation>
+        <translation>reemplazo de pieza</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3939"/>
+        <location filename="../common/lc_model.cpp" line="3957"/>
         <source>New SpotLight</source>
-        <translation>Nuevo Foco</translation>
+        <translation>nuevo foco</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3944"/>
+        <location filename="../common/lc_model.cpp" line="3962"/>
         <source>New Camera</source>
-        <translation>Nueva Cámara</translation>
+        <translation>nueva cámara</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3951"/>
+        <location filename="../common/lc_model.cpp" line="3969"/>
         <source>Move</source>
-        <translation>Mover</translation>
+        <translation>movimiento</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3955"/>
+        <location filename="../common/lc_model.cpp" line="3973"/>
         <source>Rotate</source>
-        <translation>Rotar</translation>
+        <translation>rotación</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3965"/>
-        <location filename="../common/lc_model.cpp" line="4206"/>
-        <location filename="../common/lc_model.cpp" line="4266"/>
-        <location filename="../common/lc_model.cpp" line="4278"/>
+        <location filename="../common/lc_model.cpp" line="3983"/>
+        <location filename="../common/lc_model.cpp" line="4224"/>
+        <location filename="../common/lc_model.cpp" line="4284"/>
+        <location filename="../common/lc_model.cpp" line="4296"/>
         <source>Zoom</source>
-        <translation>Ampliación</translation>
+        <translation>ampliación</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3970"/>
+        <location filename="../common/lc_model.cpp" line="3988"/>
         <source>Pan</source>
-        <translation>Desplazar</translation>
+        <translation>desplazamiento</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3975"/>
+        <location filename="../common/lc_model.cpp" line="3993"/>
         <source>Orbit</source>
-        <translation>Orbitar</translation>
+        <translation>órbita</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3980"/>
+        <location filename="../common/lc_model.cpp" line="3998"/>
         <source>Roll</source>
-        <translation>Pivotar</translation>
+        <translation>pivotaje</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4002"/>
+        <location filename="../common/lc_model.cpp" line="4020"/>
         <source>Insert</source>
-        <translation>Insertar</translation>
+        <translation>inserción</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4012"/>
+        <location filename="../common/lc_model.cpp" line="4030"/>
         <source>New Light</source>
-        <translation>Nueva Luz</translation>
+        <translation>nueva luz</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2229"/>
-        <location filename="../common/lc_model.cpp" line="4131"/>
+        <location filename="../common/lc_model.cpp" line="2232"/>
+        <location filename="../common/lc_model.cpp" line="4149"/>
         <source>Deleting</source>
-        <translation>Borrar</translation>
+        <translation>borrado</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2844"/>
-        <location filename="../common/lc_model.cpp" line="4145"/>
+        <location filename="../common/lc_model.cpp" line="4163"/>
         <source>Painting</source>
-        <translation>Pintar</translation>
+        <translation>pintado</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2531"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
         <source>No models selected.</source>
-        <translation>Ningun modelo seleccionado.</translation>
+        <translation>Ningún modelo seleccionado.</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2912"/>
         <source>Showing Pieces</source>
-        <translation>Montre les pièces</translation>
+        <translation>mostrado de piezas</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2941"/>
         <source>Hiding Pieces</source>
-        <translation>Escondiendo Piezas</translation>
+        <translation>ocultación de piezas</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2956"/>
         <location filename="../common/lc_model.cpp" line="2981"/>
         <location filename="../common/lc_model.cpp" line="2993"/>
         <source>Editing Camera</source>
-        <translation>Editando Cámara</translation>
+        <translation>edición de cámara</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2969"/>
         <source>Changing FOV</source>
-        <translation>Cambiando el FOV</translation>
+        <translation>cambio de campo de visión</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="3004"/>
         <source>Renaming Camera</source>
-        <translation>Renombrando Cámara</translation>
+        <translation>renombrado de cámara</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4229"/>
+        <location filename="../common/lc_model.cpp" line="4247"/>
         <source>Look At</source>
-        <translation>Mirar el modelo</translation>
+        <translation>mirar al modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4239"/>
+        <location filename="../common/lc_model.cpp" line="4257"/>
         <source>Moving Camera</source>
-        <translation>Moviendo Cámara</translation>
+        <translation>movimiento de cámara</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4300"/>
+        <location filename="../common/lc_model.cpp" line="4319"/>
         <source>Changing Properties</source>
-        <translation>Cambiar las propiedades</translation>
+        <translation>cambio de propiedades</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4307"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
         <source>Nothing to select.</source>
-        <translation>Nada para seleccionar.</translation>
+        <translation>Nada que seleccionar.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>Array only has 1 element or less, no pieces added.</source>
-        <translation>El conjunto solo tiene un elemento o menos, ninguna pieza añadida.</translation>
+        <translation>La secuencia solo tiene un elemento o menos, ninguna pieza añadida.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4390"/>
+        <location filename="../common/lc_model.cpp" line="4409"/>
         <source>Array</source>
-        <translation>Conjunto</translation>
+        <translation>secuencia</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4402"/>
+        <location filename="../common/lc_model.cpp" line="4421"/>
         <source>Minifig #</source>
-        <translation>Minifig n°</translation>
+        <translation>Minifig #</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4424"/>
+        <location filename="../common/lc_model.cpp" line="4443"/>
         <source>Minifig</source>
         <translation>Minifig</translation>
     </message>
@@ -5562,7 +5666,7 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../common/lc_pagesetupdialog.ui" line="14"/>
         <source>Page Setup</source>
-        <translation>Configuración de la Página</translation>
+        <translation>Configuración de página</translation>
     </message>
     <message>
         <location filename="../common/lc_pagesetupdialog.ui" line="20"/>
@@ -5582,7 +5686,7 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../common/lc_pagesetupdialog.ui" line="52"/>
         <source>Preset:</source>
-        <translation>Preestablecido:</translation>
+        <translation>Ajustes predefinidos:</translation>
     </message>
     <message>
         <location filename="../common/lc_pagesetupdialog.ui" line="62"/>
@@ -5592,7 +5696,7 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../common/lc_pagesetupdialog.ui" line="75"/>
         <source>Margins</source>
-        <translation>Margenes</translation>
+        <translation>Márgenes</translation>
     </message>
     <message>
         <location filename="../common/lc_pagesetupdialog.ui" line="81"/>
@@ -5620,17 +5724,17 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../common/lc_partpalettedialog.ui" line="14"/>
         <source>Part Palettes</source>
-        <translation>Paletas de Partes</translation>
+        <translation>Paletas de piezas</translation>
     </message>
     <message>
         <location filename="../common/lc_partpalettedialog.ui" line="27"/>
         <source>New...</source>
-        <translation>Nuevo…</translation>
+        <translation>Nueva...</translation>
     </message>
     <message>
         <location filename="../common/lc_partpalettedialog.ui" line="34"/>
         <source>Delete...</source>
-        <translation>Borrar…</translation>
+        <translation>Borrar...</translation>
     </message>
     <message>
         <location filename="../common/lc_partpalettedialog.ui" line="41"/>
@@ -5645,38 +5749,38 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../common/lc_partpalettedialog.ui" line="55"/>
         <source>Move Up</source>
-        <translation>Mover Arriba</translation>
+        <translation>Mover arriba</translation>
     </message>
     <message>
         <location filename="../common/lc_partpalettedialog.ui" line="62"/>
         <source>Move Down</source>
-        <translation>Mover Abajo</translation>
+        <translation>Mover abajo</translation>
     </message>
     <message>
         <location filename="../common/lc_partpalettedialog.cpp" line="68"/>
         <source>New Part Palette</source>
-        <translation>Nueva Paleta de Partes</translation>
+        <translation>Nueva paleta de piezas</translation>
     </message>
     <message>
         <location filename="../common/lc_partpalettedialog.cpp" line="68"/>
         <location filename="../common/lc_partpalettedialog.cpp" line="107"/>
         <source>Palette Name:</source>
-        <translation>Nombre de la Paleta:</translation>
+        <translation>Nombre de paleta:</translation>
     </message>
     <message>
         <location filename="../common/lc_partpalettedialog.cpp" line="87"/>
         <source>Are you sure you want to delete the palette &apos;%1&apos;?</source>
-        <translation>Estas seguro de querer borrar la paleta &apos;%1&apos;?</translation>
+        <translation>¿Seguro que quieres borrar la paleta &apos;%1&apos;?</translation>
     </message>
     <message>
         <location filename="../common/lc_partpalettedialog.cpp" line="88"/>
         <source>Delete Part Palette</source>
-        <translation>Borrar la Paleta de Partes</translation>
+        <translation>Borrar paleta de piezas</translation>
     </message>
     <message>
         <location filename="../common/lc_partpalettedialog.cpp" line="107"/>
         <source>Rename Part Palette</source>
-        <translation>Renombrar la Paleta de Partes</translation>
+        <translation>Renombrar paleta de piezas</translation>
     </message>
 </context>
 <context>
@@ -5687,135 +5791,140 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     </message>
     <message>
         <source>Small Icons</source>
-        <translation type="vanished">Iconos Pequeños</translation>
+        <translation type="vanished">Iconos pequeños</translation>
     </message>
     <message>
         <source>Medium Icons</source>
-        <translation type="vanished">Iconos Medianos</translation>
+        <translation type="vanished">Iconos medianos</translation>
     </message>
     <message>
         <source>Large Icons</source>
-        <translation type="vanished">Iconos Grandes</translation>
+        <translation type="vanished">Iconos grandes</translation>
     </message>
     <message>
         <source>Extra Large Icons</source>
-        <translation type="vanished">Iconos Extra Grandes</translation>
+        <translation type="vanished">Iconos extra grandes</translation>
     </message>
     <message>
         <source>Show Part Names</source>
-        <translation type="vanished">Mostras Nombres de las Piezas</translation>
+        <translation type="vanished">Mostrar nombre de piezas</translation>
     </message>
     <message>
         <source>Show Decorated Parts</source>
-        <translation type="vanished">Mostrar Piezas Decoradas</translation>
+        <translation type="vanished">Mostrar piezas decoradas</translation>
     </message>
     <message>
         <source>List Mode</source>
-        <translation type="vanished">Listar Modo</translation>
+        <translation type="vanished">Modo lista</translation>
     </message>
     <message>
         <source>Lock Preview Color</source>
-        <translation type="vanished">Fijar Previa de Color</translation>
+        <translation type="vanished">Bloquear color</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="524"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="551"/>
         <source>Add to Palette</source>
-        <translation>Añadir a la Paleta</translation>
+        <translation>Añadir a paleta</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="535"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="562"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="539"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="566"/>
         <source>Remove from Palette</source>
-        <translation>Quitar de la Paleta</translation>
+        <translation>Quitar de paleta</translation>
     </message>
 </context>
 <context>
     <name>lcPartSelectionWidget</name>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="719"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="746"/>
         <source>Search Parts</source>
-        <translation>Buscar Piezas</translation>
+        <translation>Buscar piezas</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="726"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="753"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="884"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="902"/>
+        <source>Edit Palettes...</source>
+        <translation>Editar paletas...</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_partselectionwidget.cpp" line="911"/>
         <source>No Icons</source>
-        <translation>Sin Iconos</translation>
+        <translation>Sin iconos</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="889"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="916"/>
         <source>Small Icons</source>
-        <translation>Iconos Pequeños</translation>
+        <translation>Iconos pequeños</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="894"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="921"/>
         <source>Medium Icons</source>
-        <translation>Iconos Medianos</translation>
+        <translation>Iconos medianos</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="899"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="926"/>
         <source>Large Icons</source>
-        <translation>Iconos Grandes</translation>
+        <translation>Iconos grandes</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="904"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="931"/>
         <source>Extra Large Icons</source>
-        <translation>Iconos Extra Grandes</translation>
+        <translation>Iconos extra grandes</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="914"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="941"/>
         <source>Show Part Names</source>
-        <translation>Mostras Nombres de las Piezas</translation>
+        <translation>Mostrar nombre de pieza</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="919"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="946"/>
         <source>Show Decorated Parts</source>
-        <translation>Mostrar Piezas Decoradas</translation>
+        <translation>Mostrar piezas decoradas</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="923"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="950"/>
         <source>Show Part Aliases</source>
-        <translation>Mostrar los Apodos de las Piezas</translation>
+        <translation>Mostrar apodos de piezas</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="929"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="956"/>
         <source>List Mode</source>
-        <translation>Listar Modo</translation>
+        <translation>Modo lista</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="933"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="960"/>
         <source>Lock Preview Color</source>
-        <translation>Fijar Previa de Color</translation>
+        <translation>Bloquear color</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="975"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1002"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1091"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1118"/>
         <source>All Parts</source>
-        <translation>Todas las Piezas</translation>
+        <translation>Todas las piezas</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1097"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1124"/>
         <source>In Use</source>
-        <translation>En Uso</translation>
+        <translation>En uso</translation>
     </message>
     <message>
         <source>Parts In Use</source>
-        <translation type="vanished">Piezas Usadas</translation>
+        <translation type="vanished">Piezas usadas</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1103"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1130"/>
         <source>Submodels</source>
         <translation>Submodelos</translation>
     </message>
@@ -5823,22 +5932,23 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
 <context>
     <name>lcPiecesLibrary</name>
     <message>
-        <location filename="../common/lc_library.cpp" line="775"/>
+        <location filename="../common/lc_library.cpp" line="782"/>
         <source>Initializing</source>
         <translation>Inicializando</translation>
     </message>
     <message>
-        <location filename="../common/lc_library.cpp" line="776"/>
+        <location filename="../common/lc_library.cpp" line="783"/>
         <source>Loading Parts Library</source>
-        <translation>Cargando Librería de Piezas</translation>
+        <translation>Cargando biblioteca de piezas</translation>
     </message>
 </context>
 <context>
     <name>lcPreviewDockWidget</name>
     <message>
         <location filename="../common/lc_previewwidget.cpp" line="19"/>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
         <source>Lock Preview</source>
-        <translation>Bloquear Previa</translation>
+        <translation>Bloquear previsualización</translation>
     </message>
     <message>
         <location filename="../common/lc_previewwidget.cpp" line="22"/>
@@ -5848,7 +5958,7 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../common/lc_previewwidget.cpp" line="28"/>
         <source>Toolbar</source>
-        <translation>Barra de Herramientas</translation>
+        <translation>Barra de herramientas</translation>
     </message>
     <message>
         <location filename="../common/lc_previewwidget.cpp" line="30"/>
@@ -5861,24 +5971,35 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
         <translation>Cargando...</translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Unlock</source>
-        <translation>Desbloquear</translation>
-    </message>
-    <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Lock</source>
-        <translation>Bloquear</translation>
-    </message>
-    <message>
         <location filename="../common/lc_previewwidget.cpp" line="78"/>
-        <source>%1 the preview display to %2 updates</source>
-        <translation>%1 la visualización previa en %2 actualizaciones</translation>
+        <source>Unlock the preview display to enable updates</source>
+        <translation>Desbloquear previsualización para permitir actualizaciones</translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="80"/>
+        <location filename="../common/lc_previewwidget.cpp" line="79"/>
+        <source>Lock the preview display to disable updates</source>
+        <translation>Bloquear previsualización para impedir actualizaciones</translation>
+    </message>
+    <message>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
+        <source>Unlock Preview</source>
+        <translation>Desbloquear previsualización</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation type="vanished">Desbloquear</translation>
+    </message>
+    <message>
+        <source>Lock</source>
+        <translation type="vanished">Bloquear</translation>
+    </message>
+    <message>
+        <source>%1 the preview display to %2 updates</source>
+        <translation type="vanished">%1 la visualización previa en %2 actualizaciones</translation>
+    </message>
+    <message>
         <source>%1 Preview</source>
-        <translation>%1 Previa</translation>
+        <translation type="vanished">%1 previsualización</translation>
     </message>
 </context>
 <context>
@@ -5906,12 +6027,12 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
     <message>
         <location filename="../qt/lc_qaboutdialog.cpp" line="18"/>
         <source>LeoCAD Version %1</source>
-        <translation>Version de LeoCAD %1</translation>
+        <translation>LeoCAD versión %1</translation>
     </message>
     <message>
         <source>Qt version %1 (compiled with %2)
 </source>
-        <translation type="vanished">Version de QT %1 (compilado con %2)
+        <translation type="vanished">QT versión %1 (compilado con %2)
 </translation>
     </message>
     <message>
@@ -5920,7 +6041,7 @@ Por favor Visite https://www.leocad.org para aprender como descargar e instalar 
 %3 - %4
 
 </source>
-        <translation>Version de OpenGL %1 (GLSL %2)
+        <translation>OpenGL versión %1 (GLSL %2)
 %3 - %4
 
 </translation>
@@ -5931,9 +6052,9 @@ Depth Buffer: %4 bits
 Stencil Buffer: %5 bits
 
 </source>
-        <translation type="vanished">Memoria Intermedia de Color: %1 bits %2 %3
-Memoria Intermedia de Profundidad: %4 bits
-Memoria Intermedia de Éstencil: %5 bits
+        <translation type="vanished">Memoria intermedia de color: %1 bits %2 %3
+Memoria intermedia de profundidad: %4 bits
+Memoria intermedia de éstencil: %5 bits
 
 </translation>
     </message>
@@ -5943,7 +6064,7 @@ Memoria Intermedia de Éstencil: %5 bits
     </message>
     <message>
         <source>double buffered</source>
-        <translation type="vanished">Memoria Intermedia Doble</translation>
+        <translation type="vanished">Memoria intermedia doble</translation>
     </message>
     <message>
         <source>GL_ARB_vertex_buffer_object extension: %1
@@ -5962,14 +6083,14 @@ GL_EXT_texture_filter_anisotropic extension: %5
     <message>
         <location filename="../qt/lc_qaboutdialog.cpp" line="16"/>
         <source>LeoCAD Continuous Build %1</source>
-        <translation>LeoCAD Compilación Continua %1</translation>
+        <translation>LeoCAD compilación continua %1</translation>
     </message>
     <message>
         <location filename="../qt/lc_qaboutdialog.cpp" line="26"/>
         <source>Qt Version %1 (compiled with %2)
 
 </source>
-        <translation>Version de QT %1 (compilado con %2)
+        <translation>QT versión %1 (compilado con %2)
 
 </translation>
     </message>
@@ -6029,7 +6150,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qarraydialog.ui" line="14"/>
         <source>Array</source>
-        <translation>Conjunto</translation>
+        <translation>Secuencia</translation>
     </message>
     <message>
         <location filename="../qt/lc_qarraydialog.ui" line="22"/>
@@ -6039,7 +6160,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qarraydialog.ui" line="65"/>
         <source>Offsets</source>
-        <translation>Atenuaciones</translation>
+        <translation>Desplazamientos</translation>
     </message>
     <message>
         <location filename="../qt/lc_qarraydialog.ui" line="101"/>
@@ -6049,7 +6170,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qarraydialog.cpp" line="74"/>
         <source>Array is empty.</source>
-        <translation>El Conjunto está vacío.</translation>
+        <translation>La secuencia está vacía.</translation>
     </message>
 </context>
 <context>
@@ -6067,27 +6188,27 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qcategorydialog.ui" line="35"/>
         <source>Keywords:</source>
-        <translation>Palabras Clave:</translation>
+        <translation>Palabras clave:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qcategorydialog.cpp" line="15"/>
         <source>Edit Category</source>
-        <translation>Editar la Categoría</translation>
+        <translation>Editar categoría</translation>
     </message>
     <message>
         <location filename="../qt/lc_qcategorydialog.cpp" line="17"/>
         <source>New Category</source>
-        <translation>Nueva Categoría</translation>
+        <translation>Nueva categoría</translation>
     </message>
     <message>
         <location filename="../qt/lc_qcategorydialog.cpp" line="34"/>
         <source>Name cannot be empty.</source>
-        <translation>El Nombre no puede estar vacío.</translation>
+        <translation>El nombre no puede estar vacío.</translation>
     </message>
     <message>
         <location filename="../qt/lc_qcategorydialog.cpp" line="42"/>
         <source>Keywords cannot be empty.</source>
-        <translation>Las Palabras Clave no pueden estar vacías.</translation>
+        <translation>El palabras clave no puede estar vacío.</translation>
     </message>
 </context>
 <context>
@@ -6095,17 +6216,17 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qeditgroupsdialog.ui" line="14"/>
         <source>Edit Groups</source>
-        <translation>Edición de Grupos</translation>
+        <translation>Editar grupos</translation>
     </message>
     <message>
         <location filename="../qt/lc_qeditgroupsdialog.cpp" line="20"/>
         <source>New Group</source>
-        <translation>Nuevo Grupo</translation>
+        <translation>Nuevo grupo</translation>
     </message>
     <message>
         <location filename="../qt/lc_qeditgroupsdialog.cpp" line="59"/>
         <source>Group #</source>
-        <translation>Grupo n°</translation>
+        <translation>Grupo #</translation>
     </message>
 </context>
 <context>
@@ -6120,7 +6241,7 @@ Anisotropic: %5
     </message>
     <message>
         <source>Part ID</source>
-        <translation type="vanished">ID de la pieza</translation>
+        <translation type="vanished">ID de pieza</translation>
     </message>
     <message>
         <source>Color</source>
@@ -6142,7 +6263,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qgroupdialog.cpp" line="26"/>
         <source>Name cannot be empty.</source>
-        <translation>El Nombre no puede estar vacío.</translation>
+        <translation>El nombre no puede estar vacío.</translation>
     </message>
 </context>
 <context>
@@ -6160,7 +6281,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="40"/>
         <source>Output folder:</source>
-        <translation>Carpeta de Salida :</translation>
+        <translation>Carpeta de salida:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="53"/>
@@ -6185,7 +6306,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="122"/>
         <source>Index page</source>
-        <translation>Página de Índice</translation>
+        <translation>Página índice</translation>
     </message>
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="72"/>
@@ -6195,17 +6316,17 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="78"/>
         <source>All Models</source>
-        <translation>Todos los Modelos</translation>
+        <translation>Todos los modelos</translation>
     </message>
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="85"/>
         <source>Current Model and Submodels</source>
-        <translation>Modelo Actual y Submodelos</translation>
+        <translation>Modelo actual y submodelos</translation>
     </message>
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="92"/>
         <source>Current Model Only</source>
-        <translation>Solo el Modelo Actual</translation>
+        <translation>Solo el modelo actual</translation>
     </message>
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="102"/>
@@ -6215,12 +6336,12 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="108"/>
         <source>Single Page</source>
-        <translation>Página Única</translation>
+        <translation>Página individual</translation>
     </message>
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="115"/>
         <source>One Step per Page</source>
-        <translation>Un Paso por Página</translation>
+        <translation>Un paso por página</translation>
     </message>
     <message>
         <source>Highlight new parts</source>
@@ -6229,7 +6350,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="172"/>
         <source>Parts List</source>
-        <translation>Lista de Piezas</translation>
+        <translation>Lista de piezas</translation>
     </message>
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="178"/>
@@ -6239,7 +6360,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qhtmldialog.ui" line="185"/>
         <source>After each step</source>
-        <translation>Después de cada paso</translation>
+        <translation>Tras cada paso</translation>
     </message>
     <message>
         <source>Color:</source>
@@ -6247,7 +6368,7 @@ Anisotropic: %5
     </message>
     <message>
         <source>Create images</source>
-        <translation type="vanished">Crear imagenes</translation>
+        <translation type="vanished">Crear imágenes</translation>
     </message>
     <message>
         <location filename="../qt/lc_qhtmldialog.cpp" line="46"/>
@@ -6257,7 +6378,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qhtmldialog.cpp" line="66"/>
         <source>Select Output Folder</source>
-        <translation>Seleccionar la Carpeta de Salida</translation>
+        <translation>Seleccionar carpeta de salida</translation>
     </message>
 </context>
 <context>
@@ -6265,12 +6386,12 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="14"/>
         <source>Save Image</source>
-        <translation>Guardar Imagen</translation>
+        <translation>Guardar imagen</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="24"/>
         <source>File name:</source>
-        <translation>Nombre del archivo :</translation>
+        <translation>Nombre de archivo:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="48"/>
@@ -6280,42 +6401,42 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="109"/>
         <source>Step Range</source>
-        <translation>Intervalo de Pasos</translation>
+        <translation>Intervalo de pasos</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="115"/>
         <source>All Steps</source>
-        <translation>Todos los Pasos</translation>
+        <translation>Todos los pasos</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="122"/>
         <source>Current Step</source>
-        <translation>Paso Actual</translation>
+        <translation>Paso actual</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="131"/>
         <source>Custom Range</source>
-        <translation>Intervalo Personalizado</translation>
+        <translation>Intervalo personalizado</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="138"/>
         <source>From:</source>
-        <translation>Desde :</translation>
+        <translation>Desde:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="161"/>
         <source>To:</source>
-        <translation>Hacia :</translation>
+        <translation>Hasta:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="54"/>
         <source>Width:</source>
-        <translation>Ancho :</translation>
+        <translation>Ancho:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="80"/>
         <source>Height:</source>
-        <translation>Alto :</translation>
+        <translation>Alto:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.ui" line="37"/>
@@ -6325,7 +6446,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qimagedialog.cpp" line="46"/>
         <source>Output File cannot be empty.</source>
-        <translation>El Archivo de Salida no puede estar vacío.</translation>
+        <translation>El archivo de salida no puede estar vacío.</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.cpp" line="46"/>
@@ -6350,7 +6471,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qimagedialog.cpp" line="117"/>
         <source>Supported Image Files (*.bmp *.png *.jpg);;BMP Files (*.bmp);;PNG Files (*.png);;JPEG Files (*.jpg);;All Files (*.*)</source>
-        <translation>Archivos de Imagen Soportados (*.bmp *.png *.jpg);;Archivos BMP (*.bmp);;Archivos PNG (*.png);;Archivos JPEG (*.jpg);;Todos los archivos (*.*)</translation>
+        <translation>Archivos de imágenes soportados (*.bmp *.png *.jpg);;Archivos BMP (*.bmp);;Archivos PNG (*.png);;Archivos JPEG (*.jpg);;Todos los archivos (*.*)</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.cpp" line="98"/>
@@ -6360,17 +6481,17 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qimagedialog.cpp" line="54"/>
         <source>Please enter a width between 1 and 32768.</source>
-        <translation>Por favor introducir un ancho entre 1 y 32768.</translation>
+        <translation>Por favor, introduce un ancho entre 1 y 32768.</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.cpp" line="62"/>
         <source>Please enter a height between 1 and 32768.</source>
-        <translation>Por favor introducir un alto entre 1 y 32768.</translation>
+        <translation>Por favor, introduce un alto entre 1 y 32768.</translation>
     </message>
     <message>
         <location filename="../qt/lc_qimagedialog.cpp" line="117"/>
         <source>Save Image File</source>
-        <translation>Guardar la Imagen</translation>
+        <translation>Guardar imagen</translation>
     </message>
 </context>
 <context>
@@ -6389,15 +6510,15 @@ Anisotropic: %5
     </message>
     <message>
         <source>Delete...</source>
-        <translation type="vanished">Borrar…</translation>
+        <translation type="vanished">Borrar...</translation>
     </message>
     <message>
         <source>Save Template</source>
-        <translation type="vanished">Guardar Plantilla</translation>
+        <translation type="vanished">Guardar plantilla</translation>
     </message>
     <message>
         <source>Template Name:</source>
-        <translation type="vanished">Nombre de Plantilla:</translation>
+        <translation type="vanished">Nombre de plantilla:</translation>
     </message>
     <message>
         <source>Template name cannot be empty.</source>
@@ -6405,7 +6526,7 @@ Anisotropic: %5
     </message>
     <message>
         <source>Are you sure you want to overwrite the template &apos;%1&apos;?</source>
-        <translation type="vanished">Estas seguro de querer sobreescribir la plantilla &apos;%1&apos;?</translation>
+        <translation type="vanished">¿Seguro que quieres sobreescribir la plantilla &apos;%1&apos;?</translation>
     </message>
     <message>
         <source>Overwrite Template</source>
@@ -6413,11 +6534,11 @@ Anisotropic: %5
     </message>
     <message>
         <source>Are you sure you want to delete the template &apos;%1&apos;?</source>
-        <translation type="vanished">Estas seguro de querer borrar la plantilla &apos;%1&apos;?</translation>
+        <translation type="vanished">¿Seguro que quieres borrar la plantilla &apos;%1&apos;?</translation>
     </message>
     <message>
         <source>Delete Template</source>
-        <translation type="vanished">Borrar Plantilla</translation>
+        <translation type="vanished">Borrar plantilla</translation>
     </message>
 </context>
 <context>
@@ -6435,42 +6556,42 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qmodellistdialog.ui" line="38"/>
         <source>D&amp;elete...</source>
-        <translation>Bo&amp;rrar…</translation>
+        <translation>Bo&amp;rrar...</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.ui" line="45"/>
         <source>&amp;Rename...</source>
-        <translation>&amp;Renombrar…</translation>
+        <translation>&amp;Renombrar...</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.ui" line="52"/>
         <source>Export...</source>
-        <translation>Exportar…</translation>
+        <translation>Exportar...</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.ui" line="59"/>
         <source>Duplicate...</source>
-        <translation>Duplicado...</translation>
+        <translation>Duplicar...</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.ui" line="66"/>
         <source>Move &amp;Up</source>
-        <translation>Mover Arr&amp;iba</translation>
+        <translation>Mover arr&amp;iba</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.ui" line="73"/>
         <source>Move &amp;Down</source>
-        <translation>Mover Aba&amp;jo</translation>
+        <translation>Mover aba&amp;jo</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.ui" line="80"/>
         <source>Set Active</source>
-        <translation>Definir Activo</translation>
+        <translation>Definir activo</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="113"/>
         <source>New Submodel</source>
-        <translation>Nuevo Submodelo</translation>
+        <translation>Nuevo submodelo</translation>
     </message>
     <message>
         <source>Error</source>
@@ -6484,14 +6605,14 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="141"/>
         <source>Are you sure you want to delete the submodel &apos;%1&apos;?</source>
-        <translation>Estas seguro de querer borrar el submodelo &apos;%1&apos;?</translation>
+        <translation>¿Seguro que quieres borrar el submodelo &apos;%1&apos;?</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="127"/>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="135"/>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="145"/>
         <source>Delete Submodel</source>
-        <translation>Borrar Submodelo</translation>
+        <translation>Borrar submodelo</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="135"/>
@@ -6499,23 +6620,23 @@ Anisotropic: %5
         <location filename="../qt/lc_qmodellistdialog.cpp" line="189"/>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="248"/>
         <source>No submodel selected.</source>
-        <translation>No hay un submodelo seleccionado.</translation>
+        <translation>No hay ningún submodelo seleccionado.</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="143"/>
         <source>Are you sure you want to delete %1 submodels?</source>
-        <translation>Estas seguro de querer borrar %1 estos submodelos?</translation>
+        <translation>¿Seguro que quieres borrar %1 submodelos?</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="165"/>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="176"/>
         <source>Rename Submodel</source>
-        <translation>Renombrar Submodelo</translation>
+        <translation>Renombrar submodelo</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="189"/>
         <source>Export Submodel</source>
-        <translation>Exportar Submodelo</translation>
+        <translation>Exportar submodelo</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="204"/>
@@ -6525,12 +6646,12 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="204"/>
         <source>Nothing to export.</source>
-        <translation>Nada para exportar.</translation>
+        <translation>Nada que exportar.</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="211"/>
         <source>Export Model</source>
-        <translation>Exportar Modelo</translation>
+        <translation>Exportar modelo</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="222"/>
@@ -6541,7 +6662,7 @@ Anisotropic: %5
         <location filename="../qt/lc_qmodellistdialog.cpp" line="248"/>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="266"/>
         <source>Duplicate Submodel</source>
-        <translation>Duplicar Submodelo</translation>
+        <translation>Duplicar submodelo</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="263"/>
@@ -6550,12 +6671,12 @@ Anisotropic: %5
     </message>
     <message>
         <source>Save Model</source>
-        <translation type="vanished">Guardar Modelo</translation>
+        <translation type="vanished">Guardar modelo</translation>
     </message>
     <message>
         <location filename="../qt/lc_qmodellistdialog.cpp" line="211"/>
         <source>Supported Files (*.ldr *.dat);;All Files (*.*)</source>
-        <translation>Archivos Soportados (*.ldr *.dat);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos soportados (*.ldr *.dat);;Todos los archivos (*.*)</translation>
     </message>
 </context>
 <context>
@@ -6583,7 +6704,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="107"/>
         <source>Check for updates:</source>
-        <translation>Buscar Actualizaciones:</translation>
+        <translation>Buscar actualizaciones:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="50"/>
@@ -6627,17 +6748,17 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="94"/>
         <source>Once a day</source>
-        <translation>Una vez cada día</translation>
+        <translation>Una vez al día</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="99"/>
         <source>Once a week</source>
-        <translation>Una vez cada semana</translation>
+        <translation>Una vez por semana</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="157"/>
         <source>Default author name:</source>
-        <translation>Nombre del autor por defecto :</translation>
+        <translation>Nombre de autor predeterminado:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="170"/>
@@ -6647,7 +6768,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="177"/>
         <source>Open most recent file on startup</source>
-        <translation>Abrir archivo mas reciente al inicio</translation>
+        <translation>Abrir archivo más reciente al inicio</translation>
     </message>
     <message>
         <source>Custom paths</source>
@@ -6656,12 +6777,12 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="190"/>
         <source>Parts Library:</source>
-        <translation>Librería de Piezas:</translation>
+        <translation>Biblioteca de piezas:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="223"/>
         <source>Color Configuration:</source>
-        <translation>Configuración de Color:</translation>
+        <translation>Configuración de color:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="238"/>
@@ -6679,12 +6800,12 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="271"/>
         <source>PO&amp;V-Ray Executable:</source>
-        <translation>Ejecutable PO&amp;V-Ray:</translation>
+        <translation>Ejecutable de PO&amp;V-Ray:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="295"/>
         <source>&amp;LGEO Library:</source>
-        <translation>Librería &amp;LGEO:</translation>
+        <translation>Biblioteca &amp;LGEO:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="322"/>
@@ -6698,140 +6819,137 @@ Anisotropic: %5
     </message>
     <message>
         <source>Axis icon</source>
-        <translation type="vanished">Icono de Ejes</translation>
+        <translation type="vanished">Icono de ejes</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="431"/>
         <source>Highlight new parts</source>
-        <translation>Resaltar piezas nuevas</translation>
+        <translation type="vanished">Resaltar piezas nuevas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="394"/>
         <source>Fade previous steps</source>
-        <translation>Desvanecer pasos previos</translation>
+        <translation type="vanished">Atenuar pasos previos</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="678"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="745"/>
         <source>Base Grid</source>
-        <translation>Grilla Base</translation>
+        <translation>Cuadrícula base</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="728"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="795"/>
         <source>Draw studs</source>
-        <translation>Dibujar Tetones</translation>
+        <translation>Dibujar tetones</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="751"/>
         <source>studs</source>
         <translation>tetones</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="704"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="771"/>
         <source>Draw lines every</source>
-        <translation>Dibujar lineas cada</translation>
+        <translation>Dibujar líneas cada</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1111"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1052"/>
         <source>View Sphere</source>
-        <translation>Ver Esfera</translation>
+        <translation>Esfera</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="476"/>
         <source>Mesh LOD</source>
-        <translation>LOD de Malla</translation>
+        <translation>Nivel de detalle de malla</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1498"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1767"/>
         <source>Mouse</source>
         <translation>Ratón</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1506"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1775"/>
         <source>Mouse Shortcuts</source>
-        <translation>Atajos del Ratón</translation>
+        <translation>Atajos de ratón</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1521"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1790"/>
         <source>Action</source>
         <translation>Acción</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1526"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1795"/>
         <source>Shortcut 1</source>
         <translation>Atajo 1</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1531"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1800"/>
         <source>Shortcut 2</source>
         <translation>Atajo 2</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1592"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1861"/>
         <source>Button:</source>
-        <translation>Botón :</translation>
+        <translation>Botón:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1600"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1869"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1605"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1874"/>
         <source>Left</source>
-        <translation>Izquierda</translation>
+        <translation>Izquierdo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1610"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1879"/>
         <source>Middle</source>
         <translation>Central</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1615"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1884"/>
         <source>Right</source>
-        <translation>Derecha</translation>
+        <translation>Derecho</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1623"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1892"/>
         <source>Modifiers:</source>
-        <translation>Modificadores :</translation>
+        <translation>Modificadores:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1630"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1899"/>
         <source>Control</source>
         <translation>Control</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1637"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1906"/>
         <source>Alt</source>
         <translation>Alt</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1644"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1913"/>
         <source>Shift</source>
-        <translation>Maj</translation>
+        <translation>Mayúsculas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1672"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1941"/>
         <source>Mouse sensitivity:</source>
-        <translation>Sensibilidad del ratón :</translation>
+        <translation>Sensibilidad del ratón:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="359"/>
         <source>Edge lines</source>
-        <translation>Bordes</translation>
+        <translation type="vanished">Bordes</translation>
     </message>
     <message>
         <source>width</source>
         <translation type="vanished">ancho</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="436"/>
         <source>Anti-aliasing</source>
         <translation>Anti-aliasing</translation>
     </message>
     <message>
         <source>Stud Logo</source>
-        <translation type="vanished">Logo de Tetón</translation>
+        <translation type="vanished">Logo de tetón</translation>
     </message>
     <message>
         <source>Logo1</source>
@@ -6854,98 +6972,99 @@ Anisotropic: %5
         <translation type="vanished">Logo5</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="439"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
         <source>2x</source>
         <translation>2x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
         <source>4x</source>
         <translation>4x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="454"/>
         <source>8x</source>
         <translation>8x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="409"/>
         <source>Shading Mode:</source>
-        <translation>Modo de Sombreado:</translation>
+        <translation>Modo de sombreado:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="546"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="347"/>
         <source>Wireframe</source>
         <translation>Malla</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="551"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="352"/>
         <source>Flat Shading</source>
-        <translation>Sombreado Plano</translation>
+        <translation>Sombreado plano</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="357"/>
         <source>Default Lights</source>
-        <translation>Luces por defecto</translation>
+        <translation>Luces predeterminadas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="615"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="783"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="850"/>
         <source>Disabled</source>
-        <translation>Deshabilitado</translation>
+        <translation>Desactivada</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="620"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="656"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="855"/>
         <source>Small</source>
-        <translation>Pequeño</translation>
+        <translation>Pequeña</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="625"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="793"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="661"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="860"/>
         <source>Medium</source>
-        <translation>Medio</translation>
+        <translation>Mediana</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="630"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="798"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="666"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="865"/>
         <source>Large</source>
         <translation>Grande</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1145"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1118"/>
         <source>Highlight Color:</source>
-        <translation>Destacar Color:</translation>
+        <translation>Color de resalte:</translation>
     </message>
     <message>
         <source>Size:</source>
         <translation type="vanished">Tamaño:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1117"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1058"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1131"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1088"/>
         <source>Text Color:</source>
-        <translation>Color del Texto:</translation>
+        <translation>Color de texto:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="600"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="775"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="636"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="711"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="842"/>
         <source>Location:</source>
-        <translation>Localización:</translation>
+        <translation>Posición:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="60"/>
         <source>Deutsch </source>
-        <translation>Alemán </translation>
+        <translation>Deutsch </translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="130"/>
         <source>Color Theme:</source>
-        <translation>Color del Tema:</translation>
+        <translation>Color del tema:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="141"/>
@@ -6960,601 +7079,704 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qpreferencesdialog.ui" line="184"/>
         <source>Custom Paths</source>
-        <translation>Carpetas Personalizadas</translation>
+        <translation>Rutas personalizadas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="429"/>
         <source>Stud Style</source>
-        <translation>Estilo del Tetón</translation>
+        <translation>Estilo de tetón</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="465"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="366"/>
         <source>Plain</source>
         <translation>Plano</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="470"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="371"/>
         <source>Thin Lines Logo</source>
-        <translation>Lineas Delgadas del Logo</translation>
+        <translation>Logo de líneas finas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="475"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="376"/>
         <source>Outline Logo</source>
-        <translation>Linea Exterior del Logo</translation>
+        <translation>Contorno del logo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="381"/>
         <source>Sharp Top Logo</source>
-        <translation>Logo Afilado de la Parte superior</translation>
+        <translation>Logo en relieve</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="386"/>
         <source>Rounded Top Logo</source>
-        <translation>Logo Redondeado de la Parte superior</translation>
+        <translation>Logo en relieve redondo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="490"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="391"/>
         <source>Flattened Logo</source>
-        <translation>Logo Aplanado</translation>
+        <translation>Logo aplanado</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="495"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="396"/>
         <source>High Contrast</source>
-        <translation>Alto Contraste</translation>
+        <translation>Alto contraste</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="500"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
         <source>High Contrast with Logo</source>
-        <translation>Alto Contraste con Logo</translation>
+        <translation>Alto contraste con logo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="524"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
         <source>Settings...</source>
         <translation>Preferencias...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="531"/>
         <source>Automate edge color</source>
-        <translation>Automatizar color del borde</translation>
+        <translation type="vanished">Color de bordes automático</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="538"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
         <source>Contrast Settings...</source>
-        <translation>Prerencias de Contraste...</translation>
+        <translation>Preferencias de contraste...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="581"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="617"/>
         <source>Views</source>
         <translation>Vistas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="587"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="623"/>
         <source>Model Views</source>
-        <translation>Vistas del Modelo</translation>
+        <translation>Vistas de modelo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="744"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="629"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="811"/>
         <source>Axis Icon</source>
-        <translation>Icono del Eje</translation>
+        <translation>Icono de ejes</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="607"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="806"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="643"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="873"/>
         <source>View Sphere:</source>
-        <translation>Ver Esfera:</translation>
+        <translation>Ver esfera:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="639"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="752"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="675"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="819"/>
         <source>Top Left</source>
-        <translation>Arriba Izquierda</translation>
+        <translation>Arriba izquierda</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="644"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="757"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="680"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="724"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="824"/>
         <source>Top Right</source>
-        <translation>Arriba Derecha</translation>
+        <translation>Arriba derecha</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="649"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="762"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="685"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="729"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="829"/>
         <source>Bottom Left</source>
-        <translation>Abajo Izquierda</translation>
+        <translation>Abajo izquierda</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="654"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="767"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="690"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="734"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="834"/>
         <source>Bottom Right</source>
-        <translation>Abajo Derecha</translation>
+        <translation>Abajo derecha</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="721"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
         <source>Draw origin lines</source>
-        <translation>Dibujar lineas de origen</translation>
+        <translation>Dibujar líneas de origen</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="805"/>
         <source>Part Preview</source>
-        <translation>Previa de las Partes</translation>
+        <translation>Vista previa de piezas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="843"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="910"/>
         <source>Colors</source>
         <translation>Colores</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="849"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1227"/>
         <source>Background</source>
         <translation>Fondo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="857"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1235"/>
         <source>Top Color:</source>
-        <translation>Color Superior:</translation>
+        <translation>Color superior:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="871"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1265"/>
         <source>Bottom Color:</source>
-        <translation>Color Inferior:</translation>
+        <translation>Color inferior:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="900"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
         <source>So&amp;lid Color</source>
-        <translation>Color Só&amp;lido</translation>
+        <translation>Color só&amp;lido</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="907"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1301"/>
         <source>&amp;Gradient</source>
         <translation>&amp;Gradiente</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="941"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="916"/>
         <source>Interface</source>
         <translation>Interfaz</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="947"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="936"/>
         <source>Inactive View Border:</source>
-        <translation>Vista Inactiva del Borde:</translation>
+        <translation>Borde de vista inactiva:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="961"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="978"/>
         <source>Overlay Color:</source>
-        <translation>Color Sobreimpreso:</translation>
+        <translation>Color de superposiciones:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="968"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1026"/>
         <source>Active View Border:</source>
-        <translation>Activar Ver Borde:</translation>
+        <translation>Borde de vista activa:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="989"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="950"/>
         <source>Camera Name:</source>
-        <translation>Nombre de la Cámara:</translation>
+        <translation>Nombre de cámara:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1016"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="985"/>
         <source>Axis Icon Labels:</source>
-        <translation>Etiquetas del Icono del Eje:</translation>
+        <translation>Etiquetas de icono de ejes:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1030"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="922"/>
         <source>Marquee Border:</source>
-        <translation>Borde del Marco:</translation>
+        <translation>Borde del área de selección:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1044"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="469"/>
+        <source>Highlight New Parts</source>
+        <translation>Resaltar piezas nuevas</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="506"/>
+        <source>Fade Previous Steps</source>
+        <translation>Atenuar pasos previos</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="523"/>
+        <source>Lines</source>
+        <translation>Líneas</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="536"/>
+        <source>Conditional Lines</source>
+        <translation>Líneas condicionales</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <source>Line Width:</source>
+        <translation>Grosor de bordes:</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="579"/>
+        <source>Edge Lines</source>
+        <translation>Dibujar bordes</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="586"/>
+        <source>Automate Edge Color</source>
+        <translation>Color de bordes automático</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="964"/>
         <source>Marquee Fill:</source>
-        <translation>Relleno del Marco:</translation>
+        <translation>Relleno del área de selección:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1061"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1161"/>
         <source>Grid</source>
-        <translation>Malla</translation>
+        <translation>Cuadrícula</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1067"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1167"/>
         <source>Lines:</source>
         <translation>Líneas:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1197"/>
         <source>Studs:</source>
         <translation>Tetones:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1189"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1230"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1335"/>
+        <source>Objects</source>
+        <translation>Objetos</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1341"/>
+        <source>Light:</source>
+        <translation>Luz:</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1371"/>
+        <source>Focused:</source>
+        <translation>Resaltado:</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1385"/>
+        <source>Control Point Focused:</source>
+        <translation>Punto de control resaltado:</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1420"/>
+        <source>Control Point:</source>
+        <translation>Punto de control:</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1427"/>
+        <source>Selected:</source>
+        <translation>Seleccionado:</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1434"/>
+        <source>Camera:</source>
+        <translation>Cámara:</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1458"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1499"/>
         <source>Categories</source>
-        <translation>Categorias</translation>
+        <translation>Categorías</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1195"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1464"/>
         <source>Parts Library Categories</source>
-        <translation>Categorias de la biblioteca de piezas</translation>
+        <translation>Categorías de la biblioteca de piezas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1264"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1533"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1538"/>
         <source>Number</source>
         <translation>Número</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1280"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1408"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1541"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1549"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1677"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1810"/>
         <source>Import...</source>
         <translation>Importar...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1287"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1415"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1548"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1817"/>
         <source>Export...</source>
-        <translation>Exportar…</translation>
+        <translation>Exportar...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1422"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1555"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1563"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1691"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1824"/>
         <source>Reset...</source>
-        <translation>Reiniciar…</translation>
+        <translation>Reiniciar...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1319"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1588"/>
         <source>Category</source>
         <translation>Categoría</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1325"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1594"/>
         <source>New...</source>
-        <translation>Nuevo…</translation>
+        <translation>Nueva...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1332"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1601"/>
         <source>Edit...</source>
-        <translation>Editar…</translation>
+        <translation>Editar...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1608"/>
         <source>Delete...</source>
-        <translation>Borrar…</translation>
+        <translation>Borrar...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1363"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1632"/>
         <source>Keyboard</source>
         <translation>Teclado</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1642"/>
         <source>Keyboard Shortcuts</source>
-        <translation>Atajos de Teclado</translation>
+        <translation>Atajos de teclado</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1386"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1655"/>
         <source>Command</source>
         <translation>Comando</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1391"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1450"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1584"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1660"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1853"/>
         <source>Shortcut</source>
         <translation>Atajo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1399"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1668"/>
         <source>Search shortcuts</source>
         <translation>Buscar atajos</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1456"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1725"/>
         <source>Key se&amp;quence:</source>
-        <translation>Se&amp;cuencia Clave:</translation>
+        <translation>Combina&amp;ción de teclas:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1469"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1920"/>
         <source>Assign</source>
         <translation>Asignar</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1476"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1658"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1745"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1927"/>
         <source>Remove</source>
         <translation>Quitar</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="242"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="263"/>
         <source>Grid spacing must be greater than 0.</source>
-        <translation>El espaciado de la grilla debe ser mayor que 0.</translation>
+        <translation>El espaciado de la cuadrícula base debe ser mayor que 0.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="331"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="354"/>
         <source>Select Parts Library Folder</source>
-        <translation>Seleccionar la Carpeta de la Biblioteca de Piezas</translation>
+        <translation>Seleccionar carpeta de la biblioteca de piezas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Supported Archives (*.zip *.bin);;All Files (*.*)</source>
-        <translation>Archivos Soportados (*.zip *.bin);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos soportados (*.zip *.bin);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Select Parts Library Archive</source>
-        <translation>Seleccionar el Archivo de Piezas</translation>
+        <translation>Seleccionar archivo de la biblioteca de piezas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Select Color Configuration File</source>
-        <translation>Seleccionar Fichero de Configuración del Color</translation>
+        <translation>Seleccionar archivo de configuración de color</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Settings Files (*.ldr);;All Files (*.*)</source>
-        <translation>Ficheros de Preferencias (*.ldr);;Todos los ficheros (*.*)</translation>
+        <translation>Archivos de preferencias (*.ldr);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Select Minifig Settings File</source>
-        <translation>Seleccionar Fichero de Preferencias de Minifig</translation>
+        <translation>Seleccionar archivos de preferencias de Minifig</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Settings Files (*.ini);;All Files (*.*)</source>
-        <translation>Ficheros de Preferencias (*.ini);;Todos los ficheros (*.*)</translation>
+        <translation>Archivos de preferencias (*.ini);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="364"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
         <source>Executable Files (*.exe);;All Files (*.*)</source>
-        <translation>Archivos Ejecutables (*.exe);;Todos los archivos (*.*)</translation>
+        <translation>Archivos ejecutables (*.exe);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="366"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="389"/>
         <source>All Files (*.*)</source>
-        <translation>Todos los Archivos (*.*)</translation>
+        <translation>Todos los archivos (*.*)</translation>
     </message>
     <message>
         <source>Open POV-Ray Executable</source>
-        <translation type="vanished">Abrir Ejecutable POV-Ray</translation>
+        <translation type="vanished">Abrir ejecutable de POV-Ray</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="377"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="400"/>
         <source>Open LGEO Folder</source>
-        <translation>Abrir la Carpeta LGEO</translation>
+        <translation>Abrir la carpeta de LGEO</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Reset Colors</source>
-        <translation>Resetear Colores</translation>
+        <translation>Reiniciar colores</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Would you like to also reset the interface colors to match the color theme?</source>
-        <translation>Te gustaria tambien resetear los colores de la interfaz para coincidir con el color del tema?</translation>
+        <translation>¿Te gustaría además reiniciar los colores de la interfaz para que coincidan con los del tema?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="424"/>
         <source>Select Background Color</source>
-        <translation>Seleccionar Color de Fondo</translation>
+        <translation>Seleccionar color de fondo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="406"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="429"/>
         <source>Select Gradient Top Color</source>
-        <translation>Seleccionar Gradiente del Color Superior</translation>
+        <translation>Seleccionar color superior del gradiente</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="411"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="434"/>
         <source>Select Gradient Bottom Color</source>
-        <translation>Seleccionar Gradiente del Color Inferior</translation>
+        <translation>Seleccionar color inferior del gradiente</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="416"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="439"/>
         <source>Select Axes Color</source>
-        <translation>Seleccionar Color de los Ejes</translation>
+        <translation>Seleccionar color de ejes</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="421"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="444"/>
         <source>Select Text Color</source>
-        <translation>Seleccionar Color del Texto</translation>
+        <translation>Seleccionar color de texto</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="426"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="449"/>
         <source>Select Marquee Border Color</source>
-        <translation>Seleccionar Color del Borde del Marco</translation>
+        <translation>Seleccionar color del borde del área de selección</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="431"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="454"/>
         <source>Select Marquee Fill Color</source>
-        <translation>Seleccionar Color de Relleno del Marco</translation>
+        <translation>Seleccionar color de relleno del área de selección</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="437"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="460"/>
         <source>Select Overlay Color</source>
-        <translation>Seleccionar Color del Sobreimpreso</translation>
+        <translation>Seleccionar color de superposiciones</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="442"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="465"/>
         <source>Select Active View Color</source>
-        <translation>Seleccionar Color de la Vista Activa</translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="447"/>
-        <source>Select Inactive View Color</source>
-        <translation>Seleccionar Color de la Vista Inactvia</translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="452"/>
-        <source>Select Fade Color</source>
-        <translation>Seleccionar Color de Desvanecer</translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="458"/>
-        <source>Select Highlight Color</source>
-        <translation>Seleccionar Color del Destacado</translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="464"/>
-        <source>Select Grid Stud Color</source>
-        <translation>Seleccionar el color de los tetones de la grilla</translation>
+        <translation>Seleccionar color de vista activa</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.cpp" line="470"/>
-        <source>Select Grid Line Color</source>
-        <translation>Seleccionar el color de las líneas de la grilla</translation>
+        <source>Select Inactive View Color</source>
+        <translation>Seleccionar color de vista inactiva</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpreferencesdialog.cpp" line="475"/>
+        <source>Select Fade Color</source>
+        <translation>Seleccionar color de atenuación</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="481"/>
+        <source>Select Highlight Color</source>
+        <translation>Seleccionar color de resalte</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="487"/>
+        <source>Select Grid Stud Color</source>
+        <translation>Seleccionar color de los tetones de la cuadrícula</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="493"/>
+        <source>Select Grid Line Color</source>
+        <translation>Seleccionar color de las líneas de la cuadrícula</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="498"/>
         <source>Select View Sphere Color</source>
-        <translation>Seleccionar el Color de la Vista Esférica</translation>
+        <translation>Seleccionar color de la esfera en las vistas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="503"/>
         <source>Select View Sphere Text Color</source>
-        <translation>Seleccionar el Color del Texto de la Vista Esférica</translation>
+        <translation>Seleccionar color del texto de la esfera en las vistas</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="508"/>
         <source>Select View Sphere Highlight Color</source>
-        <translation>Seleccionar el Color del Texto Resaltado de la Vista Esférica</translation>
+        <translation>Seleccionar color de resalte de la esfera de la vista</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="596"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="513"/>
+        <source>Select Object Selected Color</source>
+        <translation>Seleccionar color de objeto seleccionado</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="518"/>
+        <source>Select Object Focused Color</source>
+        <translation>Seleccionar color de objeto enfocado</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="523"/>
+        <source>Select Camera Color</source>
+        <translation>Seleccionar color de cámara</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="528"/>
+        <source>Select Light Color</source>
+        <translation>Seleccionar color de luz</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="533"/>
+        <source>Select Control Point Color</source>
+        <translation>Seleccionar color de punto de control</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="539"/>
+        <source>Select Control Point Focused Color</source>
+        <translation>Seleccionar color de punto de control enfocado</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="661"/>
         <source>Unassigned</source>
-        <translation>Sin Asignar</translation>
+        <translation>Sin asignar</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="710"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="775"/>
         <source>Are you sure you want to delete the category &apos;%1&apos;?</source>
-        <translation>Estas seguro de querer borrar la categoría « %1 » ?</translation>
+        <translation>¿Seguro que quieres borrar la categoría &apos;%1&apos; ?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
         <source>Import Categories</source>
-        <translation>Importar Categorias</translation>
+        <translation>Importar categorías</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Text Files (*.txt);;All Files (*.*)</source>
-        <translation>Archivos de Texto (*.txt);;Todos los Archivos (*.*)</translation>
+        <translation>Archivos de texto (*.txt);;Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="731"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="796"/>
         <source>Error loading categories file.</source>
-        <translation>Error cargando el archivo de categorias.</translation>
+        <translation>Error cargando el archivo de categorías.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
         <source>Export Categories</source>
-        <translation>Exportar Categorias</translation>
+        <translation>Exportar categorías</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="749"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="814"/>
         <source>Error saving categories file.</source>
-        <translation>Error guardando el archivo de categorias.</translation>
+        <translation>Error guardando el archivo de categorías.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="756"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="821"/>
         <source>Are you sure you want to load the default categories?</source>
-        <translation>Estas seguro de querer cargar las categorias por defecto?</translation>
+        <translation>¿Seguro que quieres cargar las categorías predeterminadas?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="957"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1022"/>
         <source>The shortcut &apos;%1&apos; is already assigned to &apos;%2&apos;. Do you want to replace it?</source>
-        <translation>El atajo &apos;%1&apos; ya esta asignado a &apos;%2&apos;. Quieres reemplazarlo?</translation>
+        <translation>El atajo &apos;%1&apos; ya está asignado a &apos;%2&apos;. ¿Quieres reemplazarlo?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
         <source>Import shortcuts</source>
         <translation>Importar atajos</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1020"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1085"/>
         <source>Error loading keyboard shortcuts file.</source>
         <translation>Error cargando el archivo de atajos de teclado.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
         <source>Export shortcuts</source>
         <translation>Exportar atajos</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1039"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1104"/>
         <source>Error saving keyboard shortcuts file.</source>
         <translation>Error guardando el archivo de atajos de teclado.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1046"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1111"/>
         <source>Are you sure you want to load the default keyboard shortcuts?</source>
-        <translation>Estas seguro de querer cargar los atajos de teclado por defecto?</translation>
+        <translation>¿Seguro que quieres cargar los atajos de teclado predeterminados?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1073"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1138"/>
         <source>Left Button</source>
-        <translation>Botón Izquierdo</translation>
+        <translation>Botón izquierdo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1142"/>
         <source>Middle Button</source>
-        <translation>Botón Central</translation>
+        <translation>Botón central</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1146"/>
         <source>Right Button</source>
-        <translation>Botón Derecho</translation>
+        <translation>Botón derecho</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="959"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1024"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>Override Shortcut</source>
-        <translation>Sobreescribir Atajo</translation>
+        <translation>Sobrescribir atajo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="369"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="392"/>
         <source>Select POV-Ray Executable</source>
-        <translation>Seleccionar Ejecutable de POV-Ray</translation>
+        <translation>Seleccionar ejecutable de POV-Ray</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>This shortcut is already assigned to &apos;%1&apos;, do you want to replace it?</source>
-        <translation>Este atajo ya esta asignado a « %1 », quieres reemplazarlo ?</translation>
+        <translation>Este atajo ya está asignado a &apos;%1&apos;. ¿Quieres reemplazarlo?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
         <source>Import Shortcuts</source>
-        <translation>Importar Atajos</translation>
+        <translation>Importar atajos</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1212"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1277"/>
         <source>Error loading mouse shortcuts file.</source>
-        <translation>Error cargando el fichero de atajos del raton.</translation>
+        <translation>Error cargando el archivo de atajos de ratón.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Export Shortcuts</source>
-        <translation>Exportar Atajos</translation>
+        <translation>Exportar atajos</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1231"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1296"/>
         <source>Error saving mouse shortcuts file.</source>
-        <translation>Error guardando el fichero de atajos del raton.</translation>
+        <translation>Error guardando el archivo de atajos del ratón.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1236"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1301"/>
         <source>Are you sure you want to load the default mouse shortcuts?</source>
-        <translation>Estas seguro de querer cargar los atajos de ratón por defecto?</translation>
+        <translation>¿Seguro que quieres cargar los atajos de ratón predeterminados?</translation>
     </message>
 </context>
 <context>
@@ -7572,17 +7794,22 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qpropertiesdialog.ui" line="36"/>
         <source>Author:</source>
-        <translation>Autor :</translation>
+        <translation>Autor:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpropertiesdialog.ui" line="46"/>
         <source>Description:</source>
-        <translation>Descripción :</translation>
+        <translation>Descripción:</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpropertiesdialog.ui" line="56"/>
         <source>Comments:</source>
-        <translation>Comentarios :</translation>
+        <translation>Comentarios:</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="76"/>
+        <source>Measurements:</source>
+        <translation>Medidas:</translation>
     </message>
     <message>
         <source>Scene</source>
@@ -7594,7 +7821,7 @@ Anisotropic: %5
     </message>
     <message>
         <source>So&amp;lid Color</source>
-        <translation type="vanished">Color Só&amp;lido</translation>
+        <translation type="vanished">Color só&amp;lido</translation>
     </message>
     <message>
         <source>&amp;Gradient</source>
@@ -7610,52 +7837,61 @@ Anisotropic: %5
     </message>
     <message>
         <source>Tile</source>
-        <translation type="vanished">Titulo</translation>
+        <translation type="vanished">Mosaico</translation>
     </message>
     <message>
         <source>Set default options for new projects</source>
-        <translation type="vanished">Asignar opciones por defecto para los nuevos proyectos</translation>
+        <translation type="vanished">Establecer opciones predeterminadas para nuevos proyectos</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.ui" line="77"/>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="91"/>
         <source>Parts Used</source>
-        <translation>Piezas Usadas</translation>
+        <translation>Piezas usadas</translation>
     </message>
     <message>
         <location filename="../qt/lc_qpropertiesdialog.cpp" line="44"/>
         <source>%1 Properties</source>
-        <translation>%1 Propiedades</translation>
+        <translation>Propiedades de %1</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="62"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="51"/>
+        <source>%1 x %2 x %3 cm
+%4 x %5 x %6 inches
+%7 x %8 x %9 LDU</source>
+        <translation>%1 x %2 x %3 cm
+%4 x %5 x %6 pulgadas
+%7 x %8 x %9 LDU</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="70"/>
         <source>Part</source>
         <translation>Pieza</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="73"/>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="110"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="81"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="118"/>
         <source>Total</source>
         <translation>Total</translation>
     </message>
     <message>
         <source>Select Background Color</source>
-        <translation type="vanished">Seleccionar Color de Fondo</translation>
+        <translation type="vanished">Seleccionar color de fondo</translation>
     </message>
     <message>
         <source>Select Background Top Color</source>
-        <translation type="vanished">Seleccionar Color de Arriba del Fondo</translation>
+        <translation type="vanished">Seleccionar color superior de fondo</translation>
     </message>
     <message>
         <source>Select Background Bottom Color</source>
-        <translation type="vanished">Seleccionar Color de Abajo del Fondo</translation>
+        <translation type="vanished">Seleccionar color inferior de fondo</translation>
     </message>
     <message>
         <source>Select Background Image</source>
-        <translation type="vanished">Seleccionar Imagen de Fondo</translation>
+        <translation type="vanished">Seleccionar imagen de fondo</translation>
     </message>
     <message>
         <source>All Image Files (*.png *.jpg *.gif *.bmp);;PNG Files (*.png);;JPEG Files (*.jpg);;GIF Files (*.gif);;BMP Files (*.bmp);;All Files (*.*)</source>
-        <translation type="vanished">Todos los Archivos de Imagen (*.png *.jpg *.gif *.bmp);;Archivos PNG (*.png);;Archivos JPEG (*.jpg);;Archivos GIF (*.gif);;Archivos BMP (*.bmp);;Todos los archivos (*.*)</translation>
+        <translation type="vanished">Todos los archivos de imagen (*.png *.jpg *.gif *.bmp);;Archivos PNG (*.png);;Archivos JPEG (*.jpg);;Archivos GIF (*.gif);;Archivos BMP (*.bmp);;Todos los archivos (*.*)</translation>
     </message>
 </context>
 <context>
@@ -7671,40 +7907,40 @@ Anisotropic: %5
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="886"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1018"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="895"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1027"/>
         <source>Position</source>
         <translation>Posición</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="887"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="892"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1019"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1024"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="888"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="893"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1020"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1025"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1039"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="889"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="894"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1021"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1026"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1031"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="903"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1040"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="891"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
         <source>Rotation</source>
         <translation>Rotación</translation>
     </message>
@@ -7713,75 +7949,75 @@ Anisotropic: %5
         <translation type="vanished">Visibilidad</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="905"/>
         <source>Visible Steps</source>
-        <translation>Pasos Visibles</translation>
+        <translation>Pasos visibles</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="906"/>
         <source>Show</source>
-        <translation>Mostrar</translation>
+        <translation>Mostrar en</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="907"/>
         <source>Hide</source>
-        <translation>Ocultar</translation>
+        <translation>Ocultar en</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="909"/>
         <source>Appearance</source>
         <translation>Apariencia</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="910"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="911"/>
         <source>Part</source>
         <translation>Pieza</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1023"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1032"/>
         <source>Target</source>
-        <translation>Objectivo</translation>
+        <translation>Objetivo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1042"/>
         <source>Up</source>
         <translation>Arriba</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1043"/>
         <source>Orthographic</source>
-        <translation>Ortográfico</translation>
+        <translation>Ortográfica</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1044"/>
         <source>FOV</source>
-        <translation>FOV</translation>
+        <translation>Campo de visión</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1036"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1045"/>
         <source>Near</source>
         <translation>Cerca</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1046"/>
         <source>Far</source>
         <translation>Lejos</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1047"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1118"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1127"/>
         <source>Multiple Objects Selected</source>
-        <translation>Multiples Objectos Seleccionados</translation>
+        <translation>Múltiples objetos seleccionados</translation>
     </message>
 </context>
 <context>
@@ -7789,7 +8025,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qselectdialog.ui" line="14"/>
         <source>Select Objects</source>
-        <translation>Seleccionar Objectos</translation>
+        <translation>Seleccionar objetos</translation>
     </message>
     <message>
         <location filename="../qt/lc_qselectdialog.ui" line="34"/>
@@ -7817,17 +8053,17 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qupdatedialog.cpp" line="37"/>
         <source>Connecting to update server...</source>
-        <translation>Conectando al servidor para actualizar…</translation>
+        <translation>Conectando con el servidor de actualizaciones...</translation>
     </message>
     <message>
         <location filename="../qt/lc_qupdatedialog.cpp" line="108"/>
         <source>&lt;p&gt;There&apos;s a newer version of LeoCAD available for download (%1.%2.%3).&lt;/p&gt;</source>
-        <translation>&lt;p&gt;Hay una nueva version de LeoCAD disponible para descargar (%1.%2.%3).&lt;/p&gt;</translation>
+        <translation>&lt;p&gt;Hay una nueva versión de LeoCAD disponible para descargar (%1.%2.%3).&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../qt/lc_qupdatedialog.cpp" line="110"/>
         <source>&lt;p&gt;You are using the latest LeoCAD version.&lt;/p&gt;</source>
-        <translation>&lt;p&gt;Estas utilizando la última version de LeoCAD.&lt;/p&gt;</translation>
+        <translation>&lt;p&gt;Estás utilizando la última versión de LeoCAD.&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../qt/lc_qupdatedialog.cpp" line="118"/>
@@ -7852,7 +8088,7 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_qupdatedialog.cpp" line="138"/>
         <source>Error connecting to the update server.</source>
-        <translation>Error conectando al servidor de actualización.</translation>
+        <translation>Error conectando al servidor de actualizaciones.</translation>
     </message>
 </context>
 <context>
@@ -7882,17 +8118,17 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_renderdialog.ui" line="62"/>
         <source>High</source>
-        <translation>Alto</translation>
+        <translation>Alta</translation>
     </message>
     <message>
         <location filename="../qt/lc_renderdialog.ui" line="67"/>
         <source>Medium</source>
-        <translation>Medio</translation>
+        <translation>Media</translation>
     </message>
     <message>
         <location filename="../qt/lc_renderdialog.ui" line="72"/>
         <source>Low</source>
-        <translation>Bajo</translation>
+        <translation>Baja</translation>
     </message>
     <message>
         <location filename="../qt/lc_renderdialog.ui" line="54"/>
@@ -7912,12 +8148,12 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_renderdialog.cpp" line="105"/>
         <source>Cancel Render</source>
-        <translation>Cancelar Renderizado</translation>
+        <translation>Cancelar renderizado</translation>
     </message>
     <message>
         <location filename="../qt/lc_renderdialog.cpp" line="105"/>
         <source>Are you sure you want to cancel the current render?</source>
-        <translatorcomment>Estas seguro de querer cancelar el renderizado actual?</translatorcomment>
+        <translatorcomment>¿Seguro que quieres cancelar el renderizado actual?</translatorcomment>
         <translation></translation>
     </message>
     <message>
@@ -7936,43 +8172,43 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_renderdialog.cpp" line="214"/>
         <source>Error starting POV-Ray.</source>
-        <translation>Error ejecutando POV-Ray.</translation>
+        <translation>Error al iniciar POV-Ray.</translation>
     </message>
     <message>
         <location filename="../qt/lc_renderdialog.cpp" line="320"/>
         <source>An error occurred while rendering. Check details or try again.</source>
-        <translation>Ha ocurrido un error en el renderizado. Mira los detalles o intentalo de nuevo.</translation>
+        <translation>Ha ocurrido un error en el renderizado. Comprueba los detalles o inténtalo de nuevo.</translation>
     </message>
     <message>
         <location filename="../qt/lc_renderdialog.cpp" line="337"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
-        <translation>Error guardando el archivo « %1 » :
+        <translation>Error escribiendo el archivo &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
         <location filename="../qt/lc_renderdialog.cpp" line="361"/>
         <source>Error writing to %1 file &apos;%2&apos;:
 %3</source>
-        <translation>Error grabando en %1 fichero &apos;%2&apos;:
+        <translation>Error escribiendo en %1 el archivo &apos;%2&apos;:
 %3</translation>
     </message>
     <message>
         <location filename="../qt/lc_renderdialog.cpp" line="368"/>
         <source>Select Output File</source>
-        <translation>Seleccionar el Archivo de Salida</translation>
+        <translation>Seleccionar archivo de salida</translation>
     </message>
     <message>
         <location filename="../qt/lc_renderdialog.cpp" line="368"/>
         <source>Supported Image Files (*.bmp *.png *.jpg);;BMP Files (*.bmp);;PNG Files (*.png);;JPEG Files (*.jpg);;All Files (*.*)</source>
-        <translation>Archivos de Imagen Soportados (*.bmp *.png *.jpg);;Archivos BMP (*.bmp);;Archivos PNG (*.png);;Archivos JPEG (*.jpg);;Todos los archivos (*.*)</translation>
+        <translation>Archivos de imágenes soportados (*.bmp *.png *.jpg);;Archivos BMP (*.bmp);;Archivos PNG (*.png);;Archivos JPEG (*.jpg);;Todos los archivos (*.*)</translation>
     </message>
 </context>
 <context>
     <name>lcSelectByColorDialog</name>
     <message>
         <source>Select By Color</source>
-        <translation type="vanished">Seleccionar Por Color</translation>
+        <translation type="vanished">Seleccionar por color</translation>
     </message>
     <message>
         <source>Color:</source>
@@ -7984,12 +8220,12 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_setsdatabasedialog.ui" line="14"/>
         <source>Sets Database</source>
-        <translation>Base de datos de Piezas</translation>
+        <translation>Base de datos de piezas</translation>
     </message>
     <message>
         <location filename="../qt/lc_setsdatabasedialog.ui" line="22"/>
         <source>Set Name or Number</source>
-        <translation>Asignar Nombre o Número</translation>
+        <translation>Asignar nombre o número</translation>
     </message>
     <message>
         <location filename="../qt/lc_setsdatabasedialog.ui" line="29"/>
@@ -8019,12 +8255,12 @@ Anisotropic: %5
     <message>
         <location filename="../qt/lc_setsdatabasedialog.ui" line="74"/>
         <source>Sets Database provided by &lt;a href=&quot;https://www.rebrickable.com&quot;&gt;Rebrickable&lt;/a&gt;</source>
-        <translation>Base de datos de piezas de &lt;a href=&quot;https://www.rebrickable.com&quot;&gt;Rebrickable&lt;/a&gt;</translation>
+        <translation>Base de datos de piezas proporcionada por &lt;a href=&quot;https://www.rebrickable.com&quot;&gt;Rebrickable&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../qt/lc_setsdatabasedialog.cpp" line="62"/>
         <source>Please select a set from the list.</source>
-        <translation>Por favor, seleccione un base de datos de la lista.</translation>
+        <translation>Por favor, selecciona un base de datos de la lista.</translation>
     </message>
     <message>
         <location filename="../qt/lc_setsdatabasedialog.cpp" line="69"/>
@@ -8073,25 +8309,25 @@ Anisotropic: %5
 <context>
     <name>lcView</name>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>Error creating images.</source>
         <translation>Error creando imagenes.</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
-        <translation>Error guardando el archivo « %1 » :
+        <translation>Error escribiendo el archivo &apos;%1&apos;:
 %2</translation>
     </message>
 </context>

--- a/resources/leocad_fr.ts
+++ b/resources/leocad_fr.ts
@@ -700,586 +700,581 @@
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="981"/>
-        <source>View.Cameras.Reset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="988"/>
         <source>View.Time.First</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="995"/>
+        <location filename="../common/lc_commands.cpp" line="988"/>
         <source>View.Time.Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1002"/>
+        <location filename="../common/lc_commands.cpp" line="995"/>
         <source>View.Time.Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1009"/>
+        <location filename="../common/lc_commands.cpp" line="1002"/>
         <source>View.Time.Last</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1016"/>
+        <location filename="../common/lc_commands.cpp" line="1009"/>
         <source>View.Time.InsertBefore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1023"/>
+        <location filename="../common/lc_commands.cpp" line="1016"/>
         <source>View.Time.InsertAfter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1030"/>
+        <location filename="../common/lc_commands.cpp" line="1023"/>
         <source>View.Time.Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1037"/>
+        <location filename="../common/lc_commands.cpp" line="1030"/>
         <source>View.Time.AddKeys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1044"/>
+        <location filename="../common/lc_commands.cpp" line="1037"/>
         <source>View.SplitHorizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1051"/>
+        <location filename="../common/lc_commands.cpp" line="1044"/>
         <source>View.SplitVertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1058"/>
+        <location filename="../common/lc_commands.cpp" line="1051"/>
         <source>View.RemoveView</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1065"/>
+        <location filename="../common/lc_commands.cpp" line="1058"/>
         <source>View.ResetViews</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1072"/>
+        <location filename="../common/lc_commands.cpp" line="1065"/>
         <source>View.Toolbars.Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1079"/>
+        <location filename="../common/lc_commands.cpp" line="1072"/>
         <source>View.Toolbars.Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1086"/>
+        <location filename="../common/lc_commands.cpp" line="1079"/>
         <source>View.Toolbars.Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1093"/>
+        <location filename="../common/lc_commands.cpp" line="1086"/>
         <source>View.Toolbars.Parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1100"/>
+        <location filename="../common/lc_commands.cpp" line="1093"/>
         <source>View.Toolbars.Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1107"/>
+        <location filename="../common/lc_commands.cpp" line="1100"/>
         <source>View.Toolbars.Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1114"/>
+        <location filename="../common/lc_commands.cpp" line="1107"/>
         <source>View.Toolbars.Timeline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1121"/>
+        <location filename="../common/lc_commands.cpp" line="1114"/>
         <source>View.Toolbars.Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1128"/>
+        <location filename="../common/lc_commands.cpp" line="1121"/>
         <source>View.FullScreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1135"/>
+        <location filename="../common/lc_commands.cpp" line="1128"/>
         <source>View.CloseCurrentTab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1142"/>
+        <location filename="../common/lc_commands.cpp" line="1135"/>
         <source>View.Shade.Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1149"/>
+        <location filename="../common/lc_commands.cpp" line="1142"/>
         <source>View.Shade.Flat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1156"/>
+        <location filename="../common/lc_commands.cpp" line="1149"/>
         <source>View.Shade.DefaultLights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1163"/>
+        <location filename="../common/lc_commands.cpp" line="1156"/>
         <source>View.Projection.Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1170"/>
+        <location filename="../common/lc_commands.cpp" line="1163"/>
         <source>View.Projection.Orthographic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1177"/>
+        <location filename="../common/lc_commands.cpp" line="1170"/>
         <source>View.ToggleViewSphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1184"/>
+        <location filename="../common/lc_commands.cpp" line="1177"/>
         <source>View.ToggleAxisIcon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1191"/>
+        <location filename="../common/lc_commands.cpp" line="1184"/>
         <source>View.ToggleGrid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1198"/>
+        <location filename="../common/lc_commands.cpp" line="1191"/>
         <source>View.FadePreviousSteps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1205"/>
+        <location filename="../common/lc_commands.cpp" line="1198"/>
         <source>Piece.Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1212"/>
+        <location filename="../common/lc_commands.cpp" line="1205"/>
         <source>Piece.Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1219"/>
+        <location filename="../common/lc_commands.cpp" line="1212"/>
         <source>Piece.Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1226"/>
+        <location filename="../common/lc_commands.cpp" line="1219"/>
         <source>Piece.PaintSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1233"/>
+        <location filename="../common/lc_commands.cpp" line="1226"/>
         <source>Piece.ResetPivotPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1240"/>
+        <location filename="../common/lc_commands.cpp" line="1233"/>
         <source>Piece.RemoveKeyFrames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1247"/>
+        <location filename="../common/lc_commands.cpp" line="1240"/>
         <source>Piece.ControlPoint.Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1254"/>
+        <location filename="../common/lc_commands.cpp" line="1247"/>
         <source>Piece.ControlPoint.Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1261"/>
+        <location filename="../common/lc_commands.cpp" line="1254"/>
         <source>Piece.Move.PlusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1268"/>
+        <location filename="../common/lc_commands.cpp" line="1261"/>
         <source>Piece.Move.MinusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1275"/>
+        <location filename="../common/lc_commands.cpp" line="1268"/>
         <source>Piece.Move.PlusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1282"/>
+        <location filename="../common/lc_commands.cpp" line="1275"/>
         <source>Piece.Move.MinusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1289"/>
+        <location filename="../common/lc_commands.cpp" line="1282"/>
         <source>Piece.Move.PlusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1296"/>
+        <location filename="../common/lc_commands.cpp" line="1289"/>
         <source>Piece.Move.MinusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1303"/>
+        <location filename="../common/lc_commands.cpp" line="1296"/>
         <source>Piece.Rotate.PlusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1310"/>
+        <location filename="../common/lc_commands.cpp" line="1303"/>
         <source>Piece.Rotate.MinusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1317"/>
+        <location filename="../common/lc_commands.cpp" line="1310"/>
         <source>Piece.Rotate.PlusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1324"/>
+        <location filename="../common/lc_commands.cpp" line="1317"/>
         <source>Piece.Rotate.MinusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1331"/>
+        <location filename="../common/lc_commands.cpp" line="1324"/>
         <source>Piece.Rotate.PlusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1338"/>
+        <location filename="../common/lc_commands.cpp" line="1331"/>
         <source>Piece.Rotate.MinusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1345"/>
+        <location filename="../common/lc_commands.cpp" line="1338"/>
         <source>Piece.MinifigWizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1352"/>
+        <location filename="../common/lc_commands.cpp" line="1345"/>
         <source>Piece.Array</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1359"/>
+        <location filename="../common/lc_commands.cpp" line="1352"/>
         <source>Piece.ViewSelectedModel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1366"/>
+        <location filename="../common/lc_commands.cpp" line="1359"/>
         <source>Piece.MoveSelectionToModel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1373"/>
+        <location filename="../common/lc_commands.cpp" line="1366"/>
         <source>Piece.InlineSelectedModels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1380"/>
+        <location filename="../common/lc_commands.cpp" line="1373"/>
         <source>Piece.EditSelectedSubmodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1387"/>
+        <location filename="../common/lc_commands.cpp" line="1380"/>
         <source>Piece.EditEndSubmodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1394"/>
+        <location filename="../common/lc_commands.cpp" line="1387"/>
         <source>Piece.Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1401"/>
+        <location filename="../common/lc_commands.cpp" line="1394"/>
         <source>Piece.Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1408"/>
+        <location filename="../common/lc_commands.cpp" line="1401"/>
         <source>Piece.GroupAdd</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1415"/>
+        <location filename="../common/lc_commands.cpp" line="1408"/>
         <source>Piece.GroupRemove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1422"/>
+        <location filename="../common/lc_commands.cpp" line="1415"/>
         <source>Piece.GroupEdit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1429"/>
+        <location filename="../common/lc_commands.cpp" line="1422"/>
         <source>Piece.HideSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1436"/>
+        <location filename="../common/lc_commands.cpp" line="1429"/>
         <source>Piece.HideUnselected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1443"/>
+        <location filename="../common/lc_commands.cpp" line="1436"/>
         <source>Piece.UnhideSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1450"/>
+        <location filename="../common/lc_commands.cpp" line="1443"/>
         <source>Piece.UnhideAll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1457"/>
+        <location filename="../common/lc_commands.cpp" line="1450"/>
         <source>Piece.ShowEarlier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1464"/>
+        <location filename="../common/lc_commands.cpp" line="1457"/>
         <source>Piece.ShowLater</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1471"/>
+        <location filename="../common/lc_commands.cpp" line="1464"/>
         <source>Model.New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1478"/>
+        <location filename="../common/lc_commands.cpp" line="1471"/>
         <source>Model.Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1485"/>
+        <location filename="../common/lc_commands.cpp" line="1478"/>
         <source>Model.List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1492"/>
+        <location filename="../common/lc_commands.cpp" line="1485"/>
         <source>Model.Model01</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1499"/>
+        <location filename="../common/lc_commands.cpp" line="1492"/>
         <source>Model.Model02</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1506"/>
+        <location filename="../common/lc_commands.cpp" line="1499"/>
         <source>Model.Model03</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1513"/>
+        <location filename="../common/lc_commands.cpp" line="1506"/>
         <source>Model.Model04</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1520"/>
+        <location filename="../common/lc_commands.cpp" line="1513"/>
         <source>Model.Model05</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1527"/>
+        <location filename="../common/lc_commands.cpp" line="1520"/>
         <source>Model.Model06</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1534"/>
+        <location filename="../common/lc_commands.cpp" line="1527"/>
         <source>Model.Model07</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1541"/>
+        <location filename="../common/lc_commands.cpp" line="1534"/>
         <source>Model.Model08</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1548"/>
+        <location filename="../common/lc_commands.cpp" line="1541"/>
         <source>Model.Model09</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1555"/>
+        <location filename="../common/lc_commands.cpp" line="1548"/>
         <source>Model.Model10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1562"/>
+        <location filename="../common/lc_commands.cpp" line="1555"/>
         <source>Model.Model11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1569"/>
+        <location filename="../common/lc_commands.cpp" line="1562"/>
         <source>Model.Model12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1576"/>
+        <location filename="../common/lc_commands.cpp" line="1569"/>
         <source>Model.Model13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1583"/>
+        <location filename="../common/lc_commands.cpp" line="1576"/>
         <source>Model.Model14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1590"/>
+        <location filename="../common/lc_commands.cpp" line="1583"/>
         <source>Model.Model15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1597"/>
+        <location filename="../common/lc_commands.cpp" line="1590"/>
         <source>Model.Model16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1604"/>
+        <location filename="../common/lc_commands.cpp" line="1597"/>
         <source>Model.Model17</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1611"/>
+        <location filename="../common/lc_commands.cpp" line="1604"/>
         <source>Model.Model18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1618"/>
+        <location filename="../common/lc_commands.cpp" line="1611"/>
         <source>Model.Model19</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1625"/>
+        <location filename="../common/lc_commands.cpp" line="1618"/>
         <source>Model.Model20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1632"/>
+        <location filename="../common/lc_commands.cpp" line="1625"/>
         <source>Model.Model21</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1639"/>
+        <location filename="../common/lc_commands.cpp" line="1632"/>
         <source>Model.Model22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1646"/>
+        <location filename="../common/lc_commands.cpp" line="1639"/>
         <source>Model.Model23</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1653"/>
+        <location filename="../common/lc_commands.cpp" line="1646"/>
         <source>Model.Model24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1660"/>
+        <location filename="../common/lc_commands.cpp" line="1653"/>
         <source>Model.Model25</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1667"/>
+        <location filename="../common/lc_commands.cpp" line="1660"/>
         <source>Model.Model26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1674"/>
+        <location filename="../common/lc_commands.cpp" line="1667"/>
         <source>Model.Model27</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1681"/>
+        <location filename="../common/lc_commands.cpp" line="1674"/>
         <source>Model.Model28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1688"/>
+        <location filename="../common/lc_commands.cpp" line="1681"/>
         <source>Model.Model29</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1695"/>
+        <location filename="../common/lc_commands.cpp" line="1688"/>
         <source>Model.Model30</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1702"/>
+        <location filename="../common/lc_commands.cpp" line="1695"/>
         <source>Model.Model31</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1709"/>
+        <location filename="../common/lc_commands.cpp" line="1702"/>
         <source>Model.Model32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1716"/>
+        <location filename="../common/lc_commands.cpp" line="1709"/>
         <source>Model.Model33</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1723"/>
+        <location filename="../common/lc_commands.cpp" line="1716"/>
         <source>Model.Model34</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1730"/>
+        <location filename="../common/lc_commands.cpp" line="1723"/>
         <source>Model.Model35</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1737"/>
+        <location filename="../common/lc_commands.cpp" line="1730"/>
         <source>Model.Model36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1744"/>
+        <location filename="../common/lc_commands.cpp" line="1737"/>
         <source>Model.Model37</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1751"/>
+        <location filename="../common/lc_commands.cpp" line="1744"/>
         <source>Model.Model38</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1758"/>
+        <location filename="../common/lc_commands.cpp" line="1751"/>
         <source>Model.Model39</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1765"/>
+        <location filename="../common/lc_commands.cpp" line="1758"/>
         <source>Model.Model40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1772"/>
+        <location filename="../common/lc_commands.cpp" line="1765"/>
         <source>Help.HomePage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1779"/>
+        <location filename="../common/lc_commands.cpp" line="1772"/>
         <source>Help.BugReport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1786"/>
+        <location filename="../common/lc_commands.cpp" line="1779"/>
         <source>Help.Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1793"/>
+        <location filename="../common/lc_commands.cpp" line="1786"/>
         <source>Help.About</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1377,37 +1372,37 @@
         <translation>Pas pour les déplacements activé</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1017"/>
+        <location filename="../common/lc_commands.cpp" line="1010"/>
         <source>Insert Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1017"/>
         <source>Insert After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1360"/>
+        <location filename="../common/lc_commands.cpp" line="1353"/>
         <source>Open Selected Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1381"/>
+        <location filename="../common/lc_commands.cpp" line="1374"/>
         <source>Edit Selected Submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1388"/>
+        <location filename="../common/lc_commands.cpp" line="1381"/>
         <source>End Submodel Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1472"/>
+        <location filename="../common/lc_commands.cpp" line="1465"/>
         <source>New Submodel...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1479"/>
+        <location filename="../common/lc_commands.cpp" line="1472"/>
         <source>Prope&amp;rties...</source>
         <translation>Prop&amp;riétés…</translation>
     </message>
@@ -1979,563 +1974,562 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="982"/>
         <source>Reset</source>
-        <translation>Réinitialiser</translation>
+        <translation type="vanished">Réinitialiser</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="989"/>
+        <location filename="../common/lc_commands.cpp" line="982"/>
         <source>First</source>
         <translation>Premier</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="996"/>
+        <location filename="../common/lc_commands.cpp" line="989"/>
         <source>Previous</source>
         <translation>Précédent</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1003"/>
+        <location filename="../common/lc_commands.cpp" line="996"/>
         <source>Next</source>
         <translation>Suivant</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1010"/>
+        <location filename="../common/lc_commands.cpp" line="1003"/>
         <source>Last</source>
         <translation>Dernier</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1031"/>
-        <location filename="../common/lc_commands.cpp" line="1815"/>
+        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1808"/>
         <source>Remove Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1038"/>
+        <location filename="../common/lc_commands.cpp" line="1031"/>
         <source>Add Keys</source>
         <translation>Ajouter des clés</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1045"/>
+        <location filename="../common/lc_commands.cpp" line="1038"/>
         <source>Split &amp;Horizontal</source>
         <translation>Scinder &amp;horizontalement</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1052"/>
+        <location filename="../common/lc_commands.cpp" line="1045"/>
         <source>Split &amp;Vertical</source>
         <translation>Scinder &amp;verticalement</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1059"/>
+        <location filename="../common/lc_commands.cpp" line="1052"/>
         <source>Re&amp;move View</source>
         <translation>Suppri&amp;mer la vue</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1066"/>
+        <location filename="../common/lc_commands.cpp" line="1059"/>
         <source>Rese&amp;t Views</source>
         <translation>Réinitialiser &amp;toutes les vues</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1073"/>
+        <location filename="../common/lc_commands.cpp" line="1066"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1080"/>
+        <location filename="../common/lc_commands.cpp" line="1073"/>
         <source>Tools</source>
         <translation type="unfinished">Outils</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1087"/>
+        <location filename="../common/lc_commands.cpp" line="1080"/>
         <source>Time</source>
         <translation type="unfinished">Temps</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1094"/>
+        <location filename="../common/lc_commands.cpp" line="1087"/>
         <source>Parts</source>
         <translation type="unfinished">Pièces</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1101"/>
+        <location filename="../common/lc_commands.cpp" line="1094"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1108"/>
+        <location filename="../common/lc_commands.cpp" line="1101"/>
         <source>Properties</source>
         <translation type="unfinished">Propriétés</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1115"/>
+        <location filename="../common/lc_commands.cpp" line="1108"/>
         <source>Timeline</source>
         <translation type="unfinished">Ligne temporelle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1122"/>
+        <location filename="../common/lc_commands.cpp" line="1115"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1129"/>
+        <location filename="../common/lc_commands.cpp" line="1122"/>
         <source>&amp;Full Screen</source>
         <translation>&amp;Plein écran</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1136"/>
+        <location filename="../common/lc_commands.cpp" line="1129"/>
         <source>Close &amp;Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1143"/>
+        <location filename="../common/lc_commands.cpp" line="1136"/>
         <source>&amp;Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1150"/>
+        <location filename="../common/lc_commands.cpp" line="1143"/>
         <source>&amp;Flat Shading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1157"/>
+        <location filename="../common/lc_commands.cpp" line="1150"/>
         <source>&amp;Default Lights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1164"/>
+        <location filename="../common/lc_commands.cpp" line="1157"/>
         <source>&amp;Perspective</source>
         <translation>&amp;Perspective</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1171"/>
+        <location filename="../common/lc_commands.cpp" line="1164"/>
         <source>&amp;Orthographic</source>
         <translation>&amp;Orthographique</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1178"/>
+        <location filename="../common/lc_commands.cpp" line="1171"/>
         <source>View Sphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1185"/>
+        <location filename="../common/lc_commands.cpp" line="1178"/>
         <source>Axis Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1192"/>
+        <location filename="../common/lc_commands.cpp" line="1185"/>
         <source>Base Grid</source>
         <translation type="unfinished">Grille de base</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1199"/>
+        <location filename="../common/lc_commands.cpp" line="1192"/>
         <source>Fade Previous Steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1206"/>
+        <location filename="../common/lc_commands.cpp" line="1199"/>
         <source>&amp;Insert</source>
         <translation>&amp;Insérer</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1213"/>
+        <location filename="../common/lc_commands.cpp" line="1206"/>
         <source>&amp;Delete</source>
         <translation>&amp;Supprimer</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1220"/>
+        <location filename="../common/lc_commands.cpp" line="1213"/>
         <source>&amp;Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1227"/>
+        <location filename="../common/lc_commands.cpp" line="1220"/>
         <source>&amp;Paint Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1234"/>
+        <location filename="../common/lc_commands.cpp" line="1227"/>
         <source>Reset &amp;Pivot Point</source>
         <translation>Réinitialiser le &amp;point pivot</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1241"/>
+        <location filename="../common/lc_commands.cpp" line="1234"/>
         <source>Remove &amp;Key Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1248"/>
+        <location filename="../common/lc_commands.cpp" line="1241"/>
         <source>Insert Control Point</source>
         <translation>Insérer un point de contrôle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1255"/>
+        <location filename="../common/lc_commands.cpp" line="1248"/>
         <source>Remove Control Point</source>
         <translation>Enlever le point de contrôle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1262"/>
+        <location filename="../common/lc_commands.cpp" line="1255"/>
         <source>Move +X</source>
         <translation>Déplacer +X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1269"/>
+        <location filename="../common/lc_commands.cpp" line="1262"/>
         <source>Move -X</source>
         <translation>Déplacer -X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1276"/>
+        <location filename="../common/lc_commands.cpp" line="1269"/>
         <source>Move +Y</source>
         <translation>Déplacer +Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1283"/>
+        <location filename="../common/lc_commands.cpp" line="1276"/>
         <source>Move -Y</source>
         <translation>Déplacer -Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1290"/>
+        <location filename="../common/lc_commands.cpp" line="1283"/>
         <source>Move +Z</source>
         <translation>Déplacer +Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1297"/>
+        <location filename="../common/lc_commands.cpp" line="1290"/>
         <source>Move -Z</source>
         <translation>Déplacer -Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1304"/>
+        <location filename="../common/lc_commands.cpp" line="1297"/>
         <source>Rotate +X</source>
         <translation>Tourner +X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1311"/>
+        <location filename="../common/lc_commands.cpp" line="1304"/>
         <source>Rotate -X</source>
         <translation>Tourner -X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1318"/>
+        <location filename="../common/lc_commands.cpp" line="1311"/>
         <source>Rotate +Y</source>
         <translation>Tourner +Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1325"/>
+        <location filename="../common/lc_commands.cpp" line="1318"/>
         <source>Rotate -Y</source>
         <translation>Tourner -Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1332"/>
+        <location filename="../common/lc_commands.cpp" line="1325"/>
         <source>Rotate +Z</source>
         <translation>Tourner +Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1339"/>
+        <location filename="../common/lc_commands.cpp" line="1332"/>
         <source>Rotate -Z</source>
         <translation>Tourner -Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1346"/>
+        <location filename="../common/lc_commands.cpp" line="1339"/>
         <source>Minifig &amp;Wizard...</source>
         <translation>&amp;Assistant de minifig…</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1353"/>
+        <location filename="../common/lc_commands.cpp" line="1346"/>
         <source>A&amp;rray...</source>
         <translation>&amp;Arrangement…</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1367"/>
+        <location filename="../common/lc_commands.cpp" line="1360"/>
         <source>Move to New Model...</source>
         <translation>Déplacer vers un nouveau modèle…</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1374"/>
+        <location filename="../common/lc_commands.cpp" line="1367"/>
         <source>Inline Selected Models</source>
         <translation>Fusionner les modèles sélectionnés</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1395"/>
+        <location filename="../common/lc_commands.cpp" line="1388"/>
         <source>&amp;Group...</source>
         <translation>&amp;Grouper...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1402"/>
+        <location filename="../common/lc_commands.cpp" line="1395"/>
         <source>&amp;Ungroup</source>
         <translation>&amp;Dégrouper</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1409"/>
+        <location filename="../common/lc_commands.cpp" line="1402"/>
         <source>&amp;Add to Group</source>
         <translation>&amp;Ajouter au groupe</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1416"/>
+        <location filename="../common/lc_commands.cpp" line="1409"/>
         <source>Re&amp;move from Group</source>
         <translation>En&amp;lever du groupe</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1423"/>
+        <location filename="../common/lc_commands.cpp" line="1416"/>
         <source>&amp;Edit Groups...</source>
         <translation>&amp;Éditer les groupes…</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1430"/>
+        <location filename="../common/lc_commands.cpp" line="1423"/>
         <source>&amp;Hide Selected</source>
         <translation>&amp;Cache la sélection</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1437"/>
+        <location filename="../common/lc_commands.cpp" line="1430"/>
         <source>Hide &amp;Unselected</source>
         <translation>Cacher l’&amp;anti-sélection</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1444"/>
+        <location filename="../common/lc_commands.cpp" line="1437"/>
         <source>&amp;Unhide Selected</source>
         <translation>&amp;Décacher la sélection</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1451"/>
+        <location filename="../common/lc_commands.cpp" line="1444"/>
         <source>U&amp;nhide All</source>
         <translation>Décacher &amp;tout</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1458"/>
+        <location filename="../common/lc_commands.cpp" line="1451"/>
         <source>Show Earlier</source>
         <translation>Montrer plus tôt</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1465"/>
+        <location filename="../common/lc_commands.cpp" line="1458"/>
         <source>Show Later</source>
         <translation>Montrer plus tard</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1486"/>
+        <location filename="../common/lc_commands.cpp" line="1479"/>
         <source>Submodels...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1493"/>
+        <location filename="../common/lc_commands.cpp" line="1486"/>
         <source>Model 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1500"/>
+        <location filename="../common/lc_commands.cpp" line="1493"/>
         <source>Model 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1507"/>
+        <location filename="../common/lc_commands.cpp" line="1500"/>
         <source>Model 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1514"/>
+        <location filename="../common/lc_commands.cpp" line="1507"/>
         <source>Model 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1521"/>
+        <location filename="../common/lc_commands.cpp" line="1514"/>
         <source>Model 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1528"/>
+        <location filename="../common/lc_commands.cpp" line="1521"/>
         <source>Model 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1535"/>
+        <location filename="../common/lc_commands.cpp" line="1528"/>
         <source>Model 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1542"/>
+        <location filename="../common/lc_commands.cpp" line="1535"/>
         <source>Model 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1549"/>
+        <location filename="../common/lc_commands.cpp" line="1542"/>
         <source>Model 9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1556"/>
+        <location filename="../common/lc_commands.cpp" line="1549"/>
         <source>Model 10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1563"/>
+        <location filename="../common/lc_commands.cpp" line="1556"/>
         <source>Model 11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1570"/>
+        <location filename="../common/lc_commands.cpp" line="1563"/>
         <source>Model 12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1577"/>
+        <location filename="../common/lc_commands.cpp" line="1570"/>
         <source>Model 13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1584"/>
+        <location filename="../common/lc_commands.cpp" line="1577"/>
         <source>Model 14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1591"/>
+        <location filename="../common/lc_commands.cpp" line="1584"/>
         <source>Model 15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1598"/>
+        <location filename="../common/lc_commands.cpp" line="1591"/>
         <source>Model 16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1605"/>
+        <location filename="../common/lc_commands.cpp" line="1598"/>
         <source>Model 17</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1612"/>
+        <location filename="../common/lc_commands.cpp" line="1605"/>
         <source>Model 18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1619"/>
+        <location filename="../common/lc_commands.cpp" line="1612"/>
         <source>Model 19</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1626"/>
+        <location filename="../common/lc_commands.cpp" line="1619"/>
         <source>Model 20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1633"/>
+        <location filename="../common/lc_commands.cpp" line="1626"/>
         <source>Model 21</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1640"/>
+        <location filename="../common/lc_commands.cpp" line="1633"/>
         <source>Model 22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1647"/>
+        <location filename="../common/lc_commands.cpp" line="1640"/>
         <source>Model 23</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1654"/>
+        <location filename="../common/lc_commands.cpp" line="1647"/>
         <source>Model 24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1661"/>
+        <location filename="../common/lc_commands.cpp" line="1654"/>
         <source>Model 25</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1668"/>
+        <location filename="../common/lc_commands.cpp" line="1661"/>
         <source>Model 26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1675"/>
+        <location filename="../common/lc_commands.cpp" line="1668"/>
         <source>Model 27</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1682"/>
+        <location filename="../common/lc_commands.cpp" line="1675"/>
         <source>Model 28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1689"/>
+        <location filename="../common/lc_commands.cpp" line="1682"/>
         <source>Model 29</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1696"/>
+        <location filename="../common/lc_commands.cpp" line="1689"/>
         <source>Model 30</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1703"/>
+        <location filename="../common/lc_commands.cpp" line="1696"/>
         <source>Model 31</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1710"/>
+        <location filename="../common/lc_commands.cpp" line="1703"/>
         <source>Model 32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1717"/>
+        <location filename="../common/lc_commands.cpp" line="1710"/>
         <source>Model 33</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1724"/>
+        <location filename="../common/lc_commands.cpp" line="1717"/>
         <source>Model 34</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1731"/>
+        <location filename="../common/lc_commands.cpp" line="1724"/>
         <source>Model 35</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1738"/>
+        <location filename="../common/lc_commands.cpp" line="1731"/>
         <source>Model 36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1745"/>
+        <location filename="../common/lc_commands.cpp" line="1738"/>
         <source>Model 37</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1752"/>
+        <location filename="../common/lc_commands.cpp" line="1745"/>
         <source>Model 38</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1759"/>
+        <location filename="../common/lc_commands.cpp" line="1752"/>
         <source>Model 39</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1766"/>
+        <location filename="../common/lc_commands.cpp" line="1759"/>
         <source>Model 40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1780"/>
+        <location filename="../common/lc_commands.cpp" line="1773"/>
         <source>Report a Bug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1801"/>
+        <location filename="../common/lc_commands.cpp" line="1794"/>
         <source>Insert Step Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1808"/>
+        <location filename="../common/lc_commands.cpp" line="1801"/>
         <source>Insert Step After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1822"/>
+        <location filename="../common/lc_commands.cpp" line="1815"/>
         <source>Move Selection Here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1829"/>
+        <location filename="../common/lc_commands.cpp" line="1822"/>
         <source>Set Current Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1773"/>
+        <location filename="../common/lc_commands.cpp" line="1766"/>
         <source>LeoCAD &amp;Home Page</source>
         <translation>&amp;Page d’accueil de LeoCAD</translation>
     </message>
@@ -2570,12 +2564,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1787"/>
+        <location filename="../common/lc_commands.cpp" line="1780"/>
         <source>Check for &amp;Updates...</source>
         <translation>Vérifier les &amp;mises à jour…</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1794"/>
+        <location filename="../common/lc_commands.cpp" line="1787"/>
         <source>&amp;About...</source>
         <translation>&amp;À propos...</translation>
     </message>
@@ -2583,77 +2577,77 @@
 <context>
     <name>Mouse</name>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1839"/>
+        <location filename="../common/lc_commands.cpp" line="1832"/>
         <source>NewPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1840"/>
+        <location filename="../common/lc_commands.cpp" line="1833"/>
         <source>NewPointLight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1841"/>
+        <location filename="../common/lc_commands.cpp" line="1834"/>
         <source>NewSpotLight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1842"/>
+        <location filename="../common/lc_commands.cpp" line="1835"/>
         <source>NewCamera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1843"/>
+        <location filename="../common/lc_commands.cpp" line="1836"/>
         <source>Select</source>
         <translation type="unfinished">Sélectionner</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1844"/>
+        <location filename="../common/lc_commands.cpp" line="1837"/>
         <source>Move</source>
         <translation type="unfinished">Déplacer</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1845"/>
+        <location filename="../common/lc_commands.cpp" line="1838"/>
         <source>Rotate</source>
         <translation type="unfinished">Tourner</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1846"/>
+        <location filename="../common/lc_commands.cpp" line="1839"/>
         <source>Delete</source>
         <translation type="unfinished">Effacer</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1847"/>
+        <location filename="../common/lc_commands.cpp" line="1840"/>
         <source>Paint</source>
         <translation type="unfinished">Peindre</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1848"/>
+        <location filename="../common/lc_commands.cpp" line="1841"/>
         <source>ColorPicker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1849"/>
+        <location filename="../common/lc_commands.cpp" line="1842"/>
         <source>Zoom</source>
         <translation type="unfinished">Zoomer</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1850"/>
+        <location filename="../common/lc_commands.cpp" line="1843"/>
         <source>Pan</source>
         <translation type="unfinished">Glisser</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1851"/>
+        <location filename="../common/lc_commands.cpp" line="1844"/>
         <source>Orbit</source>
         <translation type="unfinished">Orbiter</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1852"/>
+        <location filename="../common/lc_commands.cpp" line="1845"/>
         <source>Roll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1853"/>
+        <location filename="../common/lc_commands.cpp" line="1846"/>
         <source>ZoomRegion</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2661,117 +2655,115 @@
 <context>
     <name>Project</name>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>Empty Name</source>
         <translation>Nom vide</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
-        <location filename="../common/project.cpp" line="449"/>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="378"/>
+        <location filename="../common/project.cpp" line="457"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
+        <location filename="../common/project.cpp" line="378"/>
         <source>Error reading file &apos;%1&apos;:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="449"/>
+        <location filename="../common/project.cpp" line="457"/>
         <source>Error loading file &apos;%1&apos;:
 File format is not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="544"/>
+        <location filename="../common/project.cpp" line="552"/>
         <source>Merged </source>
         <translation>Fusionné </translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
-        <location filename="../common/project.cpp" line="2060"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
+        <location filename="../common/project.cpp" line="2025"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="2060"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="2025"/>
         <source>Nothing to export.</source>
         <translation>Rien à exporter.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>Export 3D Studio</source>
         <translation>Exporter vers 3D Studio</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>3DS Files (*.3ds);;All Files (*.*)</source>
         <translation>Fichiers 3DS (*.3ds);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>Could not open file &apos;%1&apos; for writing.</source>
         <translation>N’a pas pu ouvrir le fichier « %1 » en écriture.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>Export BrickLink</source>
         <translation>Exporter vers BrickLink</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>XML Files (*.xml);;All Files (*.*)</source>
         <translation>Fichiers XML (*.xml);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>Export COLLADA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>COLLADA Files (*.dae);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>Export CSV</source>
         <translation>Exporter vers CSV</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>CSV Files (*.csv);;All Files (*.*)</source>
         <translation>Fichiers CSV (*.csv);;Tous les fichiers (*.*)</translation>
     </message>
@@ -2780,81 +2772,81 @@ File format is not recognized.</source>
         <translation type="vanished">Erreur à la création des images.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>Export POV-Ray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>POV-Ray Files (*.pov);;All Files (*.*)</source>
         <translation type="unfinished">Fichiers POV-Ray (*.pov);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
         <source>Could not find LGEO files in folder &apos;%1&apos;.</source>
         <translation>N’a pas pu trouver les fichiers LGEO dans le dossier « %1 ».</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Export Wavefront</source>
         <translation>Exporter vers Wavefront</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Wavefront Files (*.obj);;All Files (*.*)</source>
         <translation>Fichiers Wavefront (*.obj);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation>Erreur en écrivant le fichier « %1 » :
 %2</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.ldr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.mpd</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="177"/>
+        <location filename="../common/project.cpp" line="178"/>
         <source>Submodel #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="201"/>
+        <location filename="../common/project.cpp" line="202"/>
         <source>Submodel Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>The submodel name cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>Duplicate Submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>A submodel named &apos;%1&apos; already exists, please enter a unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="245"/>
+        <location filename="../common/project.cpp" line="246"/>
         <source>New Submodel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2882,19 +2874,19 @@ File format is not recognized.</source>
         <translation type="vanished">Couleurs spéciales</translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="507"/>
+        <location filename="../common/lc_colors.cpp" line="318"/>
         <source>Solid</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="508"/>
+        <location filename="../common/lc_colors.cpp" line="319"/>
         <source>Translucent</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="509"/>
+        <location filename="../common/lc_colors.cpp" line="320"/>
         <source>Special</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
@@ -2903,14 +2895,21 @@ File format is not recognized.</source>
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
         <source>Error</source>
-        <translation type="unfinished">Erreur</translation>
+        <translation type="obsolete">Erreur</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>LeoCAD</source>
+        <translation type="unfinished">LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
-        <source>Failed to load &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>Could not open file &apos;%1&apos; for writing.</source>
+        <translation type="unfinished">N’a pas pu ouvrir le fichier « %1 » en écriture.</translation>
     </message>
 </context>
 <context>
@@ -3505,27 +3504,26 @@ File format is not recognized.</source>
         <translation>Utiliser cette caméra</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="983"/>
         <source>Reset views to their default positions</source>
-        <translation>Réinitialiser les vues à leur position par défaut</translation>
+        <translation type="vanished">Réinitialiser les vues à leur position par défaut</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="990"/>
+        <location filename="../common/lc_commands.cpp" line="983"/>
         <source>Go to the first step of the model</source>
         <translation>Aller à la première étape du modèle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="997"/>
+        <location filename="../common/lc_commands.cpp" line="990"/>
         <source>Go to the previous step</source>
         <translation>Aller à l’étape précédente</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1004"/>
+        <location filename="../common/lc_commands.cpp" line="997"/>
         <source>Go to the next step</source>
         <translation>Aller à l’étape suivante</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1004"/>
         <source>Go to the last step of the model</source>
         <translation>Aller à la dernière étape du modèle</translation>
     </message>
@@ -3534,47 +3532,48 @@ File format is not recognized.</source>
         <translation type="vanished">Insérer une nouvelle étape</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1032"/>
-        <location filename="../common/lc_commands.cpp" line="1816"/>
+        <location filename="../common/lc_commands.cpp" line="1025"/>
+        <location filename="../common/lc_commands.cpp" line="1809"/>
         <source>Remove current step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1137"/>
+        <location filename="../common/lc_commands.cpp" line="1130"/>
         <source>Close current tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1256"/>
+        <location filename="../common/lc_commands.cpp" line="1249"/>
         <source>Remove the selected control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1361"/>
+        <location filename="../common/lc_commands.cpp" line="1354"/>
         <source>Open the model referenced by the selected piece in a new tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1368"/>
+        <location filename="../common/lc_commands.cpp" line="1361"/>
         <source>Move the selected pieces to a new model and replace them with a reference to the model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1473"/>
+        <location filename="../common/lc_commands.cpp" line="1466"/>
         <source>Create a new submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1480"/>
+        <location filename="../common/lc_commands.cpp" line="1473"/>
         <source>Display the properties of the current submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1487"/>
+        <location filename="../common/lc_commands.cpp" line="1480"/>
         <source>Show a list of all submodels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1487"/>
         <location filename="../common/lc_commands.cpp" line="1494"/>
         <location filename="../common/lc_commands.cpp" line="1501"/>
         <location filename="../common/lc_commands.cpp" line="1508"/>
@@ -3614,27 +3613,26 @@ File format is not recognized.</source>
         <location filename="../common/lc_commands.cpp" line="1746"/>
         <location filename="../common/lc_commands.cpp" line="1753"/>
         <location filename="../common/lc_commands.cpp" line="1760"/>
-        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Switch to this submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1781"/>
+        <location filename="../common/lc_commands.cpp" line="1774"/>
         <source>Open LeoCAD&apos;s bug report form on your default web browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1823"/>
+        <location filename="../common/lc_commands.cpp" line="1816"/>
         <source>Move the selected parts into this step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1830"/>
+        <location filename="../common/lc_commands.cpp" line="1823"/>
         <source>View the model at this point in the timeline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1039"/>
+        <location filename="../common/lc_commands.cpp" line="1032"/>
         <source>Toggle adding new animation keys</source>
         <translation>Basculer l’ajout de nouvelles clés d’animation</translation>
     </message>
@@ -3689,290 +3687,290 @@ File format is not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1018"/>
-        <location filename="../common/lc_commands.cpp" line="1802"/>
+        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1795"/>
         <source>Insert a new step before the current step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1025"/>
-        <location filename="../common/lc_commands.cpp" line="1809"/>
+        <location filename="../common/lc_commands.cpp" line="1018"/>
+        <location filename="../common/lc_commands.cpp" line="1802"/>
         <source>Insert a new step after the current step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1046"/>
+        <location filename="../common/lc_commands.cpp" line="1039"/>
         <source>Split the current view horizontally</source>
         <translation>Scinder la vue courante horizontalement</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1053"/>
+        <location filename="../common/lc_commands.cpp" line="1046"/>
         <source>Split the current view vertically</source>
         <translation>Scinder la vue courante verticalement</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1060"/>
+        <location filename="../common/lc_commands.cpp" line="1053"/>
         <source>Remove the current view</source>
         <translation>Supprimer la vue courante</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1067"/>
+        <location filename="../common/lc_commands.cpp" line="1060"/>
         <source>Reset all views</source>
         <translation>Réinitialiser toutes les vues</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1074"/>
+        <location filename="../common/lc_commands.cpp" line="1067"/>
         <source>Toggle the Standard Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1081"/>
+        <location filename="../common/lc_commands.cpp" line="1074"/>
         <source>Toggle the Tools Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1088"/>
+        <location filename="../common/lc_commands.cpp" line="1081"/>
         <source>Toggle the Time Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1095"/>
+        <location filename="../common/lc_commands.cpp" line="1088"/>
         <source>Toggle the Parts Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1102"/>
+        <location filename="../common/lc_commands.cpp" line="1095"/>
         <source>Toggle the Colors Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1109"/>
+        <location filename="../common/lc_commands.cpp" line="1102"/>
         <source>Toggle the Properties Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1116"/>
+        <location filename="../common/lc_commands.cpp" line="1109"/>
         <source>Toggle the Timeline Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1123"/>
+        <location filename="../common/lc_commands.cpp" line="1116"/>
         <source>Toggle the Preview Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1130"/>
+        <location filename="../common/lc_commands.cpp" line="1123"/>
         <source>Toggle fullscreen mode</source>
         <translation>Basculer en mode plein-écran/fenêtre</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1144"/>
+        <location filename="../common/lc_commands.cpp" line="1137"/>
         <source>Display the scene as wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1151"/>
+        <location filename="../common/lc_commands.cpp" line="1144"/>
         <source>Display the scene without any shading or lights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1158"/>
+        <location filename="../common/lc_commands.cpp" line="1151"/>
         <source>Display the scene with the default lights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1165"/>
+        <location filename="../common/lc_commands.cpp" line="1158"/>
         <source>Set the current camera to use a perspective projection</source>
         <translation>Utiliser une projection perspective pour la caméra courante</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1172"/>
+        <location filename="../common/lc_commands.cpp" line="1165"/>
         <source>Set the current camera to use an orthographic projection</source>
         <translation>Utiliser une projection orthographique pour la caméra courante</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1179"/>
+        <location filename="../common/lc_commands.cpp" line="1172"/>
         <source>Toggle the view sphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1186"/>
+        <location filename="../common/lc_commands.cpp" line="1179"/>
         <source>Toggle axis icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1193"/>
+        <location filename="../common/lc_commands.cpp" line="1186"/>
         <source>Toggle grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1200"/>
+        <location filename="../common/lc_commands.cpp" line="1193"/>
         <source>Toggle fading previous model steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1207"/>
+        <location filename="../common/lc_commands.cpp" line="1200"/>
         <source>Add a new piece to the model</source>
         <translation>Ajouter une nouvelle pièce au modèle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1214"/>
+        <location filename="../common/lc_commands.cpp" line="1207"/>
         <source>Delete selected objects</source>
         <translation>Supprimer les objets sélectionnés</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1221"/>
+        <location filename="../common/lc_commands.cpp" line="1214"/>
         <source>Create a copy of the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1228"/>
+        <location filename="../common/lc_commands.cpp" line="1221"/>
         <source>Change the color of the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1235"/>
+        <location filename="../common/lc_commands.cpp" line="1228"/>
         <source>Reset the pivot point of the selected pieces to their origin</source>
         <translation>Réinitialiser le point de pivot des pièces sélectionnées à leur origine</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1242"/>
+        <location filename="../common/lc_commands.cpp" line="1235"/>
         <source>Remove all key frames from the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1249"/>
+        <location filename="../common/lc_commands.cpp" line="1242"/>
         <source>Insert a new control point</source>
         <translation>Insérer un nouveau point de contrôle</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1256"/>
         <location filename="../common/lc_commands.cpp" line="1263"/>
-        <location filename="../common/lc_commands.cpp" line="1270"/>
         <source>Move selected objects along the X axis</source>
         <translation>Déplacer les objets sélectionnés sur l’axe X</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1270"/>
         <location filename="../common/lc_commands.cpp" line="1277"/>
-        <location filename="../common/lc_commands.cpp" line="1284"/>
         <source>Move selected objects along the Y axis</source>
         <translation>Déplacer les objets sélectionnés sur l’axe Y</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1284"/>
         <location filename="../common/lc_commands.cpp" line="1291"/>
-        <location filename="../common/lc_commands.cpp" line="1298"/>
         <source>Move selected objects along the Z axis</source>
         <translation>Déplacer les objets sélectionnés sur l’axe Z</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1298"/>
         <location filename="../common/lc_commands.cpp" line="1305"/>
-        <location filename="../common/lc_commands.cpp" line="1312"/>
         <source>Rotate selected objects along the X axis</source>
         <translation>Tourner les objets sélections suivant l’axe X</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1312"/>
         <location filename="../common/lc_commands.cpp" line="1319"/>
-        <location filename="../common/lc_commands.cpp" line="1326"/>
         <source>Rotate selected objects along the Y axis</source>
         <translation>Tourner les objets sélections suivant l’axe Y</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1326"/>
         <location filename="../common/lc_commands.cpp" line="1333"/>
-        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Rotate selected objects along the Z axis</source>
         <translation>Tourner les objets sélections suivant l’axe Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1347"/>
+        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Add a new minifig to the model</source>
         <translation>Ajouter une nouvelle minifig au modèle</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1354"/>
+        <location filename="../common/lc_commands.cpp" line="1347"/>
         <source>Make copies of the selected pieces</source>
         <translation>Faire des copies des pièces sélectionnées</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1375"/>
+        <location filename="../common/lc_commands.cpp" line="1368"/>
         <source>Insert the contents of the selected model references into the current model</source>
         <translation>Insérer le contenu des modèles sélectionnés dans le modèle courant</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1382"/>
+        <location filename="../common/lc_commands.cpp" line="1375"/>
         <source>Edit the currently selected submodel in-place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1389"/>
+        <location filename="../common/lc_commands.cpp" line="1382"/>
         <source>End in-place submodel editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1396"/>
+        <location filename="../common/lc_commands.cpp" line="1389"/>
         <source>Group selected pieces together</source>
         <translation>Grouper les pièces sélectionnées</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1403"/>
+        <location filename="../common/lc_commands.cpp" line="1396"/>
         <source>Ungroup selected group</source>
         <translation>Dégrouper le groupe sélectionné</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1410"/>
+        <location filename="../common/lc_commands.cpp" line="1403"/>
         <source>Add focused piece to selected group</source>
         <translation>Ajouter la pièce qui a le focus au groupe sélectionné</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1417"/>
+        <location filename="../common/lc_commands.cpp" line="1410"/>
         <source>Remove focused piece from group</source>
         <translation>Enlever du groupe la pièce qui a le focus</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1424"/>
+        <location filename="../common/lc_commands.cpp" line="1417"/>
         <source>Edit groups</source>
         <translation>Éditer les groupes</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1431"/>
+        <location filename="../common/lc_commands.cpp" line="1424"/>
         <source>Hide selected objects</source>
         <translation>Cacher les objets sélectionnés</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1438"/>
+        <location filename="../common/lc_commands.cpp" line="1431"/>
         <source>Hide objects that are not selected</source>
         <translation>Cacher les objets qui ne sont pas sélectionnés</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1445"/>
+        <location filename="../common/lc_commands.cpp" line="1438"/>
         <source>Show hidden objects that are selected</source>
         <translation>Montrer les objets cachés qui sont sélectionnés</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1452"/>
+        <location filename="../common/lc_commands.cpp" line="1445"/>
         <source>Show all hidden objects</source>
         <translation>Montrer les objets cachés</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1459"/>
+        <location filename="../common/lc_commands.cpp" line="1452"/>
         <source>Show selected pieces one step earlier</source>
         <translation>Montrer les pièces sélectionnées une étape plus tôt</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1466"/>
+        <location filename="../common/lc_commands.cpp" line="1459"/>
         <source>Show selected pieces one step later</source>
         <translation>Montrer les pièces sélectionnées une étape plus tard</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1774"/>
+        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Open LeoCAD&apos;s home page on the internet using your default web browser</source>
         <translation>Ouvrir la page d’accueil de LeoCAD avec votre navigateur web par défaut</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1788"/>
+        <location filename="../common/lc_commands.cpp" line="1781"/>
         <source>Check if a newer LeoCAD version or parts library has been released</source>
         <translation>Vérifier si une nouvelle version de LeoCAD ou de la bibliothèque de pièces est disponible</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1795"/>
+        <location filename="../common/lc_commands.cpp" line="1788"/>
         <source>Display program version number and system information</source>
         <translation>Voir la version du programme et des informations sur le système</translation>
     </message>
@@ -4013,13 +4011,13 @@ File format is not recognized.</source>
 <context>
     <name>lcApplication</name>
     <message>
-        <location filename="../common/lc_application.cpp" line="934"/>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="954"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="929"/>
+        <location filename="../common/lc_application.cpp" line="949"/>
         <source>LeoCAD could not find a compatible Parts Library so only a small number of parts will be available.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
@@ -4028,397 +4026,397 @@ Please visit https://www.leocad.org for information on how to download and insta
 SVP visitez https://www.leocad.org pour apprendre comment télécharger et installer une bibliothèque.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="401"/>
-        <location filename="../common/lc_application.cpp" line="426"/>
-        <location filename="../common/lc_application.cpp" line="449"/>
-        <location filename="../common/lc_application.cpp" line="472"/>
-        <location filename="../common/lc_application.cpp" line="482"/>
-        <location filename="../common/lc_application.cpp" line="505"/>
-        <location filename="../common/lc_application.cpp" line="530"/>
+        <location filename="../common/lc_application.cpp" line="421"/>
+        <location filename="../common/lc_application.cpp" line="446"/>
+        <location filename="../common/lc_application.cpp" line="469"/>
+        <location filename="../common/lc_application.cpp" line="492"/>
+        <location filename="../common/lc_application.cpp" line="502"/>
+        <location filename="../common/lc_application.cpp" line="525"/>
+        <location filename="../common/lc_application.cpp" line="550"/>
         <source>Not enough parameters for the &apos;%1&apos; option.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="423"/>
-        <location filename="../common/lc_application.cpp" line="446"/>
-        <location filename="../common/lc_application.cpp" line="469"/>
-        <location filename="../common/lc_application.cpp" line="502"/>
-        <location filename="../common/lc_application.cpp" line="527"/>
-        <location filename="../common/lc_application.cpp" line="580"/>
-        <location filename="../common/lc_application.cpp" line="734"/>
-        <location filename="../common/lc_application.cpp" line="745"/>
+        <location filename="../common/lc_application.cpp" line="443"/>
+        <location filename="../common/lc_application.cpp" line="466"/>
+        <location filename="../common/lc_application.cpp" line="489"/>
+        <location filename="../common/lc_application.cpp" line="522"/>
+        <location filename="../common/lc_application.cpp" line="547"/>
+        <location filename="../common/lc_application.cpp" line="600"/>
+        <location filename="../common/lc_application.cpp" line="754"/>
+        <location filename="../common/lc_application.cpp" line="765"/>
         <source>Invalid parameter value specified for the &apos;%1&apos; option: &apos;%2&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="541"/>
+        <location filename="../common/lc_application.cpp" line="561"/>
         <source>The file &apos;%1&apos; is not readable.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="589"/>
+        <location filename="../common/lc_application.cpp" line="609"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: limits are +/- 360.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="601"/>
+        <location filename="../common/lc_application.cpp" line="621"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="620"/>
+        <location filename="../common/lc_application.cpp" line="640"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: requirements are: 1 &lt;= &lt;near&gt; &lt; &lt;far&gt;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="630"/>
-        <location filename="../common/lc_application.cpp" line="641"/>
-        <location filename="../common/lc_application.cpp" line="652"/>
-        <location filename="../common/lc_application.cpp" line="663"/>
+        <location filename="../common/lc_application.cpp" line="650"/>
+        <location filename="../common/lc_application.cpp" line="661"/>
+        <location filename="../common/lc_application.cpp" line="672"/>
+        <location filename="../common/lc_application.cpp" line="683"/>
         <source>High contrast stud style is required for the &apos;%1&apos; option but is not enabled.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="678"/>
-        <location filename="../common/lc_application.cpp" line="689"/>
+        <location filename="../common/lc_application.cpp" line="698"/>
+        <location filename="../common/lc_application.cpp" line="709"/>
         <source>Automate edge color is required for the &apos;%1&apos; option but is not enabled.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="779"/>
+        <location filename="../common/lc_application.cpp" line="799"/>
         <source>LeoCAD Continuous Build %1
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="781"/>
+        <location filename="../common/lc_application.cpp" line="801"/>
         <source>LeoCAD Version %1
 </source>
         <translation type="unfinished">LeoCAD Version %1
 </translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="783"/>
+        <location filename="../common/lc_application.cpp" line="803"/>
         <source>Compiled %1
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="788"/>
+        <location filename="../common/lc_application.cpp" line="808"/>
         <source>Usage: leocad [options] [file]
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="789"/>
+        <location filename="../common/lc_application.cpp" line="809"/>
         <source>  [options] can be:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="790"/>
+        <location filename="../common/lc_application.cpp" line="810"/>
         <source>  -l, --libpath &lt;path&gt;: Set the Parts Library location to path.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="791"/>
+        <location filename="../common/lc_application.cpp" line="811"/>
         <source>  -i, --image &lt;outfile.ext&gt;: Save a picture in the format specified by ext and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="792"/>
+        <location filename="../common/lc_application.cpp" line="812"/>
         <source>  -w, --width &lt;width&gt;: Set the picture width.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="793"/>
+        <location filename="../common/lc_application.cpp" line="813"/>
         <source>  -h, --height &lt;height&gt;: Set the picture height.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="794"/>
+        <location filename="../common/lc_application.cpp" line="814"/>
         <source>  -f, --from &lt;step&gt;: Set the first step to save pictures.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="795"/>
+        <location filename="../common/lc_application.cpp" line="815"/>
         <source>  -t, --to &lt;step&gt;: Set the last step to save pictures.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="796"/>
+        <location filename="../common/lc_application.cpp" line="816"/>
         <source>  -s, --submodel &lt;submodel&gt;: Set the active submodel.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="797"/>
+        <location filename="../common/lc_application.cpp" line="817"/>
         <source>  -c, --camera &lt;camera&gt;: Set the active camera.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="798"/>
+        <location filename="../common/lc_application.cpp" line="818"/>
         <source>  -ss, --stud-style &lt;id&gt;: Set the stud style 0=No style, 1=LDraw single wire, 2=LDraw double wire, 3=LDraw raised floating, 4=LDraw raised rounded, 5=LDraw subtle rounded, 6=LEGO no logo, 7=LEGO single wire.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="799"/>
+        <location filename="../common/lc_application.cpp" line="819"/>
         <source>  --viewpoint &lt;front|back|left|right|top|bottom|home&gt;: Set the viewpoint.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="800"/>
+        <location filename="../common/lc_application.cpp" line="820"/>
         <source>  --camera-angles &lt;latitude&gt; &lt;longitude&gt;: Set the camera angles in degrees around the model.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="801"/>
+        <location filename="../common/lc_application.cpp" line="821"/>
         <source>  --camera-position &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="802"/>
+        <location filename="../common/lc_application.cpp" line="822"/>
         <source>  --camera-position-ldraw &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector using LDraw coordinates.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="803"/>
+        <location filename="../common/lc_application.cpp" line="823"/>
         <source>  --orthographic: Render images using an orthographic projection.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="804"/>
+        <location filename="../common/lc_application.cpp" line="824"/>
         <source>  --fov &lt;degrees&gt;: Set the vertical field of view used to render images (&lt; 180).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="805"/>
+        <location filename="../common/lc_application.cpp" line="825"/>
         <source>  --zplanes &lt;near&gt; &lt;far&gt;: Set the near and far clipping planes used to render images (1 &lt;= &lt;near&gt; &lt; &lt;far&gt;).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="806"/>
+        <location filename="../common/lc_application.cpp" line="826"/>
         <source>  --fade-steps: Render parts from prior steps faded.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="807"/>
+        <location filename="../common/lc_application.cpp" line="827"/>
         <source>  --no-fade-steps: Do not render parts from prior steps faded.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="808"/>
+        <location filename="../common/lc_application.cpp" line="828"/>
         <source>  --fade-steps-color &lt;rgba&gt;: Renderinng color for prior step parts (#AARRGGBB).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="809"/>
+        <location filename="../common/lc_application.cpp" line="829"/>
         <source>  --highlight: Highlight parts in the steps they appear.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="810"/>
+        <location filename="../common/lc_application.cpp" line="830"/>
         <source>  --no-highlight: Do not highlight parts in the steps they appear.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="811"/>
+        <location filename="../common/lc_application.cpp" line="831"/>
         <source>  --highlight-color: Renderinng color for highlighted parts (#AARRGGBB).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="812"/>
+        <location filename="../common/lc_application.cpp" line="832"/>
         <source>  --shading &lt;wireframe|flat|default|full&gt;: Select shading mode for rendering.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="813"/>
-        <source>  --line-width &lt;width&gt;: Set the with of the edge lines.
+        <location filename="../common/lc_application.cpp" line="833"/>
+        <source>  --line-width &lt;width&gt;: Set the width of the edge lines.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="814"/>
+        <location filename="../common/lc_application.cpp" line="834"/>
         <source>  --aa-samples &lt;count&gt;: AntiAliasing sample size (1, 2, 4, or 8).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="815"/>
+        <location filename="../common/lc_application.cpp" line="835"/>
         <source>  -scc, --stud-cylinder-color &lt;#AARRGGBB&gt;: High contrast stud cylinder color.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="816"/>
+        <location filename="../common/lc_application.cpp" line="836"/>
         <source>  -ec, --edge-color &lt;#AARRGGBB&gt;: High contrast edge color.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="817"/>
+        <location filename="../common/lc_application.cpp" line="837"/>
         <source>  -bec, --black-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for black parts.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="818"/>
+        <location filename="../common/lc_application.cpp" line="838"/>
         <source>  -dec, --dark-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for dark color parts.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="819"/>
+        <location filename="../common/lc_application.cpp" line="839"/>
         <source>  -aec, --automate-edge-color: Enable automatically adjusted edge colors.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="820"/>
+        <location filename="../common/lc_application.cpp" line="840"/>
         <source>  -cc, --color-contrast &lt;float&gt;: Color contrast value between 0.0 and 1.0.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="821"/>
+        <location filename="../common/lc_application.cpp" line="841"/>
         <source>  -ldv, --light-dark-value &lt;float&gt;: Light/Dark color value between 0.0 and 1.0.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="822"/>
+        <location filename="../common/lc_application.cpp" line="842"/>
         <source>  -obj, --export-wavefront &lt;outfile.obj&gt;: Export the model to Wavefront OBJ format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="823"/>
+        <location filename="../common/lc_application.cpp" line="843"/>
         <source>  -3ds, --export-3ds &lt;outfile.3ds&gt;: Export the model to 3D Studio 3DS format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="824"/>
+        <location filename="../common/lc_application.cpp" line="844"/>
         <source>  -dae, --export-collada &lt;outfile.dae&gt;: Export the model to COLLADA DAE format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="825"/>
+        <location filename="../common/lc_application.cpp" line="845"/>
         <source>  -html, --export-html &lt;folder&gt;: Create an HTML page for the model.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="826"/>
+        <location filename="../common/lc_application.cpp" line="846"/>
         <source>  -v, --version: Output version information and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="827"/>
+        <location filename="../common/lc_application.cpp" line="847"/>
         <source>  -?, --help: Display this help message and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="833"/>
+        <location filename="../common/lc_application.cpp" line="853"/>
         <source>Unknown option: &apos;%1&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="840"/>
+        <location filename="../common/lc_application.cpp" line="860"/>
         <source>High contrast stud and edge color settings are ignored when -aec or --automate-edge-color is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="846"/>
+        <location filename="../common/lc_application.cpp" line="866"/>
         <source>--viewpoint is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="849"/>
+        <location filename="../common/lc_application.cpp" line="869"/>
         <source>--orthographic is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="852"/>
+        <location filename="../common/lc_application.cpp" line="872"/>
         <source>--camera-angles is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="855"/>
+        <location filename="../common/lc_application.cpp" line="875"/>
         <source>--camera-position is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="860"/>
+        <location filename="../common/lc_application.cpp" line="880"/>
         <source>--camera-angles is ignored when --viewpoint is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="863"/>
+        <location filename="../common/lc_application.cpp" line="883"/>
         <source>--camera-position is ignored when --viewpoint is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="868"/>
+        <location filename="../common/lc_application.cpp" line="888"/>
         <source>--camera-position is ignored when --camera-angles is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="875"/>
+        <location filename="../common/lc_application.cpp" line="895"/>
         <source>No file name specified.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="908"/>
+        <location filename="../common/lc_application.cpp" line="928"/>
         <source>Error creating OpenGL context.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="931"/>
+        <location filename="../common/lc_application.cpp" line="951"/>
         <source>LeoCAD could not load Parts Library.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
@@ -4427,22 +4425,22 @@ Please visit https://www.leocad.org for information on how to download and insta
 SVP visitez https://www.leocad.org pour apprendre comment télécharger et installer une bibliothèque.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1002"/>
+        <location filename="../common/lc_application.cpp" line="1022"/>
         <source>Error: model &apos;%1&apos; does not exist.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1093"/>
-        <location filename="../common/lc_application.cpp" line="1121"/>
-        <location filename="../common/lc_application.cpp" line="1146"/>
-        <location filename="../common/lc_application.cpp" line="1171"/>
+        <location filename="../common/lc_application.cpp" line="1113"/>
+        <location filename="../common/lc_application.cpp" line="1141"/>
+        <location filename="../common/lc_application.cpp" line="1166"/>
+        <location filename="../common/lc_application.cpp" line="1191"/>
         <source>Saved &apos;%1&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>Some changes will only take effect the next time you start LeoCAD.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4492,6 +4490,26 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
         <translation type="unfinished">Réinitialiser</translation>
     </message>
     <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Light/Dark Value:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Saturation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="54"/>
+        <source>Set to classify where color values are light or dark - e.g. Dark Bluish Gray (72) is light at 0.39.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="55"/>
+        <source>Set to specify amount of edge color tint or shade from the saturation adjusted part color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="68"/>
         <source>High Contrast</source>
         <translation type="unfinished"></translation>
@@ -4527,8 +4545,18 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="179"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Black parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="183"/>
         <source>Select Black Edge Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="191"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Dark parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4589,109 +4617,134 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
 <context>
     <name>lcInstructionsDialog</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="527"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="532"/>
         <source>Instructions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="542"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="547"/>
         <source>Page Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="552"/>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="554"/>
+        <source>Vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="557"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="571"/>
+        <source>Page %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPageListWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="174"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="179"/>
         <source>Pages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="189"/>
+        <source>Page Setup</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPropertiesWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="288"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="293"/>
         <source>Properties</source>
         <translation type="unfinished">Propriétés</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Forward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="296"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="301"/>
         <source>Scope:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="301"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="306"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="351"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="356"/>
         <source>Select Step Number Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="355"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="360"/>
         <source>Select Step Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="359"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="364"/>
         <source>Select Parts List Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="363"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="368"/>
         <source>Select Parts List Border Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="367"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="372"/>
         <source>Select Parts List Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="417"/>
-        <location filename="../common/lc_instructionsdialog.cpp" line="438"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="422"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="443"/>
         <source>Select Step Number Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="421"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="426"/>
         <source>Select Parts List Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="477"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="482"/>
         <source>Step Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="493"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="498"/>
         <source>Step Number Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="508"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="513"/>
         <source>Parts List Properties</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4699,225 +4752,220 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
 <context>
     <name>lcMainWindow</name>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="403"/>
-        <location filename="../common/lc_mainwindow.cpp" line="606"/>
-        <location filename="../common/lc_mainwindow.cpp" line="613"/>
+        <location filename="../common/lc_mainwindow.cpp" line="376"/>
+        <location filename="../common/lc_mainwindow.cpp" line="577"/>
+        <location filename="../common/lc_mainwindow.cpp" line="584"/>
         <source>Transform</source>
         <translation>Transformation</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="410"/>
+        <location filename="../common/lc_mainwindow.cpp" line="383"/>
         <source>C&amp;ameras</source>
         <translation>C&amp;améras</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="456"/>
+        <location filename="../common/lc_mainwindow.cpp" line="426"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="467"/>
+        <location filename="../common/lc_mainwindow.cpp" line="437"/>
         <source>&amp;Export</source>
         <translation>&amp;Exporter</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="488"/>
+        <location filename="../common/lc_mainwindow.cpp" line="458"/>
         <source>&amp;Edit</source>
         <translation>&amp;Éditer</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="512"/>
+        <location filename="../common/lc_mainwindow.cpp" line="482"/>
         <source>&amp;View</source>
         <translation>&amp;Vue</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="419"/>
+        <location filename="../common/lc_mainwindow.cpp" line="389"/>
         <source>&amp;Viewpoints</source>
         <translation>&amp;Points de vue</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="398"/>
         <source>Projection</source>
         <translation>Projection</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="521"/>
+        <location filename="../common/lc_mainwindow.cpp" line="491"/>
         <source>Ste&amp;p</source>
         <translation>Éta&amp;pe</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="506"/>
         <source>T&amp;oolbars</source>
         <translation>Barres d’&amp;outils</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="549"/>
+        <location filename="../common/lc_mainwindow.cpp" line="519"/>
         <source>&amp;Piece</source>
         <translation>&amp;Pièce</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="583"/>
+        <location filename="../common/lc_mainwindow.cpp" line="554"/>
         <source>&amp;Help</source>
         <translation>&amp;Aide</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="614"/>
+        <location filename="../common/lc_mainwindow.cpp" line="585"/>
         <source>Transform Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="618"/>
+        <location filename="../common/lc_mainwindow.cpp" line="589"/>
         <source>Snap XY</source>
         <translation>Pas XY</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="622"/>
+        <location filename="../common/lc_mainwindow.cpp" line="593"/>
         <source>Snap Z</source>
         <translation>Pas Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="626"/>
+        <location filename="../common/lc_mainwindow.cpp" line="597"/>
         <source>Snap Menu</source>
         <translation>Menu pas</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="632"/>
+        <location filename="../common/lc_mainwindow.cpp" line="603"/>
         <source>Movement Snap</source>
         <translation>Pas pour les déplacements</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="633"/>
+        <location filename="../common/lc_mainwindow.cpp" line="604"/>
         <source>Snap translations to fixed intervals</source>
         <translation>Utiliser un pas donné pour les translations</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="637"/>
+        <location filename="../common/lc_mainwindow.cpp" line="608"/>
         <source>Snap Angle Menu</source>
         <translation>Menu pas pour les angles</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="643"/>
+        <location filename="../common/lc_mainwindow.cpp" line="614"/>
         <source>Rotation Snap</source>
         <translation>Pas pour les rotations</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="644"/>
+        <location filename="../common/lc_mainwindow.cpp" line="615"/>
         <source>Snap rotations to fixed intervals</source>
         <translation>Utiliser un pas fixe pour les rotations</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="648"/>
+        <location filename="../common/lc_mainwindow.cpp" line="619"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="437"/>
-        <location filename="../common/lc_mainwindow.cpp" line="674"/>
+        <location filename="../common/lc_mainwindow.cpp" line="407"/>
+        <location filename="../common/lc_mainwindow.cpp" line="645"/>
         <source>Tools</source>
         <translation>Outils</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="172"/>
+        <location filename="../common/lc_mainwindow.cpp" line="145"/>
         <source>New Model</source>
         <translation type="unfinished">Nouveau modèle</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="173"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
+        <location filename="../common/lc_mainwindow.cpp" line="146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
         <source>Open Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="174"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2507"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2434"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="432"/>
+        <location filename="../common/lc_mainwindow.cpp" line="402"/>
         <source>Sh&amp;ading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="464"/>
+        <location filename="../common/lc_mainwindow.cpp" line="434"/>
         <source>&amp;Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="575"/>
+        <location filename="../common/lc_mainwindow.cpp" line="546"/>
         <source>Sub&amp;model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="597"/>
-        <location filename="../common/lc_mainwindow.cpp" line="601"/>
+        <location filename="../common/lc_mainwindow.cpp" line="568"/>
+        <location filename="../common/lc_mainwindow.cpp" line="572"/>
         <source>Selection Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="602"/>
+        <location filename="../common/lc_mainwindow.cpp" line="573"/>
         <source>Change selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="666"/>
+        <location filename="../common/lc_mainwindow.cpp" line="637"/>
         <source>Time</source>
         <translation>Temps</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="696"/>
+        <location filename="../common/lc_mainwindow.cpp" line="667"/>
         <source>Parts</source>
         <translation>Pièces</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="702"/>
+        <location filename="../common/lc_mainwindow.cpp" line="673"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="731"/>
+        <location filename="../common/lc_mainwindow.cpp" line="702"/>
         <source>Properties</source>
         <translation>Propriétés</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="766"/>
+        <location filename="../common/lc_mainwindow.cpp" line="737"/>
         <source>Timeline</source>
         <translation>Ligne temporelle</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
-        <source>Part preview for &apos;%1&apos; failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_mainwindow.cpp" line="814"/>
-        <location filename="../common/lc_mainwindow.cpp" line="815"/>
+        <location filename="../common/lc_mainwindow.cpp" line="784"/>
+        <location filename="../common/lc_mainwindow.cpp" line="785"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1031"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1001"/>
         <source>Close Other Tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1113"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1083"/>
         <source>The file &apos;%1&apos; has been modified by another application, do you want to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1119"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1089"/>
         <source>File Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2058"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1985"/>
         <source>%1 (ID: %2)</source>
         <translation>%1 (ID : %2)</translation>
     </message>
     <message numerus="yes">
-        <location filename="../common/lc_mainwindow.cpp" line="2064"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1991"/>
         <source>%n Object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4925,57 +4973,57 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
         </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Rel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Abs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2074"/>
         <source> M: %1 %2 R: %3 %4 </source>
         <translation type="unfinished"> M : %1 %2 R : %3  {1 %2 ?} {3 %4 ?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Merge Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
         <source>Merged 1 submodel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>Merged %1 submodels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>LEGO Diginal Designer Files (*.lxf);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2068"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1995"/>
         <source> - %1 (ID: %2)</source>
         <translation> - %1 (ID : %2)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2072"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1999"/>
         <source> in group &apos;%1&apos;</source>
         <translation> dans le groupe « %1 »</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2110"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2037"/>
         <source>Step %1</source>
         <translation>Étape %1</translation>
     </message>
@@ -4984,34 +5032,34 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
         <translation type="vanished"> M : %1 %2 R : %3 </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2168"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2095"/>
         <source>&amp;Undo %1</source>
         <translation>Ann&amp;uler %1</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2173"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2100"/>
         <source>&amp;Undo</source>
         <translation>Ann&amp;uler</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2179"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2106"/>
         <source>&amp;Redo %1</source>
         <translation>&amp;Refaire %1</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2184"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2111"/>
         <source>&amp;Redo</source>
         <translation>&amp;Refaire</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Supported Files (*.lcd *.ldr *.dat *.mpd);;All Files (*.*)</source>
         <translation>Fichiers pris en charge (*.lcd *.ldr *.dat *.mpd);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
@@ -5020,111 +5068,110 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
         <translation type="vanished">Erreur au chargement de « %1 ».</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.mpd);;All Files (*.*)</source>
         <translation>Fichiers pris en charge (*.mpd);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.ldr *.dat *.mpd);;All Files (*.*)</source>
         <translation>Fichiers pris en charge (*.ldr *.dat *.mpd);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Saving files in LCD format is no longer supported, please use the LDR or MPD formats instead.</source>
         <translation>Enregistrer les fichiers sous le format LCD n’est plus possible, SVP utiliser les formats LDR ou MPD à la place.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save changes to &apos;%1&apos;?</source>
         <translation>Enregistrer les modifications à « %1 » ?</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/20S</source>
         <translation>1/20T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/4S</source>
         <translation>1/4T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1F</source>
         <translation>1P</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/2S</source>
         <translation>1/2T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1S</source>
         <translation>1T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>2S</source>
         <translation>2T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>3S</source>
         <translation>3T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>4S</source>
         <translation>4T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>8S</source>
         <translation>8T</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="152"/>
-        <location filename="../common/lc_mainwindow.h" line="158"/>
-        <location filename="../common/lc_mainwindow.h" line="163"/>
+        <location filename="../common/lc_mainwindow.h" line="131"/>
+        <location filename="../common/lc_mainwindow.h" line="137"/>
+        <location filename="../common/lc_mainwindow.h" line="142"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1B</source>
         <translation>1B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>2B</source>
         <translation>2B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>4B</source>
         <translation>4B</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>8B</source>
         <translation>8B</translation>
     </message>
@@ -5236,119 +5283,119 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
 <context>
     <name>lcModel</name>
     <message>
-        <location filename="../common/lc_model.cpp" line="1146"/>
+        <location filename="../common/lc_model.cpp" line="1143"/>
         <source>Pasting</source>
         <translation>Collage</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="2531"/>
-        <location filename="../common/lc_model.cpp" line="4307"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
         <source>Error creating images.</source>
         <translation>Erreur à la création des images.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1765"/>
+        <location filename="../common/lc_model.cpp" line="1768"/>
         <source>Inserting Step</source>
         <translation>Insértion d’une étape</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1784"/>
+        <location filename="../common/lc_model.cpp" line="1787"/>
         <source>Removing Step</source>
         <translation>Suppression d’une étape</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
         <source>No pieces selected.</source>
         <translation>Aucune pièce sélectionnée.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="957"/>
-        <location filename="../common/lc_model.cpp" line="1831"/>
+        <location filename="../common/lc_model.cpp" line="954"/>
+        <location filename="../common/lc_model.cpp" line="1834"/>
         <source>Group #</source>
         <translation>Groupe n°</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1100"/>
+        <location filename="../common/lc_model.cpp" line="1097"/>
         <source>Cutting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1219"/>
+        <location filename="../common/lc_model.cpp" line="1216"/>
         <source>Duplicating Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation type="unfinished">Erreur en écrivant le fichier « %1 » :
 %2</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1850"/>
-        <location filename="../common/lc_model.cpp" line="1916"/>
+        <location filename="../common/lc_model.cpp" line="1853"/>
+        <location filename="../common/lc_model.cpp" line="1919"/>
         <source>Grouping</source>
         <translation>Grouper</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1886"/>
-        <location filename="../common/lc_model.cpp" line="1931"/>
+        <location filename="../common/lc_model.cpp" line="1889"/>
+        <location filename="../common/lc_model.cpp" line="1934"/>
         <source>Ungrouping</source>
         <translation>Dégrouper</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1977"/>
+        <location filename="../common/lc_model.cpp" line="1980"/>
         <source>Editing Groups</source>
         <translation>Éditer les groupes</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2176"/>
+        <location filename="../common/lc_model.cpp" line="2179"/>
         <source>Adding Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2218"/>
+        <location filename="../common/lc_model.cpp" line="2221"/>
         <source>Resetting Cameras</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2258"/>
+        <location filename="../common/lc_model.cpp" line="2261"/>
         <source>Removing Key Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2275"/>
-        <location filename="../common/lc_model.cpp" line="2292"/>
-        <location filename="../common/lc_model.cpp" line="2334"/>
-        <location filename="../common/lc_model.cpp" line="2379"/>
-        <location filename="../common/lc_model.cpp" line="2414"/>
+        <location filename="../common/lc_model.cpp" line="2278"/>
+        <location filename="../common/lc_model.cpp" line="2295"/>
+        <location filename="../common/lc_model.cpp" line="2337"/>
+        <location filename="../common/lc_model.cpp" line="2382"/>
+        <location filename="../common/lc_model.cpp" line="2417"/>
         <source>Modifying</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2482"/>
+        <location filename="../common/lc_model.cpp" line="2485"/>
         <source>New Model</source>
         <translation type="unfinished">Nouveau modèle</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2535"/>
+        <location filename="../common/lc_model.cpp" line="2538"/>
         <source>Inlining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5373,89 +5420,89 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
         <translation>Modification de pièce</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3723"/>
-        <location filename="../common/lc_model.cpp" line="3746"/>
+        <location filename="../common/lc_model.cpp" line="3741"/>
+        <location filename="../common/lc_model.cpp" line="3764"/>
         <source>Hide</source>
         <translation type="unfinished">Cacher</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3769"/>
-        <location filename="../common/lc_model.cpp" line="3792"/>
+        <location filename="../common/lc_model.cpp" line="3787"/>
+        <location filename="../common/lc_model.cpp" line="3810"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3834"/>
+        <location filename="../common/lc_model.cpp" line="3852"/>
         <source>Replacing Part</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3939"/>
+        <location filename="../common/lc_model.cpp" line="3957"/>
         <source>New SpotLight</source>
         <translation>Nouvelle lumière projecteur</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3944"/>
+        <location filename="../common/lc_model.cpp" line="3962"/>
         <source>New Camera</source>
         <translation>Nouvelle caméra</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3951"/>
+        <location filename="../common/lc_model.cpp" line="3969"/>
         <source>Move</source>
         <translation>Déplacer</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3955"/>
+        <location filename="../common/lc_model.cpp" line="3973"/>
         <source>Rotate</source>
         <translation>Tourner</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3965"/>
-        <location filename="../common/lc_model.cpp" line="4206"/>
-        <location filename="../common/lc_model.cpp" line="4266"/>
-        <location filename="../common/lc_model.cpp" line="4278"/>
+        <location filename="../common/lc_model.cpp" line="3983"/>
+        <location filename="../common/lc_model.cpp" line="4224"/>
+        <location filename="../common/lc_model.cpp" line="4284"/>
+        <location filename="../common/lc_model.cpp" line="4296"/>
         <source>Zoom</source>
         <translation>Zoomer</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3970"/>
+        <location filename="../common/lc_model.cpp" line="3988"/>
         <source>Pan</source>
         <translation>Glisser</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3975"/>
+        <location filename="../common/lc_model.cpp" line="3993"/>
         <source>Orbit</source>
         <translation>Orbiter</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3980"/>
+        <location filename="../common/lc_model.cpp" line="3998"/>
         <source>Roll</source>
         <translation>Pivoter</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4002"/>
+        <location filename="../common/lc_model.cpp" line="4020"/>
         <source>Insert</source>
         <translation>Insérer</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4012"/>
+        <location filename="../common/lc_model.cpp" line="4030"/>
         <source>New Light</source>
         <translation>Nouvelle lumière</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2229"/>
-        <location filename="../common/lc_model.cpp" line="4131"/>
+        <location filename="../common/lc_model.cpp" line="2232"/>
+        <location filename="../common/lc_model.cpp" line="4149"/>
         <source>Deleting</source>
         <translation>Suppression</translation>
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2844"/>
-        <location filename="../common/lc_model.cpp" line="4145"/>
+        <location filename="../common/lc_model.cpp" line="4163"/>
         <source>Painting</source>
         <translation>Peindre</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2531"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
         <source>No models selected.</source>
         <translation>Aucun modèle sélectionné.</translation>
     </message>
@@ -5487,42 +5534,42 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
         <translation>Renomme la caméra</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4229"/>
+        <location filename="../common/lc_model.cpp" line="4247"/>
         <source>Look At</source>
         <translation>Viser le modèle</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4239"/>
+        <location filename="../common/lc_model.cpp" line="4257"/>
         <source>Moving Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4300"/>
+        <location filename="../common/lc_model.cpp" line="4319"/>
         <source>Changing Properties</source>
         <translation>Change les propriétés</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4307"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
         <source>Nothing to select.</source>
         <translation>Rien à sélectionner.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>Array only has 1 element or less, no pieces added.</source>
         <translation>L’arrangement a seulement un élément ou moins, aucune pièce ajoutée.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4390"/>
+        <location filename="../common/lc_model.cpp" line="4409"/>
         <source>Array</source>
         <translation>Arrangement</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4402"/>
+        <location filename="../common/lc_model.cpp" line="4421"/>
         <source>Minifig #</source>
         <translation>Minifig n°</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4424"/>
+        <location filename="../common/lc_model.cpp" line="4443"/>
         <source>Minifig</source>
         <translation>Minifig</translation>
     </message>
@@ -5652,17 +5699,17 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
 <context>
     <name>lcPartSelectionListView</name>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="524"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="551"/>
         <source>Add to Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="535"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="562"/>
         <source>None</source>
         <translation type="unfinished">Aucun</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="539"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="566"/>
         <source>Remove from Palette</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5670,82 +5717,87 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
 <context>
     <name>lcPartSelectionWidget</name>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="719"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="746"/>
         <source>Search Parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="726"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="753"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="884"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="902"/>
+        <source>Edit Palettes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_partselectionwidget.cpp" line="911"/>
         <source>No Icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="889"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="916"/>
         <source>Small Icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="894"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="921"/>
         <source>Medium Icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="899"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="926"/>
         <source>Large Icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="904"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="931"/>
         <source>Extra Large Icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="914"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="941"/>
         <source>Show Part Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="919"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="946"/>
         <source>Show Decorated Parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="923"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="950"/>
         <source>Show Part Aliases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="929"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="956"/>
         <source>List Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="933"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="960"/>
         <source>Lock Preview Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="975"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1002"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1091"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1118"/>
         <source>All Parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1097"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1124"/>
         <source>In Use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1103"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1130"/>
         <source>Submodels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5753,12 +5805,12 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
 <context>
     <name>lcPiecesLibrary</name>
     <message>
-        <location filename="../common/lc_library.cpp" line="775"/>
+        <location filename="../common/lc_library.cpp" line="782"/>
         <source>Initializing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_library.cpp" line="776"/>
+        <location filename="../common/lc_library.cpp" line="783"/>
         <source>Loading Parts Library</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5767,6 +5819,7 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
     <name>lcPreviewDockWidget</name>
     <message>
         <location filename="../common/lc_previewwidget.cpp" line="19"/>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
         <source>Lock Preview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5791,23 +5844,18 @@ SVP visitez https://www.leocad.org pour apprendre comment télécharger et insta
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Unlock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Lock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../common/lc_previewwidget.cpp" line="78"/>
-        <source>%1 the preview display to %2 updates</source>
+        <source>Unlock the preview display to enable updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="80"/>
-        <source>%1 Preview</source>
+        <location filename="../common/lc_previewwidget.cpp" line="79"/>
+        <source>Lock the preview display to disable updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
+        <source>Unlock Preview</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6452,77 +6500,77 @@ Anisotropic: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1498"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1767"/>
         <source>Mouse</source>
         <translation>Souris</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1506"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1775"/>
         <source>Mouse Shortcuts</source>
         <translation>Raccourcis souris</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1521"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1790"/>
         <source>Action</source>
         <translation>Action</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1526"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1795"/>
         <source>Shortcut 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1531"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1800"/>
         <source>Shortcut 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1592"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1861"/>
         <source>Button:</source>
         <translation>Bouton :</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1600"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1869"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1605"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1874"/>
         <source>Left</source>
         <translation>Gauche</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1610"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1879"/>
         <source>Middle</source>
         <translation>Central</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1615"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1884"/>
         <source>Right</source>
         <translation>Droit</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1623"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1892"/>
         <source>Modifiers:</source>
         <translation>Modificateurs :</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1630"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1899"/>
         <source>Control</source>
         <translation>Contrôle</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1637"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1906"/>
         <source>Alt</source>
         <translation>Alt</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1644"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1913"/>
         <source>Shift</source>
         <translation>Maj</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1672"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1941"/>
         <source>Mouse sensitivity:</source>
         <translation>Sensibilité de la souris :</translation>
     </message>
@@ -6562,9 +6610,8 @@ Anisotropic: %5
         <translation>Rendu</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="359"/>
         <source>Edge lines</source>
-        <translation>Bordures</translation>
+        <translation type="vanished">Bordures</translation>
     </message>
     <message>
         <source>Axis icon</source>
@@ -6575,112 +6622,113 @@ Anisotropic: %5
         <translation type="vanished">largeur</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="436"/>
         <source>Anti-aliasing</source>
         <translation>Anti-aliasing</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="439"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
         <source>2x</source>
         <translation>2x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
         <source>4x</source>
         <translation>4x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="454"/>
         <source>8x</source>
         <translation>8x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="409"/>
         <source>Shading Mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="546"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="347"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="551"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="352"/>
         <source>Flat Shading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="357"/>
         <source>Default Lights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="678"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="745"/>
         <source>Base Grid</source>
         <translation>Grille de base</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="728"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="795"/>
         <source>Draw studs</source>
         <translation>Dessiner les tenons</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="751"/>
         <source>studs</source>
         <translation>tenons</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="704"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="771"/>
         <source>Draw lines every</source>
         <translation>Dessine des lignes tous les</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1111"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1052"/>
         <source>View Sphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="615"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="783"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="850"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="620"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="656"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="855"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="625"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="793"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="661"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="860"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="630"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="798"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="666"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="865"/>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1145"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1118"/>
         <source>Highlight Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1117"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1058"/>
         <source>Color:</source>
         <translation type="unfinished">Couleur :</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1131"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1088"/>
         <source>Text Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="600"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="775"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="636"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="711"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="842"/>
         <source>Location:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6775,374 +6823,437 @@ Anisotropic: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="429"/>
         <source>Stud Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="394"/>
-        <source>Fade previous steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="476"/>
         <source>Mesh LOD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="431"/>
         <source>Highlight new parts</source>
-        <translation type="unfinished">Mettre en évidence les nouvelles pièces</translation>
+        <translation type="obsolete">Mettre en évidence les nouvelles pièces</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="465"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="366"/>
         <source>Plain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="470"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="371"/>
         <source>Thin Lines Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="475"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="376"/>
         <source>Outline Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="381"/>
         <source>Sharp Top Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="386"/>
         <source>Rounded Top Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="490"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="391"/>
         <source>Flattened Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="495"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="396"/>
         <source>High Contrast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="500"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
         <source>High Contrast with Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="524"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
         <source>Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="531"/>
-        <source>Automate edge color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="538"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
         <source>Contrast Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="581"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="617"/>
         <source>Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="587"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="623"/>
         <source>Model Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="744"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="629"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="811"/>
         <source>Axis Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="607"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="806"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="643"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="873"/>
         <source>View Sphere:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="639"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="752"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="675"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="819"/>
         <source>Top Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="644"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="757"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="680"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="724"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="824"/>
         <source>Top Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="649"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="762"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="685"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="729"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="829"/>
         <source>Bottom Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="654"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="767"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="690"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="734"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="834"/>
         <source>Bottom Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="721"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
         <source>Draw origin lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="805"/>
         <source>Part Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="843"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="910"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="849"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1227"/>
         <source>Background</source>
         <translation type="unfinished">Fond</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="857"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1235"/>
         <source>Top Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="871"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1265"/>
         <source>Bottom Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="900"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
         <source>So&amp;lid Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="907"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1301"/>
         <source>&amp;Gradient</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="941"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="916"/>
         <source>Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="947"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="936"/>
         <source>Inactive View Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="961"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="978"/>
         <source>Overlay Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="968"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1026"/>
         <source>Active View Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="989"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="950"/>
         <source>Camera Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1016"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="985"/>
         <source>Axis Icon Labels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1030"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="922"/>
         <source>Marquee Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1044"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="469"/>
+        <source>Highlight New Parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="506"/>
+        <source>Fade Previous Steps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="523"/>
+        <source>Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="536"/>
+        <source>Conditional Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <source>Line Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="579"/>
+        <source>Edge Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="586"/>
+        <source>Automate Edge Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="964"/>
         <source>Marquee Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1061"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1161"/>
         <source>Grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1067"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1167"/>
         <source>Lines:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1197"/>
         <source>Studs:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1189"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1230"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1335"/>
+        <source>Objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1341"/>
+        <source>Light:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1371"/>
+        <source>Focused:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1385"/>
+        <source>Control Point Focused:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1420"/>
+        <source>Control Point:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1427"/>
+        <source>Selected:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1434"/>
+        <source>Camera:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1458"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1499"/>
         <source>Categories</source>
         <translation>Catégories</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1195"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1464"/>
         <source>Parts Library Categories</source>
         <translation>Catégories de la bibliothèque de pièces</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1264"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1533"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1538"/>
         <source>Number</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1280"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1408"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1541"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1549"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1677"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1810"/>
         <source>Import...</source>
         <translation>Importer…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1287"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1415"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1548"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1817"/>
         <source>Export...</source>
         <translation>Exporter…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1422"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1555"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1563"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1691"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1824"/>
         <source>Reset...</source>
         <translation>Réinitialiser…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1319"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1588"/>
         <source>Category</source>
         <translation>Catégorie</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1325"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1594"/>
         <source>New...</source>
         <translation>Nouveau…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1332"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1601"/>
         <source>Edit...</source>
         <translation>Éditer…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1608"/>
         <source>Delete...</source>
         <translation>Supprimer…</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1363"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1632"/>
         <source>Keyboard</source>
         <translation>Clavier</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1642"/>
         <source>Keyboard Shortcuts</source>
         <translation>Raccourcis clavier</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1386"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1655"/>
         <source>Command</source>
         <translation>Commande</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1391"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1450"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1584"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1660"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1853"/>
         <source>Shortcut</source>
         <translation>Raccourcis</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1399"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1668"/>
         <source>Search shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1456"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1725"/>
         <source>Key se&amp;quence:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1469"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1920"/>
         <source>Assign</source>
         <translation>Attribuer</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1476"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1658"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1745"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1927"/>
         <source>Remove</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="242"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="263"/>
         <source>Grid spacing must be greater than 0.</source>
         <translation>L’espacement de la grille doit être plus grand que 0.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="331"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="354"/>
         <source>Select Parts Library Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Supported Archives (*.zip *.bin);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Select Parts Library Archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Select Color Configuration File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Settings Files (*.ldr);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Select Minifig Settings File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Settings Files (*.ini);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="364"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
         <source>Executable Files (*.exe);;All Files (*.*)</source>
         <translation>Fichiers exécutables (*.exe);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="366"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="389"/>
         <source>All Files (*.*)</source>
         <translation>Tous les fichiers (*.*)</translation>
     </message>
@@ -7151,235 +7262,265 @@ Anisotropic: %5
         <translation type="vanished">Lancer l’exécutable POV-Ray</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="377"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="400"/>
         <source>Open LGEO Folder</source>
         <translation>Ouvrir le dossier LGEO</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Reset Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Would you like to also reset the interface colors to match the color theme?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="424"/>
         <source>Select Background Color</source>
         <translation type="unfinished">Choisir la couleur de fond</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="406"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="429"/>
         <source>Select Gradient Top Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="411"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="434"/>
         <source>Select Gradient Bottom Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="416"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="439"/>
         <source>Select Axes Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="421"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="444"/>
         <source>Select Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="426"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="449"/>
         <source>Select Marquee Border Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="431"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="454"/>
         <source>Select Marquee Fill Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="437"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="460"/>
         <source>Select Overlay Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="442"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="465"/>
         <source>Select Active View Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="447"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="470"/>
         <source>Select Inactive View Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="452"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="475"/>
         <source>Select Fade Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="458"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="481"/>
         <source>Select Highlight Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="464"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="487"/>
         <source>Select Grid Stud Color</source>
         <translation>Choisir le couleur des tenons de la grille</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="470"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="493"/>
         <source>Select Grid Line Color</source>
         <translation>Choisir la couleur des lignes de la grille</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="475"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="498"/>
         <source>Select View Sphere Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="503"/>
         <source>Select View Sphere Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="508"/>
         <source>Select View Sphere Highlight Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="596"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="513"/>
+        <source>Select Object Selected Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="518"/>
+        <source>Select Object Focused Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="523"/>
+        <source>Select Camera Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="528"/>
+        <source>Select Light Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="533"/>
+        <source>Select Control Point Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="539"/>
+        <source>Select Control Point Focused Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="661"/>
         <source>Unassigned</source>
         <translation>Non-attribué</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="710"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="775"/>
         <source>Are you sure you want to delete the category &apos;%1&apos;?</source>
         <translation>Êtes-vous sûr de vouloir supprimer la catégorie « %1 » ?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
         <source>Import Categories</source>
         <translation>Importer les catégories</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Text Files (*.txt);;All Files (*.*)</source>
         <translation>Fichiers texte (*.txt);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="731"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="796"/>
         <source>Error loading categories file.</source>
         <translation>Erreur au chargement du fichier des catégories.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
         <source>Export Categories</source>
         <translation>Exporter les catégories</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="749"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="814"/>
         <source>Error saving categories file.</source>
         <translation>Erreur à l’enregistrement du fichier des catégories.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="756"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="821"/>
         <source>Are you sure you want to load the default categories?</source>
         <translation>Êtes-vous sûr de vouloir charger les catégories par défaut ?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="957"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1022"/>
         <source>The shortcut &apos;%1&apos; is already assigned to &apos;%2&apos;. Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
         <source>Import shortcuts</source>
         <translation>Importer les raccourcis</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1020"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1085"/>
         <source>Error loading keyboard shortcuts file.</source>
         <translation>Erreur au chargement du fichier des raccourcis clavier.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
         <source>Export shortcuts</source>
         <translation>Exporter les raccourcis</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1039"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1104"/>
         <source>Error saving keyboard shortcuts file.</source>
         <translation>Erreur à l’enregistrement du fichier des raccourcis clavier.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1046"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1111"/>
         <source>Are you sure you want to load the default keyboard shortcuts?</source>
         <translation>Êtes-vous sûr de vouloir charger les raccourcis clavier par défaut ?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1073"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1138"/>
         <source>Left Button</source>
         <translation>Bouton gauche</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1142"/>
         <source>Middle Button</source>
         <translation>Bouton central</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1146"/>
         <source>Right Button</source>
         <translation>Bouton droit</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="959"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1024"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>Override Shortcut</source>
         <translation>Écraser le raccourcis</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="369"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="392"/>
         <source>Select POV-Ray Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>This shortcut is already assigned to &apos;%1&apos;, do you want to replace it?</source>
         <translation>Ce raccourcis est déjà attribué à « %1 », voulez-vous le remplacer ?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
         <source>Import Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1212"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1277"/>
         <source>Error loading mouse shortcuts file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Export Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1231"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1296"/>
         <source>Error saving mouse shortcuts file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1236"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1301"/>
         <source>Are you sure you want to load the default mouse shortcuts?</source>
         <translation>Êtes-vous sûr de vouloir charger les raccourcis souris par défaut ?</translation>
     </message>
@@ -7412,6 +7553,11 @@ Anisotropic: %5
         <translation>Commentaires :</translation>
     </message>
     <message>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="76"/>
+        <source>Measurements:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scene</source>
         <translation type="vanished">Scène</translation>
     </message>
@@ -7436,7 +7582,7 @@ Anisotropic: %5
         <translation type="vanished">Attribuer les options par défauts aux nouveaux projets</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.ui" line="77"/>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="91"/>
         <source>Parts Used</source>
         <translation>Pièces utilisées</translation>
     </message>
@@ -7446,13 +7592,20 @@ Anisotropic: %5
         <translation>%1 propriétés</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="62"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="51"/>
+        <source>%1 x %2 x %3 cm
+%4 x %5 x %6 inches
+%7 x %8 x %9 LDU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="70"/>
         <source>Part</source>
         <translation>Pièce</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="73"/>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="110"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="81"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="118"/>
         <source>Total</source>
         <translation>Total</translation>
     </message>
@@ -7490,40 +7643,40 @@ Anisotropic: %5
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="886"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1018"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="895"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1027"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="887"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="892"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1019"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1024"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="888"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="893"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1020"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1025"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1039"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="889"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="894"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1021"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1026"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1031"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="903"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1040"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="891"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
         <source>Rotation</source>
         <translation>Rotation</translation>
     </message>
@@ -7532,73 +7685,73 @@ Anisotropic: %5
         <translation type="vanished">Visibilité</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="905"/>
         <source>Visible Steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="906"/>
         <source>Show</source>
         <translation>Montrer</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="907"/>
         <source>Hide</source>
         <translation>Cacher</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="909"/>
         <source>Appearance</source>
         <translation>Apparence</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="910"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="911"/>
         <source>Part</source>
         <translation>Pièce</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1023"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1032"/>
         <source>Target</source>
         <translation>Cible</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1042"/>
         <source>Up</source>
         <translation>Haut</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1043"/>
         <source>Orthographic</source>
         <translation>Orthographique</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1044"/>
         <source>FOV</source>
         <translation>FOV</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1036"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1045"/>
         <source>Near</source>
         <translation>Proche</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1046"/>
         <source>Far</source>
         <translation>Loin</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1047"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1118"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1127"/>
         <source>Multiple Objects Selected</source>
         <translation>Plusieurs objets sélectionnés</translation>
     </message>
@@ -7886,22 +8039,22 @@ Anisotropic: %5
 <context>
     <name>lcView</name>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>LeoCAD</source>
         <translation type="unfinished">LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>Error creating images.</source>
         <translation type="unfinished">Erreur à la création des images.</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error</source>
         <translation type="unfinished">Erreur</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation type="unfinished">Erreur en écrivant le fichier « %1 » :

--- a/resources/leocad_pt.ts
+++ b/resources/leocad_pt.ts
@@ -700,586 +700,581 @@
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="981"/>
-        <source>View.Cameras.Reset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="988"/>
         <source>View.Time.First</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="995"/>
+        <location filename="../common/lc_commands.cpp" line="988"/>
         <source>View.Time.Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1002"/>
+        <location filename="../common/lc_commands.cpp" line="995"/>
         <source>View.Time.Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1009"/>
+        <location filename="../common/lc_commands.cpp" line="1002"/>
         <source>View.Time.Last</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1016"/>
+        <location filename="../common/lc_commands.cpp" line="1009"/>
         <source>View.Time.InsertBefore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1023"/>
+        <location filename="../common/lc_commands.cpp" line="1016"/>
         <source>View.Time.InsertAfter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1030"/>
+        <location filename="../common/lc_commands.cpp" line="1023"/>
         <source>View.Time.Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1037"/>
+        <location filename="../common/lc_commands.cpp" line="1030"/>
         <source>View.Time.AddKeys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1044"/>
+        <location filename="../common/lc_commands.cpp" line="1037"/>
         <source>View.SplitHorizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1051"/>
+        <location filename="../common/lc_commands.cpp" line="1044"/>
         <source>View.SplitVertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1058"/>
+        <location filename="../common/lc_commands.cpp" line="1051"/>
         <source>View.RemoveView</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1065"/>
+        <location filename="../common/lc_commands.cpp" line="1058"/>
         <source>View.ResetViews</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1072"/>
+        <location filename="../common/lc_commands.cpp" line="1065"/>
         <source>View.Toolbars.Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1079"/>
+        <location filename="../common/lc_commands.cpp" line="1072"/>
         <source>View.Toolbars.Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1086"/>
+        <location filename="../common/lc_commands.cpp" line="1079"/>
         <source>View.Toolbars.Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1093"/>
+        <location filename="../common/lc_commands.cpp" line="1086"/>
         <source>View.Toolbars.Parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1100"/>
+        <location filename="../common/lc_commands.cpp" line="1093"/>
         <source>View.Toolbars.Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1107"/>
+        <location filename="../common/lc_commands.cpp" line="1100"/>
         <source>View.Toolbars.Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1114"/>
+        <location filename="../common/lc_commands.cpp" line="1107"/>
         <source>View.Toolbars.Timeline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1121"/>
+        <location filename="../common/lc_commands.cpp" line="1114"/>
         <source>View.Toolbars.Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1128"/>
+        <location filename="../common/lc_commands.cpp" line="1121"/>
         <source>View.FullScreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1135"/>
+        <location filename="../common/lc_commands.cpp" line="1128"/>
         <source>View.CloseCurrentTab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1142"/>
+        <location filename="../common/lc_commands.cpp" line="1135"/>
         <source>View.Shade.Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1149"/>
+        <location filename="../common/lc_commands.cpp" line="1142"/>
         <source>View.Shade.Flat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1156"/>
+        <location filename="../common/lc_commands.cpp" line="1149"/>
         <source>View.Shade.DefaultLights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1163"/>
+        <location filename="../common/lc_commands.cpp" line="1156"/>
         <source>View.Projection.Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1170"/>
+        <location filename="../common/lc_commands.cpp" line="1163"/>
         <source>View.Projection.Orthographic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1177"/>
+        <location filename="../common/lc_commands.cpp" line="1170"/>
         <source>View.ToggleViewSphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1184"/>
+        <location filename="../common/lc_commands.cpp" line="1177"/>
         <source>View.ToggleAxisIcon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1191"/>
+        <location filename="../common/lc_commands.cpp" line="1184"/>
         <source>View.ToggleGrid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1198"/>
+        <location filename="../common/lc_commands.cpp" line="1191"/>
         <source>View.FadePreviousSteps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1205"/>
+        <location filename="../common/lc_commands.cpp" line="1198"/>
         <source>Piece.Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1212"/>
+        <location filename="../common/lc_commands.cpp" line="1205"/>
         <source>Piece.Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1219"/>
+        <location filename="../common/lc_commands.cpp" line="1212"/>
         <source>Piece.Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1226"/>
+        <location filename="../common/lc_commands.cpp" line="1219"/>
         <source>Piece.PaintSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1233"/>
+        <location filename="../common/lc_commands.cpp" line="1226"/>
         <source>Piece.ResetPivotPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1240"/>
+        <location filename="../common/lc_commands.cpp" line="1233"/>
         <source>Piece.RemoveKeyFrames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1247"/>
+        <location filename="../common/lc_commands.cpp" line="1240"/>
         <source>Piece.ControlPoint.Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1254"/>
+        <location filename="../common/lc_commands.cpp" line="1247"/>
         <source>Piece.ControlPoint.Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1261"/>
+        <location filename="../common/lc_commands.cpp" line="1254"/>
         <source>Piece.Move.PlusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1268"/>
+        <location filename="../common/lc_commands.cpp" line="1261"/>
         <source>Piece.Move.MinusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1275"/>
+        <location filename="../common/lc_commands.cpp" line="1268"/>
         <source>Piece.Move.PlusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1282"/>
+        <location filename="../common/lc_commands.cpp" line="1275"/>
         <source>Piece.Move.MinusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1289"/>
+        <location filename="../common/lc_commands.cpp" line="1282"/>
         <source>Piece.Move.PlusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1296"/>
+        <location filename="../common/lc_commands.cpp" line="1289"/>
         <source>Piece.Move.MinusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1303"/>
+        <location filename="../common/lc_commands.cpp" line="1296"/>
         <source>Piece.Rotate.PlusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1310"/>
+        <location filename="../common/lc_commands.cpp" line="1303"/>
         <source>Piece.Rotate.MinusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1317"/>
+        <location filename="../common/lc_commands.cpp" line="1310"/>
         <source>Piece.Rotate.PlusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1324"/>
+        <location filename="../common/lc_commands.cpp" line="1317"/>
         <source>Piece.Rotate.MinusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1331"/>
+        <location filename="../common/lc_commands.cpp" line="1324"/>
         <source>Piece.Rotate.PlusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1338"/>
+        <location filename="../common/lc_commands.cpp" line="1331"/>
         <source>Piece.Rotate.MinusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1345"/>
+        <location filename="../common/lc_commands.cpp" line="1338"/>
         <source>Piece.MinifigWizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1352"/>
+        <location filename="../common/lc_commands.cpp" line="1345"/>
         <source>Piece.Array</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1359"/>
+        <location filename="../common/lc_commands.cpp" line="1352"/>
         <source>Piece.ViewSelectedModel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1366"/>
+        <location filename="../common/lc_commands.cpp" line="1359"/>
         <source>Piece.MoveSelectionToModel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1373"/>
+        <location filename="../common/lc_commands.cpp" line="1366"/>
         <source>Piece.InlineSelectedModels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1380"/>
+        <location filename="../common/lc_commands.cpp" line="1373"/>
         <source>Piece.EditSelectedSubmodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1387"/>
+        <location filename="../common/lc_commands.cpp" line="1380"/>
         <source>Piece.EditEndSubmodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1394"/>
+        <location filename="../common/lc_commands.cpp" line="1387"/>
         <source>Piece.Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1401"/>
+        <location filename="../common/lc_commands.cpp" line="1394"/>
         <source>Piece.Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1408"/>
+        <location filename="../common/lc_commands.cpp" line="1401"/>
         <source>Piece.GroupAdd</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1415"/>
+        <location filename="../common/lc_commands.cpp" line="1408"/>
         <source>Piece.GroupRemove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1422"/>
+        <location filename="../common/lc_commands.cpp" line="1415"/>
         <source>Piece.GroupEdit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1429"/>
+        <location filename="../common/lc_commands.cpp" line="1422"/>
         <source>Piece.HideSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1436"/>
+        <location filename="../common/lc_commands.cpp" line="1429"/>
         <source>Piece.HideUnselected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1443"/>
+        <location filename="../common/lc_commands.cpp" line="1436"/>
         <source>Piece.UnhideSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1450"/>
+        <location filename="../common/lc_commands.cpp" line="1443"/>
         <source>Piece.UnhideAll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1457"/>
+        <location filename="../common/lc_commands.cpp" line="1450"/>
         <source>Piece.ShowEarlier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1464"/>
+        <location filename="../common/lc_commands.cpp" line="1457"/>
         <source>Piece.ShowLater</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1471"/>
+        <location filename="../common/lc_commands.cpp" line="1464"/>
         <source>Model.New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1478"/>
+        <location filename="../common/lc_commands.cpp" line="1471"/>
         <source>Model.Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1485"/>
+        <location filename="../common/lc_commands.cpp" line="1478"/>
         <source>Model.List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1492"/>
+        <location filename="../common/lc_commands.cpp" line="1485"/>
         <source>Model.Model01</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1499"/>
+        <location filename="../common/lc_commands.cpp" line="1492"/>
         <source>Model.Model02</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1506"/>
+        <location filename="../common/lc_commands.cpp" line="1499"/>
         <source>Model.Model03</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1513"/>
+        <location filename="../common/lc_commands.cpp" line="1506"/>
         <source>Model.Model04</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1520"/>
+        <location filename="../common/lc_commands.cpp" line="1513"/>
         <source>Model.Model05</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1527"/>
+        <location filename="../common/lc_commands.cpp" line="1520"/>
         <source>Model.Model06</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1534"/>
+        <location filename="../common/lc_commands.cpp" line="1527"/>
         <source>Model.Model07</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1541"/>
+        <location filename="../common/lc_commands.cpp" line="1534"/>
         <source>Model.Model08</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1548"/>
+        <location filename="../common/lc_commands.cpp" line="1541"/>
         <source>Model.Model09</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1555"/>
+        <location filename="../common/lc_commands.cpp" line="1548"/>
         <source>Model.Model10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1562"/>
+        <location filename="../common/lc_commands.cpp" line="1555"/>
         <source>Model.Model11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1569"/>
+        <location filename="../common/lc_commands.cpp" line="1562"/>
         <source>Model.Model12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1576"/>
+        <location filename="../common/lc_commands.cpp" line="1569"/>
         <source>Model.Model13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1583"/>
+        <location filename="../common/lc_commands.cpp" line="1576"/>
         <source>Model.Model14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1590"/>
+        <location filename="../common/lc_commands.cpp" line="1583"/>
         <source>Model.Model15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1597"/>
+        <location filename="../common/lc_commands.cpp" line="1590"/>
         <source>Model.Model16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1604"/>
+        <location filename="../common/lc_commands.cpp" line="1597"/>
         <source>Model.Model17</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1611"/>
+        <location filename="../common/lc_commands.cpp" line="1604"/>
         <source>Model.Model18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1618"/>
+        <location filename="../common/lc_commands.cpp" line="1611"/>
         <source>Model.Model19</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1625"/>
+        <location filename="../common/lc_commands.cpp" line="1618"/>
         <source>Model.Model20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1632"/>
+        <location filename="../common/lc_commands.cpp" line="1625"/>
         <source>Model.Model21</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1639"/>
+        <location filename="../common/lc_commands.cpp" line="1632"/>
         <source>Model.Model22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1646"/>
+        <location filename="../common/lc_commands.cpp" line="1639"/>
         <source>Model.Model23</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1653"/>
+        <location filename="../common/lc_commands.cpp" line="1646"/>
         <source>Model.Model24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1660"/>
+        <location filename="../common/lc_commands.cpp" line="1653"/>
         <source>Model.Model25</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1667"/>
+        <location filename="../common/lc_commands.cpp" line="1660"/>
         <source>Model.Model26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1674"/>
+        <location filename="../common/lc_commands.cpp" line="1667"/>
         <source>Model.Model27</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1681"/>
+        <location filename="../common/lc_commands.cpp" line="1674"/>
         <source>Model.Model28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1688"/>
+        <location filename="../common/lc_commands.cpp" line="1681"/>
         <source>Model.Model29</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1695"/>
+        <location filename="../common/lc_commands.cpp" line="1688"/>
         <source>Model.Model30</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1702"/>
+        <location filename="../common/lc_commands.cpp" line="1695"/>
         <source>Model.Model31</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1709"/>
+        <location filename="../common/lc_commands.cpp" line="1702"/>
         <source>Model.Model32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1716"/>
+        <location filename="../common/lc_commands.cpp" line="1709"/>
         <source>Model.Model33</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1723"/>
+        <location filename="../common/lc_commands.cpp" line="1716"/>
         <source>Model.Model34</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1730"/>
+        <location filename="../common/lc_commands.cpp" line="1723"/>
         <source>Model.Model35</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1737"/>
+        <location filename="../common/lc_commands.cpp" line="1730"/>
         <source>Model.Model36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1744"/>
+        <location filename="../common/lc_commands.cpp" line="1737"/>
         <source>Model.Model37</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1751"/>
+        <location filename="../common/lc_commands.cpp" line="1744"/>
         <source>Model.Model38</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1758"/>
+        <location filename="../common/lc_commands.cpp" line="1751"/>
         <source>Model.Model39</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1765"/>
+        <location filename="../common/lc_commands.cpp" line="1758"/>
         <source>Model.Model40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1772"/>
+        <location filename="../common/lc_commands.cpp" line="1765"/>
         <source>Help.HomePage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1779"/>
+        <location filename="../common/lc_commands.cpp" line="1772"/>
         <source>Help.BugReport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1786"/>
+        <location filename="../common/lc_commands.cpp" line="1779"/>
         <source>Help.Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1793"/>
+        <location filename="../common/lc_commands.cpp" line="1786"/>
         <source>Help.About</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1377,37 +1372,37 @@
         <translation>Grelha de Movimentos Activada</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1017"/>
+        <location filename="../common/lc_commands.cpp" line="1010"/>
         <source>Insert Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1017"/>
         <source>Insert After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1360"/>
+        <location filename="../common/lc_commands.cpp" line="1353"/>
         <source>Open Selected Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1381"/>
+        <location filename="../common/lc_commands.cpp" line="1374"/>
         <source>Edit Selected Submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1388"/>
+        <location filename="../common/lc_commands.cpp" line="1381"/>
         <source>End Submodel Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1472"/>
+        <location filename="../common/lc_commands.cpp" line="1465"/>
         <source>New Submodel...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1479"/>
+        <location filename="../common/lc_commands.cpp" line="1472"/>
         <source>Prope&amp;rties...</source>
         <translation>Prop&amp;riedades...</translation>
     </message>
@@ -1979,563 +1974,562 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="982"/>
         <source>Reset</source>
-        <translation>Reiniciar</translation>
+        <translation type="vanished">Reiniciar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="989"/>
+        <location filename="../common/lc_commands.cpp" line="982"/>
         <source>First</source>
         <translation>Primeiro</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="996"/>
+        <location filename="../common/lc_commands.cpp" line="989"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1003"/>
+        <location filename="../common/lc_commands.cpp" line="996"/>
         <source>Next</source>
         <translation>Seguinte</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1010"/>
+        <location filename="../common/lc_commands.cpp" line="1003"/>
         <source>Last</source>
         <translation>Último</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1031"/>
-        <location filename="../common/lc_commands.cpp" line="1815"/>
+        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1808"/>
         <source>Remove Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1038"/>
+        <location filename="../common/lc_commands.cpp" line="1031"/>
         <source>Add Keys</source>
         <translation>Adicionar Passos</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1045"/>
+        <location filename="../common/lc_commands.cpp" line="1038"/>
         <source>Split &amp;Horizontal</source>
         <translation>Corte &amp;Horizontal</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1052"/>
+        <location filename="../common/lc_commands.cpp" line="1045"/>
         <source>Split &amp;Vertical</source>
         <translation>Corte &amp;Vertical</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1059"/>
+        <location filename="../common/lc_commands.cpp" line="1052"/>
         <source>Re&amp;move View</source>
         <translation>Re&amp;mover Vista</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1066"/>
+        <location filename="../common/lc_commands.cpp" line="1059"/>
         <source>Rese&amp;t Views</source>
         <translation>Reini&amp;ciar Vistas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1073"/>
+        <location filename="../common/lc_commands.cpp" line="1066"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1080"/>
+        <location filename="../common/lc_commands.cpp" line="1073"/>
         <source>Tools</source>
         <translation type="unfinished">Ferramentas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1087"/>
+        <location filename="../common/lc_commands.cpp" line="1080"/>
         <source>Time</source>
         <translation type="unfinished">Hora</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1094"/>
+        <location filename="../common/lc_commands.cpp" line="1087"/>
         <source>Parts</source>
         <translation type="unfinished">Peças</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1101"/>
+        <location filename="../common/lc_commands.cpp" line="1094"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1108"/>
+        <location filename="../common/lc_commands.cpp" line="1101"/>
         <source>Properties</source>
         <translation type="unfinished">Propriedades</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1115"/>
+        <location filename="../common/lc_commands.cpp" line="1108"/>
         <source>Timeline</source>
         <translation type="unfinished">Linha Temporal</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1122"/>
+        <location filename="../common/lc_commands.cpp" line="1115"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1129"/>
+        <location filename="../common/lc_commands.cpp" line="1122"/>
         <source>&amp;Full Screen</source>
         <translation>&amp;Tela Cheia</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1136"/>
+        <location filename="../common/lc_commands.cpp" line="1129"/>
         <source>Close &amp;Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1143"/>
+        <location filename="../common/lc_commands.cpp" line="1136"/>
         <source>&amp;Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1150"/>
+        <location filename="../common/lc_commands.cpp" line="1143"/>
         <source>&amp;Flat Shading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1157"/>
+        <location filename="../common/lc_commands.cpp" line="1150"/>
         <source>&amp;Default Lights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1164"/>
+        <location filename="../common/lc_commands.cpp" line="1157"/>
         <source>&amp;Perspective</source>
         <translation>&amp;Perspectiva</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1171"/>
+        <location filename="../common/lc_commands.cpp" line="1164"/>
         <source>&amp;Orthographic</source>
         <translation>&amp;Ortográphica</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1178"/>
+        <location filename="../common/lc_commands.cpp" line="1171"/>
         <source>View Sphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1185"/>
+        <location filename="../common/lc_commands.cpp" line="1178"/>
         <source>Axis Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1192"/>
+        <location filename="../common/lc_commands.cpp" line="1185"/>
         <source>Base Grid</source>
         <translation type="unfinished">Grelha de Base</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1199"/>
+        <location filename="../common/lc_commands.cpp" line="1192"/>
         <source>Fade Previous Steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1206"/>
+        <location filename="../common/lc_commands.cpp" line="1199"/>
         <source>&amp;Insert</source>
         <translation>&amp;Inserir</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1213"/>
+        <location filename="../common/lc_commands.cpp" line="1206"/>
         <source>&amp;Delete</source>
         <translation>&amp;Apagar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1220"/>
+        <location filename="../common/lc_commands.cpp" line="1213"/>
         <source>&amp;Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1227"/>
+        <location filename="../common/lc_commands.cpp" line="1220"/>
         <source>&amp;Paint Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1234"/>
+        <location filename="../common/lc_commands.cpp" line="1227"/>
         <source>Reset &amp;Pivot Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1241"/>
+        <location filename="../common/lc_commands.cpp" line="1234"/>
         <source>Remove &amp;Key Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1248"/>
+        <location filename="../common/lc_commands.cpp" line="1241"/>
         <source>Insert Control Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1255"/>
+        <location filename="../common/lc_commands.cpp" line="1248"/>
         <source>Remove Control Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1262"/>
+        <location filename="../common/lc_commands.cpp" line="1255"/>
         <source>Move +X</source>
         <translation>Mover +X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1269"/>
+        <location filename="../common/lc_commands.cpp" line="1262"/>
         <source>Move -X</source>
         <translation>Mover -X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1276"/>
+        <location filename="../common/lc_commands.cpp" line="1269"/>
         <source>Move +Y</source>
         <translation>Mover +Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1283"/>
+        <location filename="../common/lc_commands.cpp" line="1276"/>
         <source>Move -Y</source>
         <translation>Mover -Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1290"/>
+        <location filename="../common/lc_commands.cpp" line="1283"/>
         <source>Move +Z</source>
         <translation>Mover +Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1297"/>
+        <location filename="../common/lc_commands.cpp" line="1290"/>
         <source>Move -Z</source>
         <translation>Mover -Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1304"/>
+        <location filename="../common/lc_commands.cpp" line="1297"/>
         <source>Rotate +X</source>
         <translation>Rodar +X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1311"/>
+        <location filename="../common/lc_commands.cpp" line="1304"/>
         <source>Rotate -X</source>
         <translation>Rodar -X</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1318"/>
+        <location filename="../common/lc_commands.cpp" line="1311"/>
         <source>Rotate +Y</source>
         <translation>Rodar +Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1325"/>
+        <location filename="../common/lc_commands.cpp" line="1318"/>
         <source>Rotate -Y</source>
         <translation>Rodar -Y</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1332"/>
+        <location filename="../common/lc_commands.cpp" line="1325"/>
         <source>Rotate +Z</source>
         <translation>Rodar +Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1339"/>
+        <location filename="../common/lc_commands.cpp" line="1332"/>
         <source>Rotate -Z</source>
         <translation>Rodar -Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1346"/>
+        <location filename="../common/lc_commands.cpp" line="1339"/>
         <source>Minifig &amp;Wizard...</source>
         <translation>&amp;Assistente Minifig...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1353"/>
+        <location filename="../common/lc_commands.cpp" line="1346"/>
         <source>A&amp;rray...</source>
         <translation>Quad&amp;ro...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1367"/>
+        <location filename="../common/lc_commands.cpp" line="1360"/>
         <source>Move to New Model...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1374"/>
+        <location filename="../common/lc_commands.cpp" line="1367"/>
         <source>Inline Selected Models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1395"/>
+        <location filename="../common/lc_commands.cpp" line="1388"/>
         <source>&amp;Group...</source>
         <translation>&amp;Grupo...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1402"/>
+        <location filename="../common/lc_commands.cpp" line="1395"/>
         <source>&amp;Ungroup</source>
         <translation>Desagr&amp;upar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1409"/>
+        <location filename="../common/lc_commands.cpp" line="1402"/>
         <source>&amp;Add to Group</source>
         <translation>&amp;Meter no Grupo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1416"/>
+        <location filename="../common/lc_commands.cpp" line="1409"/>
         <source>Re&amp;move from Group</source>
         <translation>Re&amp;mover do Grupo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1423"/>
+        <location filename="../common/lc_commands.cpp" line="1416"/>
         <source>&amp;Edit Groups...</source>
         <translation>&amp;Editar Grupos...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1430"/>
+        <location filename="../common/lc_commands.cpp" line="1423"/>
         <source>&amp;Hide Selected</source>
         <translation>&amp;Esconder Selecção</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1437"/>
+        <location filename="../common/lc_commands.cpp" line="1430"/>
         <source>Hide &amp;Unselected</source>
         <translation>E&amp;sconder não Seleccionados</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1444"/>
+        <location filename="../common/lc_commands.cpp" line="1437"/>
         <source>&amp;Unhide Selected</source>
         <translation>&amp;Mostrar Selecção</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1451"/>
+        <location filename="../common/lc_commands.cpp" line="1444"/>
         <source>U&amp;nhide All</source>
         <translation>Mostr&amp;ar Tudo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1458"/>
+        <location filename="../common/lc_commands.cpp" line="1451"/>
         <source>Show Earlier</source>
         <translation>Mostrar Anteriores</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1465"/>
+        <location filename="../common/lc_commands.cpp" line="1458"/>
         <source>Show Later</source>
         <translation>Mostrar Seguintes</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1486"/>
+        <location filename="../common/lc_commands.cpp" line="1479"/>
         <source>Submodels...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1493"/>
+        <location filename="../common/lc_commands.cpp" line="1486"/>
         <source>Model 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1500"/>
+        <location filename="../common/lc_commands.cpp" line="1493"/>
         <source>Model 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1507"/>
+        <location filename="../common/lc_commands.cpp" line="1500"/>
         <source>Model 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1514"/>
+        <location filename="../common/lc_commands.cpp" line="1507"/>
         <source>Model 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1521"/>
+        <location filename="../common/lc_commands.cpp" line="1514"/>
         <source>Model 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1528"/>
+        <location filename="../common/lc_commands.cpp" line="1521"/>
         <source>Model 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1535"/>
+        <location filename="../common/lc_commands.cpp" line="1528"/>
         <source>Model 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1542"/>
+        <location filename="../common/lc_commands.cpp" line="1535"/>
         <source>Model 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1549"/>
+        <location filename="../common/lc_commands.cpp" line="1542"/>
         <source>Model 9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1556"/>
+        <location filename="../common/lc_commands.cpp" line="1549"/>
         <source>Model 10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1563"/>
+        <location filename="../common/lc_commands.cpp" line="1556"/>
         <source>Model 11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1570"/>
+        <location filename="../common/lc_commands.cpp" line="1563"/>
         <source>Model 12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1577"/>
+        <location filename="../common/lc_commands.cpp" line="1570"/>
         <source>Model 13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1584"/>
+        <location filename="../common/lc_commands.cpp" line="1577"/>
         <source>Model 14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1591"/>
+        <location filename="../common/lc_commands.cpp" line="1584"/>
         <source>Model 15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1598"/>
+        <location filename="../common/lc_commands.cpp" line="1591"/>
         <source>Model 16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1605"/>
+        <location filename="../common/lc_commands.cpp" line="1598"/>
         <source>Model 17</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1612"/>
+        <location filename="../common/lc_commands.cpp" line="1605"/>
         <source>Model 18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1619"/>
+        <location filename="../common/lc_commands.cpp" line="1612"/>
         <source>Model 19</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1626"/>
+        <location filename="../common/lc_commands.cpp" line="1619"/>
         <source>Model 20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1633"/>
+        <location filename="../common/lc_commands.cpp" line="1626"/>
         <source>Model 21</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1640"/>
+        <location filename="../common/lc_commands.cpp" line="1633"/>
         <source>Model 22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1647"/>
+        <location filename="../common/lc_commands.cpp" line="1640"/>
         <source>Model 23</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1654"/>
+        <location filename="../common/lc_commands.cpp" line="1647"/>
         <source>Model 24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1661"/>
+        <location filename="../common/lc_commands.cpp" line="1654"/>
         <source>Model 25</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1668"/>
+        <location filename="../common/lc_commands.cpp" line="1661"/>
         <source>Model 26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1675"/>
+        <location filename="../common/lc_commands.cpp" line="1668"/>
         <source>Model 27</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1682"/>
+        <location filename="../common/lc_commands.cpp" line="1675"/>
         <source>Model 28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1689"/>
+        <location filename="../common/lc_commands.cpp" line="1682"/>
         <source>Model 29</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1696"/>
+        <location filename="../common/lc_commands.cpp" line="1689"/>
         <source>Model 30</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1703"/>
+        <location filename="../common/lc_commands.cpp" line="1696"/>
         <source>Model 31</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1710"/>
+        <location filename="../common/lc_commands.cpp" line="1703"/>
         <source>Model 32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1717"/>
+        <location filename="../common/lc_commands.cpp" line="1710"/>
         <source>Model 33</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1724"/>
+        <location filename="../common/lc_commands.cpp" line="1717"/>
         <source>Model 34</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1731"/>
+        <location filename="../common/lc_commands.cpp" line="1724"/>
         <source>Model 35</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1738"/>
+        <location filename="../common/lc_commands.cpp" line="1731"/>
         <source>Model 36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1745"/>
+        <location filename="../common/lc_commands.cpp" line="1738"/>
         <source>Model 37</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1752"/>
+        <location filename="../common/lc_commands.cpp" line="1745"/>
         <source>Model 38</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1759"/>
+        <location filename="../common/lc_commands.cpp" line="1752"/>
         <source>Model 39</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1766"/>
+        <location filename="../common/lc_commands.cpp" line="1759"/>
         <source>Model 40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1780"/>
+        <location filename="../common/lc_commands.cpp" line="1773"/>
         <source>Report a Bug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1801"/>
+        <location filename="../common/lc_commands.cpp" line="1794"/>
         <source>Insert Step Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1808"/>
+        <location filename="../common/lc_commands.cpp" line="1801"/>
         <source>Insert Step After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1822"/>
+        <location filename="../common/lc_commands.cpp" line="1815"/>
         <source>Move Selection Here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1829"/>
+        <location filename="../common/lc_commands.cpp" line="1822"/>
         <source>Set Current Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1773"/>
+        <location filename="../common/lc_commands.cpp" line="1766"/>
         <source>LeoCAD &amp;Home Page</source>
         <translation>&amp;Página do LeoCAD</translation>
     </message>
@@ -2570,12 +2564,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1787"/>
+        <location filename="../common/lc_commands.cpp" line="1780"/>
         <source>Check for &amp;Updates...</source>
         <translation>Procurar act&amp;ualizações...</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1794"/>
+        <location filename="../common/lc_commands.cpp" line="1787"/>
         <source>&amp;About...</source>
         <translation>&amp;Acerca...</translation>
     </message>
@@ -2583,77 +2577,77 @@
 <context>
     <name>Mouse</name>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1839"/>
+        <location filename="../common/lc_commands.cpp" line="1832"/>
         <source>NewPiece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1840"/>
+        <location filename="../common/lc_commands.cpp" line="1833"/>
         <source>NewPointLight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1841"/>
+        <location filename="../common/lc_commands.cpp" line="1834"/>
         <source>NewSpotLight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1842"/>
+        <location filename="../common/lc_commands.cpp" line="1835"/>
         <source>NewCamera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1843"/>
+        <location filename="../common/lc_commands.cpp" line="1836"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1844"/>
+        <location filename="../common/lc_commands.cpp" line="1837"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1845"/>
+        <location filename="../common/lc_commands.cpp" line="1838"/>
         <source>Rotate</source>
         <translation>Rodar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1846"/>
+        <location filename="../common/lc_commands.cpp" line="1839"/>
         <source>Delete</source>
         <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1847"/>
+        <location filename="../common/lc_commands.cpp" line="1840"/>
         <source>Paint</source>
         <translation>Pintar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1848"/>
+        <location filename="../common/lc_commands.cpp" line="1841"/>
         <source>ColorPicker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1849"/>
+        <location filename="../common/lc_commands.cpp" line="1842"/>
         <source>Zoom</source>
         <translation type="unfinished">Zoom</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1850"/>
+        <location filename="../common/lc_commands.cpp" line="1843"/>
         <source>Pan</source>
         <translation type="unfinished">Movimento Horizontal</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1851"/>
+        <location filename="../common/lc_commands.cpp" line="1844"/>
         <source>Orbit</source>
         <translation type="unfinished">Órbitar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1852"/>
+        <location filename="../common/lc_commands.cpp" line="1845"/>
         <source>Roll</source>
         <translation type="unfinished">Inclinar</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1853"/>
+        <location filename="../common/lc_commands.cpp" line="1846"/>
         <source>ZoomRegion</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2661,117 +2655,115 @@
 <context>
     <name>Project</name>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>Empty Name</source>
         <translation>Nome Vazio</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
-        <location filename="../common/project.cpp" line="449"/>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="378"/>
+        <location filename="../common/project.cpp" line="457"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
+        <location filename="../common/project.cpp" line="378"/>
         <source>Error reading file &apos;%1&apos;:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="449"/>
+        <location filename="../common/project.cpp" line="457"/>
         <source>Error loading file &apos;%1&apos;:
 File format is not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="544"/>
+        <location filename="../common/project.cpp" line="552"/>
         <source>Merged </source>
         <translation>Combinado </translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
-        <location filename="../common/project.cpp" line="2060"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
+        <location filename="../common/project.cpp" line="2025"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="2060"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="2025"/>
         <source>Nothing to export.</source>
         <translation>Nada a exportar.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>Export 3D Studio</source>
         <translation>Exportar para 3D Studio</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>3DS Files (*.3ds);;All Files (*.*)</source>
         <translation>Ficheiros 3DS (*.3ds);;Todos os Ficheiros (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>Could not open file &apos;%1&apos; for writing.</source>
         <translation>Erro ao abrir o ficheiro &apos;%1&apos; para escrever.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>Export BrickLink</source>
         <translation>Exportar BrickLink</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>XML Files (*.xml);;All Files (*.*)</source>
         <translation>Ficheiros XML (*.xml);;Todos os Ficheiros (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>Export COLLADA</source>
         <translation>Exportar COLLADA</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>COLLADA Files (*.dae);;All Files (*.*)</source>
         <translation>Ficheiros COLLADA (*.dae);;Todos os Ficheiros (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>Export CSV</source>
         <translation>Exportar CSV</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>CSV Files (*.csv);;All Files (*.*)</source>
         <translation>Ficheiros CSV (*.csv);;Todos os Ficheiros (*.*)</translation>
     </message>
@@ -2780,81 +2772,81 @@ File format is not recognized.</source>
         <translation type="vanished">Erro ao criar as imagens.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>Export POV-Ray</source>
         <translation>Exportar POV-Ray</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>POV-Ray Files (*.pov);;All Files (*.*)</source>
         <translation>Ficheiros POV-Ray (*.pov);;Todos os Ficheiros (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
         <source>Could not find LGEO files in folder &apos;%1&apos;.</source>
         <translation>Não achei ficheiros LGEO na pasta &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Export Wavefront</source>
         <translation>Exportar Wavefront</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Wavefront Files (*.obj);;All Files (*.*)</source>
         <translation>Ficheiros Wavefront (*.obj);;Todos os Ficheiros (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation>Erro ao escrever no ficheiro &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.ldr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.mpd</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="177"/>
+        <location filename="../common/project.cpp" line="178"/>
         <source>Submodel #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="201"/>
+        <location filename="../common/project.cpp" line="202"/>
         <source>Submodel Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>The submodel name cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>Duplicate Submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>A submodel named &apos;%1&apos; already exists, please enter a unique name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="245"/>
+        <location filename="../common/project.cpp" line="246"/>
         <source>New Submodel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2882,19 +2874,19 @@ File format is not recognized.</source>
         <translation type="vanished">Cores Especiais</translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="507"/>
+        <location filename="../common/lc_colors.cpp" line="318"/>
         <source>Solid</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="508"/>
+        <location filename="../common/lc_colors.cpp" line="319"/>
         <source>Translucent</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="509"/>
+        <location filename="../common/lc_colors.cpp" line="320"/>
         <source>Special</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
@@ -2903,14 +2895,21 @@ File format is not recognized.</source>
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
         <source>Error</source>
-        <translation type="unfinished">Erro</translation>
+        <translation type="obsolete">Erro</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>LeoCAD</source>
+        <translation type="unfinished">LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
-        <source>Failed to load &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>Could not open file &apos;%1&apos; for writing.</source>
+        <translation type="unfinished">Erro ao abrir o ficheiro &apos;%1&apos; para escrever.</translation>
     </message>
 </context>
 <context>
@@ -3505,27 +3504,26 @@ File format is not recognized.</source>
         <translation>Utilizar esta câmara</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="983"/>
         <source>Reset views to their default positions</source>
-        <translation>Repor as vistas por omissão</translation>
+        <translation type="vanished">Repor as vistas por omissão</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="990"/>
+        <location filename="../common/lc_commands.cpp" line="983"/>
         <source>Go to the first step of the model</source>
         <translation>Ir ao primeiro passo do modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="997"/>
+        <location filename="../common/lc_commands.cpp" line="990"/>
         <source>Go to the previous step</source>
         <translation>Ir ao passo anterior</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1004"/>
+        <location filename="../common/lc_commands.cpp" line="997"/>
         <source>Go to the next step</source>
         <translation>Ir ao passo seguinte</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1004"/>
         <source>Go to the last step of the model</source>
         <translation>Ir ao último passo do modelo</translation>
     </message>
@@ -3534,47 +3532,48 @@ File format is not recognized.</source>
         <translation type="vanished">Inserir um novo passo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1032"/>
-        <location filename="../common/lc_commands.cpp" line="1816"/>
+        <location filename="../common/lc_commands.cpp" line="1025"/>
+        <location filename="../common/lc_commands.cpp" line="1809"/>
         <source>Remove current step</source>
         <translation>Apaga o passo actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1137"/>
+        <location filename="../common/lc_commands.cpp" line="1130"/>
         <source>Close current tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1361"/>
+        <location filename="../common/lc_commands.cpp" line="1354"/>
         <source>Open the model referenced by the selected piece in a new tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1382"/>
+        <location filename="../common/lc_commands.cpp" line="1375"/>
         <source>Edit the currently selected submodel in-place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1389"/>
+        <location filename="../common/lc_commands.cpp" line="1382"/>
         <source>End in-place submodel editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1473"/>
+        <location filename="../common/lc_commands.cpp" line="1466"/>
         <source>Create a new submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1480"/>
+        <location filename="../common/lc_commands.cpp" line="1473"/>
         <source>Display the properties of the current submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1487"/>
+        <location filename="../common/lc_commands.cpp" line="1480"/>
         <source>Show a list of all submodels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1487"/>
         <location filename="../common/lc_commands.cpp" line="1494"/>
         <location filename="../common/lc_commands.cpp" line="1501"/>
         <location filename="../common/lc_commands.cpp" line="1508"/>
@@ -3614,27 +3613,26 @@ File format is not recognized.</source>
         <location filename="../common/lc_commands.cpp" line="1746"/>
         <location filename="../common/lc_commands.cpp" line="1753"/>
         <location filename="../common/lc_commands.cpp" line="1760"/>
-        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Switch to this submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1781"/>
+        <location filename="../common/lc_commands.cpp" line="1774"/>
         <source>Open LeoCAD&apos;s bug report form on your default web browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1823"/>
+        <location filename="../common/lc_commands.cpp" line="1816"/>
         <source>Move the selected parts into this step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1830"/>
+        <location filename="../common/lc_commands.cpp" line="1823"/>
         <source>View the model at this point in the timeline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1039"/>
+        <location filename="../common/lc_commands.cpp" line="1032"/>
         <source>Toggle adding new animation keys</source>
         <translation>Activa a adição de novos passos</translation>
     </message>
@@ -3689,290 +3687,290 @@ File format is not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1018"/>
-        <location filename="../common/lc_commands.cpp" line="1802"/>
+        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1795"/>
         <source>Insert a new step before the current step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1025"/>
-        <location filename="../common/lc_commands.cpp" line="1809"/>
+        <location filename="../common/lc_commands.cpp" line="1018"/>
+        <location filename="../common/lc_commands.cpp" line="1802"/>
         <source>Insert a new step after the current step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1046"/>
+        <location filename="../common/lc_commands.cpp" line="1039"/>
         <source>Split the current view horizontally</source>
         <translation>Divide horizontalemente a vista actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1053"/>
+        <location filename="../common/lc_commands.cpp" line="1046"/>
         <source>Split the current view vertically</source>
         <translation>Divide verticalemente a vista actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1060"/>
+        <location filename="../common/lc_commands.cpp" line="1053"/>
         <source>Remove the current view</source>
         <translation>Apaga a vista actual</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1067"/>
+        <location filename="../common/lc_commands.cpp" line="1060"/>
         <source>Reset all views</source>
         <translation>Reinicia todas as vistas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1074"/>
+        <location filename="../common/lc_commands.cpp" line="1067"/>
         <source>Toggle the Standard Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1081"/>
+        <location filename="../common/lc_commands.cpp" line="1074"/>
         <source>Toggle the Tools Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1088"/>
+        <location filename="../common/lc_commands.cpp" line="1081"/>
         <source>Toggle the Time Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1095"/>
+        <location filename="../common/lc_commands.cpp" line="1088"/>
         <source>Toggle the Parts Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1102"/>
+        <location filename="../common/lc_commands.cpp" line="1095"/>
         <source>Toggle the Colors Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1109"/>
+        <location filename="../common/lc_commands.cpp" line="1102"/>
         <source>Toggle the Properties Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1116"/>
+        <location filename="../common/lc_commands.cpp" line="1109"/>
         <source>Toggle the Timeline Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1123"/>
+        <location filename="../common/lc_commands.cpp" line="1116"/>
         <source>Toggle the Preview Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1130"/>
+        <location filename="../common/lc_commands.cpp" line="1123"/>
         <source>Toggle fullscreen mode</source>
         <translation>Modo tela cheia</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1144"/>
+        <location filename="../common/lc_commands.cpp" line="1137"/>
         <source>Display the scene as wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1151"/>
+        <location filename="../common/lc_commands.cpp" line="1144"/>
         <source>Display the scene without any shading or lights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1158"/>
+        <location filename="../common/lc_commands.cpp" line="1151"/>
         <source>Display the scene with the default lights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1165"/>
+        <location filename="../common/lc_commands.cpp" line="1158"/>
         <source>Set the current camera to use a perspective projection</source>
         <translation>Define a câmara actual em projecção por perspectiva</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1172"/>
+        <location filename="../common/lc_commands.cpp" line="1165"/>
         <source>Set the current camera to use an orthographic projection</source>
         <translation>Define a câmara actual em projecção ortogonal</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1179"/>
+        <location filename="../common/lc_commands.cpp" line="1172"/>
         <source>Toggle the view sphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1186"/>
+        <location filename="../common/lc_commands.cpp" line="1179"/>
         <source>Toggle axis icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1193"/>
+        <location filename="../common/lc_commands.cpp" line="1186"/>
         <source>Toggle grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1200"/>
+        <location filename="../common/lc_commands.cpp" line="1193"/>
         <source>Toggle fading previous model steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1207"/>
+        <location filename="../common/lc_commands.cpp" line="1200"/>
         <source>Add a new piece to the model</source>
         <translation>Adiciona ma nova peça ao modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1214"/>
+        <location filename="../common/lc_commands.cpp" line="1207"/>
         <source>Delete selected objects</source>
         <translation>Apagar os objectos seleccionados</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1221"/>
+        <location filename="../common/lc_commands.cpp" line="1214"/>
         <source>Create a copy of the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1228"/>
+        <location filename="../common/lc_commands.cpp" line="1221"/>
         <source>Change the color of the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1235"/>
+        <location filename="../common/lc_commands.cpp" line="1228"/>
         <source>Reset the pivot point of the selected pieces to their origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1242"/>
+        <location filename="../common/lc_commands.cpp" line="1235"/>
         <source>Remove all key frames from the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1249"/>
+        <location filename="../common/lc_commands.cpp" line="1242"/>
         <source>Insert a new control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1256"/>
+        <location filename="../common/lc_commands.cpp" line="1249"/>
         <source>Remove the selected control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1256"/>
         <location filename="../common/lc_commands.cpp" line="1263"/>
-        <location filename="../common/lc_commands.cpp" line="1270"/>
         <source>Move selected objects along the X axis</source>
         <translation>Move os objectos seleccionados no eixo X</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1270"/>
         <location filename="../common/lc_commands.cpp" line="1277"/>
-        <location filename="../common/lc_commands.cpp" line="1284"/>
         <source>Move selected objects along the Y axis</source>
         <translation>Move os objectos seleccionados no eixo Y</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1284"/>
         <location filename="../common/lc_commands.cpp" line="1291"/>
-        <location filename="../common/lc_commands.cpp" line="1298"/>
         <source>Move selected objects along the Z axis</source>
         <translation>Move os objectos seleccionados no eixo Z</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1298"/>
         <location filename="../common/lc_commands.cpp" line="1305"/>
-        <location filename="../common/lc_commands.cpp" line="1312"/>
         <source>Rotate selected objects along the X axis</source>
         <translation>Roda os objectos seleccionados no eixo X</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1312"/>
         <location filename="../common/lc_commands.cpp" line="1319"/>
-        <location filename="../common/lc_commands.cpp" line="1326"/>
         <source>Rotate selected objects along the Y axis</source>
         <translation>Roda os objectos seleccionados no eixo Y</translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1326"/>
         <location filename="../common/lc_commands.cpp" line="1333"/>
-        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Rotate selected objects along the Z axis</source>
         <translation>Roda os objectos seleccionados no eixo Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1347"/>
+        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Add a new minifig to the model</source>
         <translation>Adiciona uma minifigura ao modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1354"/>
+        <location filename="../common/lc_commands.cpp" line="1347"/>
         <source>Make copies of the selected pieces</source>
         <translation>Duplica as peças seleccionadas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1368"/>
+        <location filename="../common/lc_commands.cpp" line="1361"/>
         <source>Move the selected pieces to a new model and replace them with a reference to the model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1375"/>
+        <location filename="../common/lc_commands.cpp" line="1368"/>
         <source>Insert the contents of the selected model references into the current model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1396"/>
+        <location filename="../common/lc_commands.cpp" line="1389"/>
         <source>Group selected pieces together</source>
         <translation>Agrupa as peças seleccionadas</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1403"/>
+        <location filename="../common/lc_commands.cpp" line="1396"/>
         <source>Ungroup selected group</source>
         <translation>Desagrupa o grupo seleccionado</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1410"/>
+        <location filename="../common/lc_commands.cpp" line="1403"/>
         <source>Add focused piece to selected group</source>
         <translation>Adiciona a peça activa ao grupo seleccionado</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1417"/>
+        <location filename="../common/lc_commands.cpp" line="1410"/>
         <source>Remove focused piece from group</source>
         <translation>Apaga a peça activa do grupo seleccionado</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1424"/>
+        <location filename="../common/lc_commands.cpp" line="1417"/>
         <source>Edit groups</source>
         <translation>Editar grupos</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1431"/>
+        <location filename="../common/lc_commands.cpp" line="1424"/>
         <source>Hide selected objects</source>
         <translation>Esconder os objectos seleccionados</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1438"/>
+        <location filename="../common/lc_commands.cpp" line="1431"/>
         <source>Hide objects that are not selected</source>
         <translation>Esconder os objectos não seleccionados</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1445"/>
+        <location filename="../common/lc_commands.cpp" line="1438"/>
         <source>Show hidden objects that are selected</source>
         <translation>Mostrar os objectos escondidos que estão seleccionados</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1452"/>
+        <location filename="../common/lc_commands.cpp" line="1445"/>
         <source>Show all hidden objects</source>
         <translation>Mostrar todos os objectos escondidos</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1459"/>
+        <location filename="../common/lc_commands.cpp" line="1452"/>
         <source>Show selected pieces one step earlier</source>
         <translation>Mostrar as peças seleccionadas um passo antes</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1466"/>
+        <location filename="../common/lc_commands.cpp" line="1459"/>
         <source>Show selected pieces one step later</source>
         <translation>Mostrar as peças seleccionadas um passo depois</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1774"/>
+        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Open LeoCAD&apos;s home page on the internet using your default web browser</source>
         <translation>Abre a página internet do LeoCAD com o navegador por omissão</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1788"/>
+        <location filename="../common/lc_commands.cpp" line="1781"/>
         <source>Check if a newer LeoCAD version or parts library has been released</source>
         <translation>Verifica se uma nova versão do LeoCAD ou da Biblioteca de peças estão disponiveis</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1795"/>
+        <location filename="../common/lc_commands.cpp" line="1788"/>
         <source>Display program version number and system information</source>
         <translation>Mostra o número de versão do programa e informações do sisitema</translation>
     </message>
@@ -4013,13 +4011,13 @@ File format is not recognized.</source>
 <context>
     <name>lcApplication</name>
     <message>
-        <location filename="../common/lc_application.cpp" line="934"/>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="954"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="929"/>
+        <location filename="../common/lc_application.cpp" line="949"/>
         <source>LeoCAD could not find a compatible Parts Library so only a small number of parts will be available.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
@@ -4028,397 +4026,397 @@ Please visit https://www.leocad.org for information on how to download and insta
 Veja https://www.leocad.org para saber como descarragar e instalar uma biblioteca.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="401"/>
-        <location filename="../common/lc_application.cpp" line="426"/>
-        <location filename="../common/lc_application.cpp" line="449"/>
-        <location filename="../common/lc_application.cpp" line="472"/>
-        <location filename="../common/lc_application.cpp" line="482"/>
-        <location filename="../common/lc_application.cpp" line="505"/>
-        <location filename="../common/lc_application.cpp" line="530"/>
+        <location filename="../common/lc_application.cpp" line="421"/>
+        <location filename="../common/lc_application.cpp" line="446"/>
+        <location filename="../common/lc_application.cpp" line="469"/>
+        <location filename="../common/lc_application.cpp" line="492"/>
+        <location filename="../common/lc_application.cpp" line="502"/>
+        <location filename="../common/lc_application.cpp" line="525"/>
+        <location filename="../common/lc_application.cpp" line="550"/>
         <source>Not enough parameters for the &apos;%1&apos; option.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="423"/>
-        <location filename="../common/lc_application.cpp" line="446"/>
-        <location filename="../common/lc_application.cpp" line="469"/>
-        <location filename="../common/lc_application.cpp" line="502"/>
-        <location filename="../common/lc_application.cpp" line="527"/>
-        <location filename="../common/lc_application.cpp" line="580"/>
-        <location filename="../common/lc_application.cpp" line="734"/>
-        <location filename="../common/lc_application.cpp" line="745"/>
+        <location filename="../common/lc_application.cpp" line="443"/>
+        <location filename="../common/lc_application.cpp" line="466"/>
+        <location filename="../common/lc_application.cpp" line="489"/>
+        <location filename="../common/lc_application.cpp" line="522"/>
+        <location filename="../common/lc_application.cpp" line="547"/>
+        <location filename="../common/lc_application.cpp" line="600"/>
+        <location filename="../common/lc_application.cpp" line="754"/>
+        <location filename="../common/lc_application.cpp" line="765"/>
         <source>Invalid parameter value specified for the &apos;%1&apos; option: &apos;%2&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="541"/>
+        <location filename="../common/lc_application.cpp" line="561"/>
         <source>The file &apos;%1&apos; is not readable.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="589"/>
+        <location filename="../common/lc_application.cpp" line="609"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: limits are +/- 360.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="601"/>
+        <location filename="../common/lc_application.cpp" line="621"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="620"/>
+        <location filename="../common/lc_application.cpp" line="640"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: requirements are: 1 &lt;= &lt;near&gt; &lt; &lt;far&gt;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="630"/>
-        <location filename="../common/lc_application.cpp" line="641"/>
-        <location filename="../common/lc_application.cpp" line="652"/>
-        <location filename="../common/lc_application.cpp" line="663"/>
+        <location filename="../common/lc_application.cpp" line="650"/>
+        <location filename="../common/lc_application.cpp" line="661"/>
+        <location filename="../common/lc_application.cpp" line="672"/>
+        <location filename="../common/lc_application.cpp" line="683"/>
         <source>High contrast stud style is required for the &apos;%1&apos; option but is not enabled.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="678"/>
-        <location filename="../common/lc_application.cpp" line="689"/>
+        <location filename="../common/lc_application.cpp" line="698"/>
+        <location filename="../common/lc_application.cpp" line="709"/>
         <source>Automate edge color is required for the &apos;%1&apos; option but is not enabled.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="779"/>
+        <location filename="../common/lc_application.cpp" line="799"/>
         <source>LeoCAD Continuous Build %1
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="781"/>
+        <location filename="../common/lc_application.cpp" line="801"/>
         <source>LeoCAD Version %1
 </source>
         <translation type="unfinished">LeoCAD Versão %1
 </translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="783"/>
+        <location filename="../common/lc_application.cpp" line="803"/>
         <source>Compiled %1
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="788"/>
+        <location filename="../common/lc_application.cpp" line="808"/>
         <source>Usage: leocad [options] [file]
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="789"/>
+        <location filename="../common/lc_application.cpp" line="809"/>
         <source>  [options] can be:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="790"/>
+        <location filename="../common/lc_application.cpp" line="810"/>
         <source>  -l, --libpath &lt;path&gt;: Set the Parts Library location to path.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="791"/>
+        <location filename="../common/lc_application.cpp" line="811"/>
         <source>  -i, --image &lt;outfile.ext&gt;: Save a picture in the format specified by ext and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="792"/>
+        <location filename="../common/lc_application.cpp" line="812"/>
         <source>  -w, --width &lt;width&gt;: Set the picture width.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="793"/>
+        <location filename="../common/lc_application.cpp" line="813"/>
         <source>  -h, --height &lt;height&gt;: Set the picture height.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="794"/>
+        <location filename="../common/lc_application.cpp" line="814"/>
         <source>  -f, --from &lt;step&gt;: Set the first step to save pictures.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="795"/>
+        <location filename="../common/lc_application.cpp" line="815"/>
         <source>  -t, --to &lt;step&gt;: Set the last step to save pictures.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="796"/>
+        <location filename="../common/lc_application.cpp" line="816"/>
         <source>  -s, --submodel &lt;submodel&gt;: Set the active submodel.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="797"/>
+        <location filename="../common/lc_application.cpp" line="817"/>
         <source>  -c, --camera &lt;camera&gt;: Set the active camera.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="798"/>
+        <location filename="../common/lc_application.cpp" line="818"/>
         <source>  -ss, --stud-style &lt;id&gt;: Set the stud style 0=No style, 1=LDraw single wire, 2=LDraw double wire, 3=LDraw raised floating, 4=LDraw raised rounded, 5=LDraw subtle rounded, 6=LEGO no logo, 7=LEGO single wire.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="799"/>
+        <location filename="../common/lc_application.cpp" line="819"/>
         <source>  --viewpoint &lt;front|back|left|right|top|bottom|home&gt;: Set the viewpoint.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="800"/>
+        <location filename="../common/lc_application.cpp" line="820"/>
         <source>  --camera-angles &lt;latitude&gt; &lt;longitude&gt;: Set the camera angles in degrees around the model.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="801"/>
+        <location filename="../common/lc_application.cpp" line="821"/>
         <source>  --camera-position &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="802"/>
+        <location filename="../common/lc_application.cpp" line="822"/>
         <source>  --camera-position-ldraw &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector using LDraw coordinates.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="803"/>
+        <location filename="../common/lc_application.cpp" line="823"/>
         <source>  --orthographic: Render images using an orthographic projection.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="804"/>
+        <location filename="../common/lc_application.cpp" line="824"/>
         <source>  --fov &lt;degrees&gt;: Set the vertical field of view used to render images (&lt; 180).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="805"/>
+        <location filename="../common/lc_application.cpp" line="825"/>
         <source>  --zplanes &lt;near&gt; &lt;far&gt;: Set the near and far clipping planes used to render images (1 &lt;= &lt;near&gt; &lt; &lt;far&gt;).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="806"/>
+        <location filename="../common/lc_application.cpp" line="826"/>
         <source>  --fade-steps: Render parts from prior steps faded.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="807"/>
+        <location filename="../common/lc_application.cpp" line="827"/>
         <source>  --no-fade-steps: Do not render parts from prior steps faded.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="808"/>
+        <location filename="../common/lc_application.cpp" line="828"/>
         <source>  --fade-steps-color &lt;rgba&gt;: Renderinng color for prior step parts (#AARRGGBB).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="809"/>
+        <location filename="../common/lc_application.cpp" line="829"/>
         <source>  --highlight: Highlight parts in the steps they appear.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="810"/>
+        <location filename="../common/lc_application.cpp" line="830"/>
         <source>  --no-highlight: Do not highlight parts in the steps they appear.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="811"/>
+        <location filename="../common/lc_application.cpp" line="831"/>
         <source>  --highlight-color: Renderinng color for highlighted parts (#AARRGGBB).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="812"/>
+        <location filename="../common/lc_application.cpp" line="832"/>
         <source>  --shading &lt;wireframe|flat|default|full&gt;: Select shading mode for rendering.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="813"/>
-        <source>  --line-width &lt;width&gt;: Set the with of the edge lines.
+        <location filename="../common/lc_application.cpp" line="833"/>
+        <source>  --line-width &lt;width&gt;: Set the width of the edge lines.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="814"/>
+        <location filename="../common/lc_application.cpp" line="834"/>
         <source>  --aa-samples &lt;count&gt;: AntiAliasing sample size (1, 2, 4, or 8).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="815"/>
+        <location filename="../common/lc_application.cpp" line="835"/>
         <source>  -scc, --stud-cylinder-color &lt;#AARRGGBB&gt;: High contrast stud cylinder color.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="816"/>
+        <location filename="../common/lc_application.cpp" line="836"/>
         <source>  -ec, --edge-color &lt;#AARRGGBB&gt;: High contrast edge color.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="817"/>
+        <location filename="../common/lc_application.cpp" line="837"/>
         <source>  -bec, --black-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for black parts.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="818"/>
+        <location filename="../common/lc_application.cpp" line="838"/>
         <source>  -dec, --dark-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for dark color parts.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="819"/>
+        <location filename="../common/lc_application.cpp" line="839"/>
         <source>  -aec, --automate-edge-color: Enable automatically adjusted edge colors.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="820"/>
+        <location filename="../common/lc_application.cpp" line="840"/>
         <source>  -cc, --color-contrast &lt;float&gt;: Color contrast value between 0.0 and 1.0.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="821"/>
+        <location filename="../common/lc_application.cpp" line="841"/>
         <source>  -ldv, --light-dark-value &lt;float&gt;: Light/Dark color value between 0.0 and 1.0.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="822"/>
+        <location filename="../common/lc_application.cpp" line="842"/>
         <source>  -obj, --export-wavefront &lt;outfile.obj&gt;: Export the model to Wavefront OBJ format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="823"/>
+        <location filename="../common/lc_application.cpp" line="843"/>
         <source>  -3ds, --export-3ds &lt;outfile.3ds&gt;: Export the model to 3D Studio 3DS format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="824"/>
+        <location filename="../common/lc_application.cpp" line="844"/>
         <source>  -dae, --export-collada &lt;outfile.dae&gt;: Export the model to COLLADA DAE format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="825"/>
+        <location filename="../common/lc_application.cpp" line="845"/>
         <source>  -html, --export-html &lt;folder&gt;: Create an HTML page for the model.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="826"/>
+        <location filename="../common/lc_application.cpp" line="846"/>
         <source>  -v, --version: Output version information and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="827"/>
+        <location filename="../common/lc_application.cpp" line="847"/>
         <source>  -?, --help: Display this help message and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="833"/>
+        <location filename="../common/lc_application.cpp" line="853"/>
         <source>Unknown option: &apos;%1&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="840"/>
+        <location filename="../common/lc_application.cpp" line="860"/>
         <source>High contrast stud and edge color settings are ignored when -aec or --automate-edge-color is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="846"/>
+        <location filename="../common/lc_application.cpp" line="866"/>
         <source>--viewpoint is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="849"/>
+        <location filename="../common/lc_application.cpp" line="869"/>
         <source>--orthographic is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="852"/>
+        <location filename="../common/lc_application.cpp" line="872"/>
         <source>--camera-angles is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="855"/>
+        <location filename="../common/lc_application.cpp" line="875"/>
         <source>--camera-position is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="860"/>
+        <location filename="../common/lc_application.cpp" line="880"/>
         <source>--camera-angles is ignored when --viewpoint is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="863"/>
+        <location filename="../common/lc_application.cpp" line="883"/>
         <source>--camera-position is ignored when --viewpoint is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="868"/>
+        <location filename="../common/lc_application.cpp" line="888"/>
         <source>--camera-position is ignored when --camera-angles is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="875"/>
+        <location filename="../common/lc_application.cpp" line="895"/>
         <source>No file name specified.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="908"/>
+        <location filename="../common/lc_application.cpp" line="928"/>
         <source>Error creating OpenGL context.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="931"/>
+        <location filename="../common/lc_application.cpp" line="951"/>
         <source>LeoCAD could not load Parts Library.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
@@ -4427,22 +4425,22 @@ Please visit https://www.leocad.org for information on how to download and insta
 Veja https://www.leocad.org para saber como descarragar e instalar uma biblioteca.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1002"/>
+        <location filename="../common/lc_application.cpp" line="1022"/>
         <source>Error: model &apos;%1&apos; does not exist.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1093"/>
-        <location filename="../common/lc_application.cpp" line="1121"/>
-        <location filename="../common/lc_application.cpp" line="1146"/>
-        <location filename="../common/lc_application.cpp" line="1171"/>
+        <location filename="../common/lc_application.cpp" line="1113"/>
+        <location filename="../common/lc_application.cpp" line="1141"/>
+        <location filename="../common/lc_application.cpp" line="1166"/>
+        <location filename="../common/lc_application.cpp" line="1191"/>
         <source>Saved &apos;%1&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>Some changes will only take effect the next time you start LeoCAD.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4492,6 +4490,26 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
         <translation type="unfinished">Reiniciar</translation>
     </message>
     <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Light/Dark Value:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Saturation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="54"/>
+        <source>Set to classify where color values are light or dark - e.g. Dark Bluish Gray (72) is light at 0.39.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="55"/>
+        <source>Set to specify amount of edge color tint or shade from the saturation adjusted part color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="68"/>
         <source>High Contrast</source>
         <translation type="unfinished"></translation>
@@ -4527,8 +4545,18 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="179"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Black parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="183"/>
         <source>Select Black Edge Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="191"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Dark parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4589,109 +4617,134 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
 <context>
     <name>lcInstructionsDialog</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="527"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="532"/>
         <source>Instructions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="542"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="547"/>
         <source>Page Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="552"/>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="554"/>
+        <source>Vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="557"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="571"/>
+        <source>Page %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPageListWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="174"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="179"/>
         <source>Pages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="189"/>
+        <source>Page Setup</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPropertiesWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="288"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="293"/>
         <source>Properties</source>
         <translation type="unfinished">Propriedades</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Forward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="296"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="301"/>
         <source>Scope:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="301"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="306"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="351"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="356"/>
         <source>Select Step Number Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="355"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="360"/>
         <source>Select Step Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="359"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="364"/>
         <source>Select Parts List Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="363"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="368"/>
         <source>Select Parts List Border Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="367"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="372"/>
         <source>Select Parts List Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="417"/>
-        <location filename="../common/lc_instructionsdialog.cpp" line="438"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="422"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="443"/>
         <source>Select Step Number Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="421"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="426"/>
         <source>Select Parts List Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="477"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="482"/>
         <source>Step Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="493"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="498"/>
         <source>Step Number Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="508"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="513"/>
         <source>Parts List Properties</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4699,225 +4752,220 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
 <context>
     <name>lcMainWindow</name>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="403"/>
-        <location filename="../common/lc_mainwindow.cpp" line="606"/>
-        <location filename="../common/lc_mainwindow.cpp" line="613"/>
+        <location filename="../common/lc_mainwindow.cpp" line="376"/>
+        <location filename="../common/lc_mainwindow.cpp" line="577"/>
+        <location filename="../common/lc_mainwindow.cpp" line="584"/>
         <source>Transform</source>
         <translation>Transformar</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="410"/>
+        <location filename="../common/lc_mainwindow.cpp" line="383"/>
         <source>C&amp;ameras</source>
         <translation>Câm&amp;aras</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="456"/>
+        <location filename="../common/lc_mainwindow.cpp" line="426"/>
         <source>&amp;File</source>
         <translation>&amp;Ficheiro</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="467"/>
+        <location filename="../common/lc_mainwindow.cpp" line="437"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="488"/>
+        <location filename="../common/lc_mainwindow.cpp" line="458"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="512"/>
+        <location filename="../common/lc_mainwindow.cpp" line="482"/>
         <source>&amp;View</source>
         <translation>&amp;Ver</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="419"/>
+        <location filename="../common/lc_mainwindow.cpp" line="389"/>
         <source>&amp;Viewpoints</source>
         <translation>Ponto de &amp;Vista</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="398"/>
         <source>Projection</source>
         <translation>Projecção</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="521"/>
+        <location filename="../common/lc_mainwindow.cpp" line="491"/>
         <source>Ste&amp;p</source>
         <translation>&amp;Passo</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="506"/>
         <source>T&amp;oolbars</source>
         <translation>&amp;Barras de Ferramentas</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="549"/>
+        <location filename="../common/lc_mainwindow.cpp" line="519"/>
         <source>&amp;Piece</source>
         <translation>&amp;Peça</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="583"/>
+        <location filename="../common/lc_mainwindow.cpp" line="554"/>
         <source>&amp;Help</source>
         <translation>A&amp;juda</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="614"/>
+        <location filename="../common/lc_mainwindow.cpp" line="585"/>
         <source>Transform Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="618"/>
+        <location filename="../common/lc_mainwindow.cpp" line="589"/>
         <source>Snap XY</source>
         <translation>Fixa XY</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="622"/>
+        <location filename="../common/lc_mainwindow.cpp" line="593"/>
         <source>Snap Z</source>
         <translation>Fixa Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="626"/>
+        <location filename="../common/lc_mainwindow.cpp" line="597"/>
         <source>Snap Menu</source>
         <translation>Menu Fixar</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="632"/>
+        <location filename="../common/lc_mainwindow.cpp" line="603"/>
         <source>Movement Snap</source>
         <translation>Fixar Movimentos</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="633"/>
+        <location filename="../common/lc_mainwindow.cpp" line="604"/>
         <source>Snap translations to fixed intervals</source>
         <translation>Fixa translações por intervalos fixos</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="637"/>
+        <location filename="../common/lc_mainwindow.cpp" line="608"/>
         <source>Snap Angle Menu</source>
         <translation>Menu de fixação dos ângulos</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="643"/>
+        <location filename="../common/lc_mainwindow.cpp" line="614"/>
         <source>Rotation Snap</source>
         <translation>Grelha de Rotação</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="644"/>
+        <location filename="../common/lc_mainwindow.cpp" line="615"/>
         <source>Snap rotations to fixed intervals</source>
         <translation>Fixa as rotações por intervalos fixos</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="648"/>
+        <location filename="../common/lc_mainwindow.cpp" line="619"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="437"/>
-        <location filename="../common/lc_mainwindow.cpp" line="674"/>
+        <location filename="../common/lc_mainwindow.cpp" line="407"/>
+        <location filename="../common/lc_mainwindow.cpp" line="645"/>
         <source>Tools</source>
         <translation>Ferramentas</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="172"/>
+        <location filename="../common/lc_mainwindow.cpp" line="145"/>
         <source>New Model</source>
         <translation>Novo Modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="173"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
+        <location filename="../common/lc_mainwindow.cpp" line="146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
         <source>Open Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="174"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2507"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2434"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="432"/>
+        <location filename="../common/lc_mainwindow.cpp" line="402"/>
         <source>Sh&amp;ading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="464"/>
+        <location filename="../common/lc_mainwindow.cpp" line="434"/>
         <source>&amp;Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="575"/>
+        <location filename="../common/lc_mainwindow.cpp" line="546"/>
         <source>Sub&amp;model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="597"/>
-        <location filename="../common/lc_mainwindow.cpp" line="601"/>
+        <location filename="../common/lc_mainwindow.cpp" line="568"/>
+        <location filename="../common/lc_mainwindow.cpp" line="572"/>
         <source>Selection Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="602"/>
+        <location filename="../common/lc_mainwindow.cpp" line="573"/>
         <source>Change selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="666"/>
+        <location filename="../common/lc_mainwindow.cpp" line="637"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="696"/>
+        <location filename="../common/lc_mainwindow.cpp" line="667"/>
         <source>Parts</source>
         <translation>Peças</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="702"/>
+        <location filename="../common/lc_mainwindow.cpp" line="673"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="731"/>
+        <location filename="../common/lc_mainwindow.cpp" line="702"/>
         <source>Properties</source>
         <translation>Propriedades</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="766"/>
+        <location filename="../common/lc_mainwindow.cpp" line="737"/>
         <source>Timeline</source>
         <translation>Linha Temporal</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
-        <source>Part preview for &apos;%1&apos; failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_mainwindow.cpp" line="814"/>
-        <location filename="../common/lc_mainwindow.cpp" line="815"/>
+        <location filename="../common/lc_mainwindow.cpp" line="784"/>
+        <location filename="../common/lc_mainwindow.cpp" line="785"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1031"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1001"/>
         <source>Close Other Tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1113"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1083"/>
         <source>The file &apos;%1&apos; has been modified by another application, do you want to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1119"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1089"/>
         <source>File Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2058"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1985"/>
         <source>%1 (ID: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../common/lc_mainwindow.cpp" line="2064"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1991"/>
         <source>%n Object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4925,17 +4973,17 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
         </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2068"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1995"/>
         <source> - %1 (ID: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2072"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1999"/>
         <source> in group &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2110"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2037"/>
         <source>Step %1</source>
         <translation>Passo %1</translation>
     </message>
@@ -4944,59 +4992,59 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
         <translation type="vanished"> M: %1 %2 R: %3 </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2168"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2095"/>
         <source>&amp;Undo %1</source>
         <translation>&amp;Desfazer %1</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2173"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2100"/>
         <source>&amp;Undo</source>
         <translation>Desfa&amp;zer</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2179"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2106"/>
         <source>&amp;Redo %1</source>
         <translation>&amp;Refazer %1</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2184"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2111"/>
         <source>&amp;Redo</source>
         <translation>&amp;Refazer</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Supported Files (*.lcd *.ldr *.dat *.mpd);;All Files (*.*)</source>
         <translation>Ficheiros Aceites (*.lcd *.ldr *.dat *.mpd);;Todos os Ficheiros (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Merge Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
         <source>Merged 1 submodel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>Merged %1 submodels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>LEGO Diginal Designer Files (*.lxf);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>LeoCAD</source>
         <translation></translation>
     </message>
@@ -5005,126 +5053,125 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
         <translation type="vanished">Erro ao carregar &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.mpd);;All Files (*.*)</source>
         <translation>Ficheiros Aceites (*.mpd);;Todos os Ficheiros (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.ldr *.dat *.mpd);;All Files (*.*)</source>
         <translation>Ficheiros Aceites (*.ldr *.dat *.mpd);;Todos os Ficheiros (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Rel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Abs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2074"/>
         <source> M: %1 %2 R: %3 %4 </source>
         <translation type="unfinished"> M: %1 %2 R: %3  {1 %2 ?} {3 %4 ?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Saving files in LCD format is no longer supported, please use the LDR or MPD formats instead.</source>
         <translation>O formato LCD já não é aceite para gravar, escolha os formatos LDR ou MPD.</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save changes to &apos;%1&apos;?</source>
         <translation>Gravar as modificações de &apos;%1&apos;?</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>0</source>
         <translation>8x {0?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/20S</source>
         <translation>8x {1/20S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/4S</source>
         <translation>8x {1/4S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1F</source>
         <translation>8x {1F?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/2S</source>
         <translation>8x {1/2S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1S</source>
         <translation>8x {1S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>2S</source>
         <translation>8x {2S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>3S</source>
         <translation>8x {3S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>4S</source>
         <translation>8x {4S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>8S</source>
         <translation>8x {8S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="152"/>
-        <location filename="../common/lc_mainwindow.h" line="158"/>
-        <location filename="../common/lc_mainwindow.h" line="163"/>
+        <location filename="../common/lc_mainwindow.h" line="131"/>
+        <location filename="../common/lc_mainwindow.h" line="137"/>
+        <location filename="../common/lc_mainwindow.h" line="142"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1B</source>
         <translation>8x {1B?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>2B</source>
         <translation>8x {2B?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>4B</source>
         <translation>8x {4B?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>8B</source>
         <translation>8x {8B?}</translation>
     </message>
@@ -5236,63 +5283,63 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
 <context>
     <name>lcModel</name>
     <message>
-        <location filename="../common/lc_model.cpp" line="1146"/>
+        <location filename="../common/lc_model.cpp" line="1143"/>
         <source>Pasting</source>
         <translation>Colando</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="2531"/>
-        <location filename="../common/lc_model.cpp" line="4307"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>LeoCAD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
         <source>Error creating images.</source>
         <translation>Erro ao criar as imagens.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1765"/>
+        <location filename="../common/lc_model.cpp" line="1768"/>
         <source>Inserting Step</source>
         <translation>Inserir Passo</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1784"/>
+        <location filename="../common/lc_model.cpp" line="1787"/>
         <source>Removing Step</source>
         <translation>Remover Passo</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
         <source>No pieces selected.</source>
         <translation>Nenhuma peça seleccionada.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="957"/>
-        <location filename="../common/lc_model.cpp" line="1831"/>
+        <location filename="../common/lc_model.cpp" line="954"/>
+        <location filename="../common/lc_model.cpp" line="1834"/>
         <source>Group #</source>
         <translation>Grupo #</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1850"/>
-        <location filename="../common/lc_model.cpp" line="1916"/>
+        <location filename="../common/lc_model.cpp" line="1853"/>
+        <location filename="../common/lc_model.cpp" line="1919"/>
         <source>Grouping</source>
         <translation>Agrupar</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1886"/>
-        <location filename="../common/lc_model.cpp" line="1931"/>
+        <location filename="../common/lc_model.cpp" line="1889"/>
+        <location filename="../common/lc_model.cpp" line="1934"/>
         <source>Ungrouping</source>
         <translation>Desagrupar</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1977"/>
+        <location filename="../common/lc_model.cpp" line="1980"/>
         <source>Editing Groups</source>
         <translation>Editar Grupos</translation>
     </message>
@@ -5312,127 +5359,127 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
         <translation>Definir a Peça</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4239"/>
+        <location filename="../common/lc_model.cpp" line="4257"/>
         <source>Moving Camera</source>
         <translation>Mover a Câmara</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3939"/>
+        <location filename="../common/lc_model.cpp" line="3957"/>
         <source>New SpotLight</source>
         <translation>Novo Projector</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3944"/>
+        <location filename="../common/lc_model.cpp" line="3962"/>
         <source>New Camera</source>
         <translation>Nova Câmara</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3951"/>
+        <location filename="../common/lc_model.cpp" line="3969"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3955"/>
+        <location filename="../common/lc_model.cpp" line="3973"/>
         <source>Rotate</source>
         <translation>Rodar</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3965"/>
-        <location filename="../common/lc_model.cpp" line="4206"/>
-        <location filename="../common/lc_model.cpp" line="4266"/>
-        <location filename="../common/lc_model.cpp" line="4278"/>
+        <location filename="../common/lc_model.cpp" line="3983"/>
+        <location filename="../common/lc_model.cpp" line="4224"/>
+        <location filename="../common/lc_model.cpp" line="4284"/>
+        <location filename="../common/lc_model.cpp" line="4296"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3970"/>
+        <location filename="../common/lc_model.cpp" line="3988"/>
         <source>Pan</source>
         <translation>Movimento Horizontal</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3975"/>
+        <location filename="../common/lc_model.cpp" line="3993"/>
         <source>Orbit</source>
         <translation>Órbitar</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3980"/>
+        <location filename="../common/lc_model.cpp" line="3998"/>
         <source>Roll</source>
         <translation>Inclinar</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4002"/>
+        <location filename="../common/lc_model.cpp" line="4020"/>
         <source>Insert</source>
         <translation>Inserir</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4012"/>
+        <location filename="../common/lc_model.cpp" line="4030"/>
         <source>New Light</source>
         <translation>Nova Luz</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2229"/>
-        <location filename="../common/lc_model.cpp" line="4131"/>
+        <location filename="../common/lc_model.cpp" line="2232"/>
+        <location filename="../common/lc_model.cpp" line="4149"/>
         <source>Deleting</source>
         <translation>Apagando</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1100"/>
+        <location filename="../common/lc_model.cpp" line="1097"/>
         <source>Cutting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1219"/>
+        <location filename="../common/lc_model.cpp" line="1216"/>
         <source>Duplicating Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation>Erro ao escrever no ficheiro &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2176"/>
+        <location filename="../common/lc_model.cpp" line="2179"/>
         <source>Adding Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2218"/>
+        <location filename="../common/lc_model.cpp" line="2221"/>
         <source>Resetting Cameras</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2258"/>
+        <location filename="../common/lc_model.cpp" line="2261"/>
         <source>Removing Key Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2275"/>
-        <location filename="../common/lc_model.cpp" line="2292"/>
-        <location filename="../common/lc_model.cpp" line="2334"/>
-        <location filename="../common/lc_model.cpp" line="2379"/>
-        <location filename="../common/lc_model.cpp" line="2414"/>
+        <location filename="../common/lc_model.cpp" line="2278"/>
+        <location filename="../common/lc_model.cpp" line="2295"/>
+        <location filename="../common/lc_model.cpp" line="2337"/>
+        <location filename="../common/lc_model.cpp" line="2382"/>
+        <location filename="../common/lc_model.cpp" line="2417"/>
         <source>Modifying</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2482"/>
+        <location filename="../common/lc_model.cpp" line="2485"/>
         <source>New Model</source>
         <translation>Novo Modelo</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2531"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
         <source>No models selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2535"/>
+        <location filename="../common/lc_model.cpp" line="2538"/>
         <source>Inlining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5443,7 +5490,7 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2844"/>
-        <location filename="../common/lc_model.cpp" line="4145"/>
+        <location filename="../common/lc_model.cpp" line="4163"/>
         <source>Painting</source>
         <translation>Pintado</translation>
     </message>
@@ -5475,54 +5522,54 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3723"/>
-        <location filename="../common/lc_model.cpp" line="3746"/>
+        <location filename="../common/lc_model.cpp" line="3741"/>
+        <location filename="../common/lc_model.cpp" line="3764"/>
         <source>Hide</source>
         <translation type="unfinished">Esconder</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3769"/>
-        <location filename="../common/lc_model.cpp" line="3792"/>
+        <location filename="../common/lc_model.cpp" line="3787"/>
+        <location filename="../common/lc_model.cpp" line="3810"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3834"/>
+        <location filename="../common/lc_model.cpp" line="3852"/>
         <source>Replacing Part</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4229"/>
+        <location filename="../common/lc_model.cpp" line="4247"/>
         <source>Look At</source>
         <translation>Olhar Para</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4300"/>
+        <location filename="../common/lc_model.cpp" line="4319"/>
         <source>Changing Properties</source>
         <translation>Mudando Propriedades</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4307"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
         <source>Nothing to select.</source>
         <translation>Nada a selccionar.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>Array only has 1 element or less, no pieces added.</source>
         <translation>O quadro só tem um elemento ou menos, nenhuma peça foi adicionada.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4390"/>
+        <location filename="../common/lc_model.cpp" line="4409"/>
         <source>Array</source>
         <translation>Quadro</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4402"/>
+        <location filename="../common/lc_model.cpp" line="4421"/>
         <source>Minifig #</source>
         <translation>Mnifig #</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4424"/>
+        <location filename="../common/lc_model.cpp" line="4443"/>
         <source>Minifig</source>
         <translation>Mini-figura</translation>
     </message>
@@ -5652,17 +5699,17 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
 <context>
     <name>lcPartSelectionListView</name>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="524"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="551"/>
         <source>Add to Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="535"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="562"/>
         <source>None</source>
         <translation type="unfinished">Nenhum</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="539"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="566"/>
         <source>Remove from Palette</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5670,82 +5717,87 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
 <context>
     <name>lcPartSelectionWidget</name>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="719"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="746"/>
         <source>Search Parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="726"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="753"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="884"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="902"/>
+        <source>Edit Palettes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_partselectionwidget.cpp" line="911"/>
         <source>No Icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="889"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="916"/>
         <source>Small Icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="894"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="921"/>
         <source>Medium Icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="899"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="926"/>
         <source>Large Icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="904"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="931"/>
         <source>Extra Large Icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="914"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="941"/>
         <source>Show Part Names</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="919"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="946"/>
         <source>Show Decorated Parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="923"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="950"/>
         <source>Show Part Aliases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="929"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="956"/>
         <source>List Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="933"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="960"/>
         <source>Lock Preview Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="975"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1002"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1091"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1118"/>
         <source>All Parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1097"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1124"/>
         <source>In Use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1103"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1130"/>
         <source>Submodels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5753,12 +5805,12 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
 <context>
     <name>lcPiecesLibrary</name>
     <message>
-        <location filename="../common/lc_library.cpp" line="775"/>
+        <location filename="../common/lc_library.cpp" line="782"/>
         <source>Initializing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_library.cpp" line="776"/>
+        <location filename="../common/lc_library.cpp" line="783"/>
         <source>Loading Parts Library</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5767,6 +5819,7 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
     <name>lcPreviewDockWidget</name>
     <message>
         <location filename="../common/lc_previewwidget.cpp" line="19"/>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
         <source>Lock Preview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5791,23 +5844,18 @@ Veja https://www.leocad.org para saber como descarragar e instalar uma bibliotec
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Unlock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Lock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../common/lc_previewwidget.cpp" line="78"/>
-        <source>%1 the preview display to %2 updates</source>
+        <source>Unlock the preview display to enable updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="80"/>
-        <source>%1 Preview</source>
+        <location filename="../common/lc_previewwidget.cpp" line="79"/>
+        <source>Lock the preview display to disable updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
+        <source>Unlock Preview</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6447,7 +6495,7 @@ Anisotropic: %5
         <translation type="vanished">Biblioteca de peças personalizada:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1672"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1941"/>
         <source>Mouse sensitivity:</source>
         <translation>Sensibilidade do rato :</translation>
     </message>
@@ -6492,9 +6540,8 @@ Anisotropic: %5
         <translation>Restituir</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="359"/>
         <source>Edge lines</source>
-        <translation>Contornos</translation>
+        <translation type="vanished">Contornos</translation>
     </message>
     <message>
         <source>Axis icon</source>
@@ -6505,112 +6552,113 @@ Anisotropic: %5
         <translation type="vanished">largura</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="436"/>
         <source>Anti-aliasing</source>
         <translation>Suavização</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="439"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
         <source>2x</source>
         <translation>2x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
         <source>4x</source>
         <translation>4x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="454"/>
         <source>8x</source>
         <translation>8x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="409"/>
         <source>Shading Mode:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="546"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="347"/>
         <source>Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="551"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="352"/>
         <source>Flat Shading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="357"/>
         <source>Default Lights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="678"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="745"/>
         <source>Base Grid</source>
         <translation>Grelha de Base</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="728"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="795"/>
         <source>Draw studs</source>
         <translation>Desenhar pregos</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="751"/>
         <source>studs</source>
         <translation>pregos</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="704"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="771"/>
         <source>Draw lines every</source>
         <translation>Desenhar linhas cada</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1111"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1052"/>
         <source>View Sphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="615"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="783"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="850"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="620"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="656"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="855"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="625"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="793"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="661"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="860"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="630"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="798"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="666"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="865"/>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1145"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1118"/>
         <source>Highlight Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1117"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1058"/>
         <source>Color:</source>
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1131"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1088"/>
         <source>Text Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="600"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="775"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="636"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="711"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="842"/>
         <source>Location:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6705,444 +6753,507 @@ Anisotropic: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="429"/>
         <source>Stud Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="394"/>
-        <source>Fade previous steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="476"/>
         <source>Mesh LOD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="431"/>
         <source>Highlight new parts</source>
-        <translation type="unfinished">Destacar as novas peças</translation>
+        <translation type="obsolete">Destacar as novas peças</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="465"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="366"/>
         <source>Plain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="470"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="371"/>
         <source>Thin Lines Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="475"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="376"/>
         <source>Outline Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="381"/>
         <source>Sharp Top Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="386"/>
         <source>Rounded Top Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="490"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="391"/>
         <source>Flattened Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="495"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="396"/>
         <source>High Contrast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="500"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
         <source>High Contrast with Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="524"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
         <source>Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="531"/>
-        <source>Automate edge color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="538"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
         <source>Contrast Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="581"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="617"/>
         <source>Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="587"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="623"/>
         <source>Model Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="744"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="629"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="811"/>
         <source>Axis Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="607"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="806"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="643"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="873"/>
         <source>View Sphere:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="639"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="752"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="675"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="819"/>
         <source>Top Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="644"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="757"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="680"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="724"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="824"/>
         <source>Top Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="649"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="762"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="685"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="729"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="829"/>
         <source>Bottom Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="654"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="767"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="690"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="734"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="834"/>
         <source>Bottom Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="721"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
         <source>Draw origin lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="805"/>
         <source>Part Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="843"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="910"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="849"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1227"/>
         <source>Background</source>
         <translation type="unfinished">Fundo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="857"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1235"/>
         <source>Top Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="871"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1265"/>
         <source>Bottom Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="900"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
         <source>So&amp;lid Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="907"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1301"/>
         <source>&amp;Gradient</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="941"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="916"/>
         <source>Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="947"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="936"/>
         <source>Inactive View Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="961"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="978"/>
         <source>Overlay Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="968"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1026"/>
         <source>Active View Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="989"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="950"/>
         <source>Camera Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1016"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="985"/>
         <source>Axis Icon Labels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1030"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="922"/>
         <source>Marquee Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1044"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="469"/>
+        <source>Highlight New Parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="506"/>
+        <source>Fade Previous Steps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="523"/>
+        <source>Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="536"/>
+        <source>Conditional Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <source>Line Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="579"/>
+        <source>Edge Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="586"/>
+        <source>Automate Edge Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="964"/>
         <source>Marquee Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1061"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1161"/>
         <source>Grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1067"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1167"/>
         <source>Lines:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1197"/>
         <source>Studs:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1189"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1230"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1335"/>
+        <source>Objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1341"/>
+        <source>Light:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1371"/>
+        <source>Focused:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1385"/>
+        <source>Control Point Focused:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1420"/>
+        <source>Control Point:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1427"/>
+        <source>Selected:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1434"/>
+        <source>Camera:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1458"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1499"/>
         <source>Categories</source>
         <translation>Categorias</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1195"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1464"/>
         <source>Parts Library Categories</source>
         <translation>Categorias de Peças na Biblioteca</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1264"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1533"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1538"/>
         <source>Number</source>
         <translation>Número</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1280"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1408"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1541"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1549"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1677"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1810"/>
         <source>Import...</source>
         <translation>Importar....</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1287"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1415"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1548"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1817"/>
         <source>Export...</source>
         <translation>Exportar...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1422"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1555"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1563"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1691"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1824"/>
         <source>Reset...</source>
         <translation>Reiniciar...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1319"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1588"/>
         <source>Category</source>
         <translation>Categoria</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1325"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1594"/>
         <source>New...</source>
         <translation>Novo...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1332"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1601"/>
         <source>Edit...</source>
         <translation>Editar...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1608"/>
         <source>Delete...</source>
         <translation>Apagar...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1363"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1632"/>
         <source>Keyboard</source>
         <translation>Teclado</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1642"/>
         <source>Keyboard Shortcuts</source>
         <translation>Atalhos de Teclado</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1386"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1655"/>
         <source>Command</source>
         <translation>Commando</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1391"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1450"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1584"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1660"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1853"/>
         <source>Shortcut</source>
         <translation>Atalho</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1399"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1668"/>
         <source>Search shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1456"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1725"/>
         <source>Key se&amp;quence:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1498"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1767"/>
         <source>Mouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1506"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1775"/>
         <source>Mouse Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1521"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1790"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1526"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1795"/>
         <source>Shortcut 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1531"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1800"/>
         <source>Shortcut 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1592"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1861"/>
         <source>Button:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1600"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1869"/>
         <source>None</source>
         <translation type="unfinished">Nenhum</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1605"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1874"/>
         <source>Left</source>
         <translation type="unfinished">Left</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1610"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1879"/>
         <source>Middle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1615"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1884"/>
         <source>Right</source>
         <translation type="unfinished">Right</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1623"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1892"/>
         <source>Modifiers:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1630"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1899"/>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1637"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1906"/>
         <source>Alt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1644"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1913"/>
         <source>Shift</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1469"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1920"/>
         <source>Assign</source>
         <translation>Definir</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1476"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1658"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1745"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1927"/>
         <source>Remove</source>
         <translation>Remover</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="242"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="263"/>
         <source>Grid spacing must be greater than 0.</source>
         <translation>O espaço de grelha deve ser superior a 0.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="331"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="354"/>
         <source>Select Parts Library Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Supported Archives (*.zip *.bin);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Select Parts Library Archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Select Color Configuration File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Settings Files (*.ldr);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Select Minifig Settings File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Settings Files (*.ini);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="364"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
         <source>Executable Files (*.exe);;All Files (*.*)</source>
         <translation>Ficheiros Executaveis(*.exe);;Todos os Ficheiros (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="366"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="389"/>
         <source>All Files (*.*)</source>
         <translation>Todos os Ficheiros (*.*)</translation>
     </message>
@@ -7151,235 +7262,265 @@ Anisotropic: %5
         <translation type="vanished">Escolher o programa POV-Ray</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="377"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="400"/>
         <source>Open LGEO Folder</source>
         <translation>Escolher a Pasta LGEO</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Reset Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Would you like to also reset the interface colors to match the color theme?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="424"/>
         <source>Select Background Color</source>
         <translation type="unfinished">Seleccionar a Cor do Fundo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="406"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="429"/>
         <source>Select Gradient Top Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="411"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="434"/>
         <source>Select Gradient Bottom Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="416"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="439"/>
         <source>Select Axes Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="421"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="444"/>
         <source>Select Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="426"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="449"/>
         <source>Select Marquee Border Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="431"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="454"/>
         <source>Select Marquee Fill Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="437"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="460"/>
         <source>Select Overlay Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="442"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="465"/>
         <source>Select Active View Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="447"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="470"/>
         <source>Select Inactive View Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="452"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="475"/>
         <source>Select Fade Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="458"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="481"/>
         <source>Select Highlight Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="464"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="487"/>
         <source>Select Grid Stud Color</source>
         <translation>Cor dos Pregos na Grelha</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="470"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="493"/>
         <source>Select Grid Line Color</source>
         <translation>Cor das Linhas na Grelha</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="475"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="498"/>
         <source>Select View Sphere Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="503"/>
         <source>Select View Sphere Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="508"/>
         <source>Select View Sphere Highlight Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="596"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="513"/>
+        <source>Select Object Selected Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="518"/>
+        <source>Select Object Focused Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="523"/>
+        <source>Select Camera Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="528"/>
+        <source>Select Light Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="533"/>
+        <source>Select Control Point Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="539"/>
+        <source>Select Control Point Focused Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="661"/>
         <source>Unassigned</source>
         <translation>Por Definir</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="710"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="775"/>
         <source>Are you sure you want to delete the category &apos;%1&apos;?</source>
         <translation>Confirmar querer apagar a categoria &apos;%1&apos;?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
         <source>Import Categories</source>
         <translation>Importar Categorias</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Text Files (*.txt);;All Files (*.*)</source>
         <translation>Ficheiros Texto (*.txt);;Todos os Ficheiros (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="731"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="796"/>
         <source>Error loading categories file.</source>
         <translation>Erro ao carregar o ficheiro de categorias.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
         <source>Export Categories</source>
         <translation>Exportar Categorias</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="749"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="814"/>
         <source>Error saving categories file.</source>
         <translation>Erro ao gravar o ficheiro de categorias.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="756"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="821"/>
         <source>Are you sure you want to load the default categories?</source>
         <translation>Confirmar querer carregar as categorias por omissão?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="957"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1022"/>
         <source>The shortcut &apos;%1&apos; is already assigned to &apos;%2&apos;. Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
         <source>Import shortcuts</source>
         <translation>Importar Atalhos de Teclado</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1020"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1085"/>
         <source>Error loading keyboard shortcuts file.</source>
         <translation>Erro ao carregar o ficheiro de atalhos de teclado.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
         <source>Export shortcuts</source>
         <translation>Exportar Atalhos de Teclado</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1039"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1104"/>
         <source>Error saving keyboard shortcuts file.</source>
         <translation>Erro ao gravar o ficheiro de atalhos de teclado.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1046"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1111"/>
         <source>Are you sure you want to load the default keyboard shortcuts?</source>
         <translation>Confirmar querer carregar os atalhos de teclado por omissão?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1073"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1138"/>
         <source>Left Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1142"/>
         <source>Middle Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1146"/>
         <source>Right Button</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="959"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1024"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>Override Shortcut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="369"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="392"/>
         <source>Select POV-Ray Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>This shortcut is already assigned to &apos;%1&apos;, do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
         <source>Import Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1212"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1277"/>
         <source>Error loading mouse shortcuts file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Export Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1231"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1296"/>
         <source>Error saving mouse shortcuts file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1236"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1301"/>
         <source>Are you sure you want to load the default mouse shortcuts?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7412,6 +7553,11 @@ Anisotropic: %5
         <translation>Comentários:</translation>
     </message>
     <message>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="76"/>
+        <source>Measurements:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scene</source>
         <translation type="vanished">Cena</translation>
     </message>
@@ -7432,7 +7578,7 @@ Anisotropic: %5
         <translation type="vanished">Definir por omissão para os novos projectos</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.ui" line="77"/>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="91"/>
         <source>Parts Used</source>
         <translation>Peças Utilizadas</translation>
     </message>
@@ -7442,13 +7588,20 @@ Anisotropic: %5
         <translation>Propriedades %1</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="62"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="51"/>
+        <source>%1 x %2 x %3 cm
+%4 x %5 x %6 inches
+%7 x %8 x %9 LDU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="70"/>
         <source>Part</source>
         <translation>Peça</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="73"/>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="110"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="81"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="118"/>
         <source>Total</source>
         <translation>Total</translation>
     </message>
@@ -7486,40 +7639,40 @@ Anisotropic: %5
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="886"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1018"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="895"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1027"/>
         <source>Position</source>
         <translation>Posição</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="887"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="892"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1019"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1024"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="888"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="893"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1020"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1025"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1039"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="889"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="894"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1021"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1026"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1031"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="903"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1040"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="891"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
         <source>Rotation</source>
         <translation>Rotação</translation>
     </message>
@@ -7528,73 +7681,73 @@ Anisotropic: %5
         <translation type="vanished">Visibilidade</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="905"/>
         <source>Visible Steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="906"/>
         <source>Show</source>
         <translation>Mostrar</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="907"/>
         <source>Hide</source>
         <translation>Esconder</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="909"/>
         <source>Appearance</source>
         <translation>Estilo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="910"/>
         <source>Color</source>
         <translation>Cor</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="911"/>
         <source>Part</source>
         <translation>Peça</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1023"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1032"/>
         <source>Target</source>
         <translation>Objectivo</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1042"/>
         <source>Up</source>
         <translation>Subir</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1043"/>
         <source>Orthographic</source>
         <translation>Ortográfico</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1044"/>
         <source>FOV</source>
         <translation>FOV</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1036"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1045"/>
         <source>Near</source>
         <translation>Perto</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1046"/>
         <source>Far</source>
         <translation>Longe</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1047"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1118"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1127"/>
         <source>Multiple Objects Selected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7886,22 +8039,22 @@ Anisotropic: %5
 <context>
     <name>lcView</name>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>LeoCAD</source>
         <translation type="unfinished">LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>Error creating images.</source>
         <translation type="unfinished">Erro ao criar as imagens.</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation type="unfinished">Erro ao escrever no ficheiro &apos;%1&apos;:

--- a/resources/leocad_uk.ts
+++ b/resources/leocad_uk.ts
@@ -700,586 +700,581 @@
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="981"/>
-        <source>View.Cameras.Reset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="988"/>
         <source>View.Time.First</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="995"/>
+        <location filename="../common/lc_commands.cpp" line="988"/>
         <source>View.Time.Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1002"/>
+        <location filename="../common/lc_commands.cpp" line="995"/>
         <source>View.Time.Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1009"/>
+        <location filename="../common/lc_commands.cpp" line="1002"/>
         <source>View.Time.Last</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1016"/>
+        <location filename="../common/lc_commands.cpp" line="1009"/>
         <source>View.Time.InsertBefore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1023"/>
+        <location filename="../common/lc_commands.cpp" line="1016"/>
         <source>View.Time.InsertAfter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1030"/>
+        <location filename="../common/lc_commands.cpp" line="1023"/>
         <source>View.Time.Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1037"/>
+        <location filename="../common/lc_commands.cpp" line="1030"/>
         <source>View.Time.AddKeys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1044"/>
+        <location filename="../common/lc_commands.cpp" line="1037"/>
         <source>View.SplitHorizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1051"/>
+        <location filename="../common/lc_commands.cpp" line="1044"/>
         <source>View.SplitVertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1058"/>
+        <location filename="../common/lc_commands.cpp" line="1051"/>
         <source>View.RemoveView</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1065"/>
+        <location filename="../common/lc_commands.cpp" line="1058"/>
         <source>View.ResetViews</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1072"/>
+        <location filename="../common/lc_commands.cpp" line="1065"/>
         <source>View.Toolbars.Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1079"/>
+        <location filename="../common/lc_commands.cpp" line="1072"/>
         <source>View.Toolbars.Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1086"/>
+        <location filename="../common/lc_commands.cpp" line="1079"/>
         <source>View.Toolbars.Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1093"/>
+        <location filename="../common/lc_commands.cpp" line="1086"/>
         <source>View.Toolbars.Parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1100"/>
+        <location filename="../common/lc_commands.cpp" line="1093"/>
         <source>View.Toolbars.Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1107"/>
+        <location filename="../common/lc_commands.cpp" line="1100"/>
         <source>View.Toolbars.Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1114"/>
+        <location filename="../common/lc_commands.cpp" line="1107"/>
         <source>View.Toolbars.Timeline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1121"/>
+        <location filename="../common/lc_commands.cpp" line="1114"/>
         <source>View.Toolbars.Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1128"/>
+        <location filename="../common/lc_commands.cpp" line="1121"/>
         <source>View.FullScreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1135"/>
+        <location filename="../common/lc_commands.cpp" line="1128"/>
         <source>View.CloseCurrentTab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1142"/>
+        <location filename="../common/lc_commands.cpp" line="1135"/>
         <source>View.Shade.Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1149"/>
+        <location filename="../common/lc_commands.cpp" line="1142"/>
         <source>View.Shade.Flat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1156"/>
+        <location filename="../common/lc_commands.cpp" line="1149"/>
         <source>View.Shade.DefaultLights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1163"/>
+        <location filename="../common/lc_commands.cpp" line="1156"/>
         <source>View.Projection.Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1170"/>
+        <location filename="../common/lc_commands.cpp" line="1163"/>
         <source>View.Projection.Orthographic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1177"/>
+        <location filename="../common/lc_commands.cpp" line="1170"/>
         <source>View.ToggleViewSphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1184"/>
+        <location filename="../common/lc_commands.cpp" line="1177"/>
         <source>View.ToggleAxisIcon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1191"/>
+        <location filename="../common/lc_commands.cpp" line="1184"/>
         <source>View.ToggleGrid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1198"/>
+        <location filename="../common/lc_commands.cpp" line="1191"/>
         <source>View.FadePreviousSteps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1205"/>
+        <location filename="../common/lc_commands.cpp" line="1198"/>
         <source>Piece.Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1212"/>
+        <location filename="../common/lc_commands.cpp" line="1205"/>
         <source>Piece.Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1219"/>
+        <location filename="../common/lc_commands.cpp" line="1212"/>
         <source>Piece.Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1226"/>
+        <location filename="../common/lc_commands.cpp" line="1219"/>
         <source>Piece.PaintSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1233"/>
+        <location filename="../common/lc_commands.cpp" line="1226"/>
         <source>Piece.ResetPivotPoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1240"/>
+        <location filename="../common/lc_commands.cpp" line="1233"/>
         <source>Piece.RemoveKeyFrames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1247"/>
+        <location filename="../common/lc_commands.cpp" line="1240"/>
         <source>Piece.ControlPoint.Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1254"/>
+        <location filename="../common/lc_commands.cpp" line="1247"/>
         <source>Piece.ControlPoint.Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1261"/>
+        <location filename="../common/lc_commands.cpp" line="1254"/>
         <source>Piece.Move.PlusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1268"/>
+        <location filename="../common/lc_commands.cpp" line="1261"/>
         <source>Piece.Move.MinusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1275"/>
+        <location filename="../common/lc_commands.cpp" line="1268"/>
         <source>Piece.Move.PlusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1282"/>
+        <location filename="../common/lc_commands.cpp" line="1275"/>
         <source>Piece.Move.MinusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1289"/>
+        <location filename="../common/lc_commands.cpp" line="1282"/>
         <source>Piece.Move.PlusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1296"/>
+        <location filename="../common/lc_commands.cpp" line="1289"/>
         <source>Piece.Move.MinusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1303"/>
+        <location filename="../common/lc_commands.cpp" line="1296"/>
         <source>Piece.Rotate.PlusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1310"/>
+        <location filename="../common/lc_commands.cpp" line="1303"/>
         <source>Piece.Rotate.MinusX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1317"/>
+        <location filename="../common/lc_commands.cpp" line="1310"/>
         <source>Piece.Rotate.PlusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1324"/>
+        <location filename="../common/lc_commands.cpp" line="1317"/>
         <source>Piece.Rotate.MinusY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1331"/>
+        <location filename="../common/lc_commands.cpp" line="1324"/>
         <source>Piece.Rotate.PlusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1338"/>
+        <location filename="../common/lc_commands.cpp" line="1331"/>
         <source>Piece.Rotate.MinusZ</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1345"/>
+        <location filename="../common/lc_commands.cpp" line="1338"/>
         <source>Piece.MinifigWizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1352"/>
+        <location filename="../common/lc_commands.cpp" line="1345"/>
         <source>Piece.Array</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1359"/>
+        <location filename="../common/lc_commands.cpp" line="1352"/>
         <source>Piece.ViewSelectedModel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1366"/>
+        <location filename="../common/lc_commands.cpp" line="1359"/>
         <source>Piece.MoveSelectionToModel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1373"/>
+        <location filename="../common/lc_commands.cpp" line="1366"/>
         <source>Piece.InlineSelectedModels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1380"/>
+        <location filename="../common/lc_commands.cpp" line="1373"/>
         <source>Piece.EditSelectedSubmodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1387"/>
+        <location filename="../common/lc_commands.cpp" line="1380"/>
         <source>Piece.EditEndSubmodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1394"/>
+        <location filename="../common/lc_commands.cpp" line="1387"/>
         <source>Piece.Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1401"/>
+        <location filename="../common/lc_commands.cpp" line="1394"/>
         <source>Piece.Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1408"/>
+        <location filename="../common/lc_commands.cpp" line="1401"/>
         <source>Piece.GroupAdd</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1415"/>
+        <location filename="../common/lc_commands.cpp" line="1408"/>
         <source>Piece.GroupRemove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1422"/>
+        <location filename="../common/lc_commands.cpp" line="1415"/>
         <source>Piece.GroupEdit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1429"/>
+        <location filename="../common/lc_commands.cpp" line="1422"/>
         <source>Piece.HideSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1436"/>
+        <location filename="../common/lc_commands.cpp" line="1429"/>
         <source>Piece.HideUnselected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1443"/>
+        <location filename="../common/lc_commands.cpp" line="1436"/>
         <source>Piece.UnhideSelected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1450"/>
+        <location filename="../common/lc_commands.cpp" line="1443"/>
         <source>Piece.UnhideAll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1457"/>
+        <location filename="../common/lc_commands.cpp" line="1450"/>
         <source>Piece.ShowEarlier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1464"/>
+        <location filename="../common/lc_commands.cpp" line="1457"/>
         <source>Piece.ShowLater</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1471"/>
+        <location filename="../common/lc_commands.cpp" line="1464"/>
         <source>Model.New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1478"/>
+        <location filename="../common/lc_commands.cpp" line="1471"/>
         <source>Model.Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1485"/>
+        <location filename="../common/lc_commands.cpp" line="1478"/>
         <source>Model.List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1492"/>
+        <location filename="../common/lc_commands.cpp" line="1485"/>
         <source>Model.Model01</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1499"/>
+        <location filename="../common/lc_commands.cpp" line="1492"/>
         <source>Model.Model02</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1506"/>
+        <location filename="../common/lc_commands.cpp" line="1499"/>
         <source>Model.Model03</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1513"/>
+        <location filename="../common/lc_commands.cpp" line="1506"/>
         <source>Model.Model04</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1520"/>
+        <location filename="../common/lc_commands.cpp" line="1513"/>
         <source>Model.Model05</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1527"/>
+        <location filename="../common/lc_commands.cpp" line="1520"/>
         <source>Model.Model06</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1534"/>
+        <location filename="../common/lc_commands.cpp" line="1527"/>
         <source>Model.Model07</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1541"/>
+        <location filename="../common/lc_commands.cpp" line="1534"/>
         <source>Model.Model08</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1548"/>
+        <location filename="../common/lc_commands.cpp" line="1541"/>
         <source>Model.Model09</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1555"/>
+        <location filename="../common/lc_commands.cpp" line="1548"/>
         <source>Model.Model10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1562"/>
+        <location filename="../common/lc_commands.cpp" line="1555"/>
         <source>Model.Model11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1569"/>
+        <location filename="../common/lc_commands.cpp" line="1562"/>
         <source>Model.Model12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1576"/>
+        <location filename="../common/lc_commands.cpp" line="1569"/>
         <source>Model.Model13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1583"/>
+        <location filename="../common/lc_commands.cpp" line="1576"/>
         <source>Model.Model14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1590"/>
+        <location filename="../common/lc_commands.cpp" line="1583"/>
         <source>Model.Model15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1597"/>
+        <location filename="../common/lc_commands.cpp" line="1590"/>
         <source>Model.Model16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1604"/>
+        <location filename="../common/lc_commands.cpp" line="1597"/>
         <source>Model.Model17</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1611"/>
+        <location filename="../common/lc_commands.cpp" line="1604"/>
         <source>Model.Model18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1618"/>
+        <location filename="../common/lc_commands.cpp" line="1611"/>
         <source>Model.Model19</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1625"/>
+        <location filename="../common/lc_commands.cpp" line="1618"/>
         <source>Model.Model20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1632"/>
+        <location filename="../common/lc_commands.cpp" line="1625"/>
         <source>Model.Model21</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1639"/>
+        <location filename="../common/lc_commands.cpp" line="1632"/>
         <source>Model.Model22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1646"/>
+        <location filename="../common/lc_commands.cpp" line="1639"/>
         <source>Model.Model23</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1653"/>
+        <location filename="../common/lc_commands.cpp" line="1646"/>
         <source>Model.Model24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1660"/>
+        <location filename="../common/lc_commands.cpp" line="1653"/>
         <source>Model.Model25</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1667"/>
+        <location filename="../common/lc_commands.cpp" line="1660"/>
         <source>Model.Model26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1674"/>
+        <location filename="../common/lc_commands.cpp" line="1667"/>
         <source>Model.Model27</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1681"/>
+        <location filename="../common/lc_commands.cpp" line="1674"/>
         <source>Model.Model28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1688"/>
+        <location filename="../common/lc_commands.cpp" line="1681"/>
         <source>Model.Model29</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1695"/>
+        <location filename="../common/lc_commands.cpp" line="1688"/>
         <source>Model.Model30</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1702"/>
+        <location filename="../common/lc_commands.cpp" line="1695"/>
         <source>Model.Model31</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1709"/>
+        <location filename="../common/lc_commands.cpp" line="1702"/>
         <source>Model.Model32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1716"/>
+        <location filename="../common/lc_commands.cpp" line="1709"/>
         <source>Model.Model33</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1723"/>
+        <location filename="../common/lc_commands.cpp" line="1716"/>
         <source>Model.Model34</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1730"/>
+        <location filename="../common/lc_commands.cpp" line="1723"/>
         <source>Model.Model35</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1737"/>
+        <location filename="../common/lc_commands.cpp" line="1730"/>
         <source>Model.Model36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1744"/>
+        <location filename="../common/lc_commands.cpp" line="1737"/>
         <source>Model.Model37</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1751"/>
+        <location filename="../common/lc_commands.cpp" line="1744"/>
         <source>Model.Model38</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1758"/>
+        <location filename="../common/lc_commands.cpp" line="1751"/>
         <source>Model.Model39</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1765"/>
+        <location filename="../common/lc_commands.cpp" line="1758"/>
         <source>Model.Model40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1772"/>
+        <location filename="../common/lc_commands.cpp" line="1765"/>
         <source>Help.HomePage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1779"/>
+        <location filename="../common/lc_commands.cpp" line="1772"/>
         <source>Help.BugReport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1786"/>
+        <location filename="../common/lc_commands.cpp" line="1779"/>
         <source>Help.Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1793"/>
+        <location filename="../common/lc_commands.cpp" line="1786"/>
         <source>Help.About</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1951,607 +1946,602 @@
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="982"/>
-        <source>Reset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="989"/>
         <source>First</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="996"/>
+        <location filename="../common/lc_commands.cpp" line="989"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1003"/>
+        <location filename="../common/lc_commands.cpp" line="996"/>
         <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1010"/>
+        <location filename="../common/lc_commands.cpp" line="1003"/>
         <source>Last</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1017"/>
+        <location filename="../common/lc_commands.cpp" line="1010"/>
         <source>Insert Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1017"/>
         <source>Insert After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1031"/>
-        <location filename="../common/lc_commands.cpp" line="1815"/>
+        <location filename="../common/lc_commands.cpp" line="1024"/>
+        <location filename="../common/lc_commands.cpp" line="1808"/>
         <source>Remove Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1038"/>
+        <location filename="../common/lc_commands.cpp" line="1031"/>
         <source>Add Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1045"/>
+        <location filename="../common/lc_commands.cpp" line="1038"/>
         <source>Split &amp;Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1052"/>
+        <location filename="../common/lc_commands.cpp" line="1045"/>
         <source>Split &amp;Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1059"/>
+        <location filename="../common/lc_commands.cpp" line="1052"/>
         <source>Re&amp;move View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1066"/>
+        <location filename="../common/lc_commands.cpp" line="1059"/>
         <source>Rese&amp;t Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1073"/>
+        <location filename="../common/lc_commands.cpp" line="1066"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1080"/>
+        <location filename="../common/lc_commands.cpp" line="1073"/>
         <source>Tools</source>
         <translation type="unfinished">Інтструменти</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1087"/>
+        <location filename="../common/lc_commands.cpp" line="1080"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1094"/>
+        <location filename="../common/lc_commands.cpp" line="1087"/>
         <source>Parts</source>
         <translation type="unfinished">Блоків</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1101"/>
+        <location filename="../common/lc_commands.cpp" line="1094"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1108"/>
+        <location filename="../common/lc_commands.cpp" line="1101"/>
         <source>Properties</source>
         <translation type="unfinished">Властивості</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1115"/>
+        <location filename="../common/lc_commands.cpp" line="1108"/>
         <source>Timeline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1122"/>
+        <location filename="../common/lc_commands.cpp" line="1115"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1129"/>
+        <location filename="../common/lc_commands.cpp" line="1122"/>
         <source>&amp;Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1136"/>
+        <location filename="../common/lc_commands.cpp" line="1129"/>
         <source>Close &amp;Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1143"/>
+        <location filename="../common/lc_commands.cpp" line="1136"/>
         <source>&amp;Wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1150"/>
+        <location filename="../common/lc_commands.cpp" line="1143"/>
         <source>&amp;Flat Shading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1157"/>
+        <location filename="../common/lc_commands.cpp" line="1150"/>
         <source>&amp;Default Lights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1164"/>
+        <location filename="../common/lc_commands.cpp" line="1157"/>
         <source>&amp;Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1171"/>
+        <location filename="../common/lc_commands.cpp" line="1164"/>
         <source>&amp;Orthographic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1178"/>
+        <location filename="../common/lc_commands.cpp" line="1171"/>
         <source>View Sphere</source>
         <translation type="unfinished">Сфера візуалізації</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1185"/>
+        <location filename="../common/lc_commands.cpp" line="1178"/>
         <source>Axis Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1192"/>
+        <location filename="../common/lc_commands.cpp" line="1185"/>
         <source>Base Grid</source>
         <translation type="unfinished">Базова сітка</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1199"/>
+        <location filename="../common/lc_commands.cpp" line="1192"/>
         <source>Fade Previous Steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1206"/>
+        <location filename="../common/lc_commands.cpp" line="1199"/>
         <source>&amp;Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1213"/>
+        <location filename="../common/lc_commands.cpp" line="1206"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1220"/>
+        <location filename="../common/lc_commands.cpp" line="1213"/>
         <source>&amp;Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1227"/>
+        <location filename="../common/lc_commands.cpp" line="1220"/>
         <source>&amp;Paint Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1234"/>
+        <location filename="../common/lc_commands.cpp" line="1227"/>
         <source>Reset &amp;Pivot Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1241"/>
+        <location filename="../common/lc_commands.cpp" line="1234"/>
         <source>Remove &amp;Key Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1248"/>
+        <location filename="../common/lc_commands.cpp" line="1241"/>
         <source>Insert Control Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1255"/>
+        <location filename="../common/lc_commands.cpp" line="1248"/>
         <source>Remove Control Point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1262"/>
+        <location filename="../common/lc_commands.cpp" line="1255"/>
         <source>Move +X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1269"/>
+        <location filename="../common/lc_commands.cpp" line="1262"/>
         <source>Move -X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1276"/>
+        <location filename="../common/lc_commands.cpp" line="1269"/>
         <source>Move +Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1283"/>
+        <location filename="../common/lc_commands.cpp" line="1276"/>
         <source>Move -Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1290"/>
+        <location filename="../common/lc_commands.cpp" line="1283"/>
         <source>Move +Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1297"/>
+        <location filename="../common/lc_commands.cpp" line="1290"/>
         <source>Move -Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1304"/>
+        <location filename="../common/lc_commands.cpp" line="1297"/>
         <source>Rotate +X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1311"/>
+        <location filename="../common/lc_commands.cpp" line="1304"/>
         <source>Rotate -X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1318"/>
+        <location filename="../common/lc_commands.cpp" line="1311"/>
         <source>Rotate +Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1325"/>
+        <location filename="../common/lc_commands.cpp" line="1318"/>
         <source>Rotate -Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1332"/>
+        <location filename="../common/lc_commands.cpp" line="1325"/>
         <source>Rotate +Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1339"/>
+        <location filename="../common/lc_commands.cpp" line="1332"/>
         <source>Rotate -Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1346"/>
+        <location filename="../common/lc_commands.cpp" line="1339"/>
         <source>Minifig &amp;Wizard...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1353"/>
+        <location filename="../common/lc_commands.cpp" line="1346"/>
         <source>A&amp;rray...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1360"/>
+        <location filename="../common/lc_commands.cpp" line="1353"/>
         <source>Open Selected Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1367"/>
+        <location filename="../common/lc_commands.cpp" line="1360"/>
         <source>Move to New Model...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1374"/>
+        <location filename="../common/lc_commands.cpp" line="1367"/>
         <source>Inline Selected Models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1381"/>
+        <location filename="../common/lc_commands.cpp" line="1374"/>
         <source>Edit Selected Submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1388"/>
+        <location filename="../common/lc_commands.cpp" line="1381"/>
         <source>End Submodel Editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1395"/>
+        <location filename="../common/lc_commands.cpp" line="1388"/>
         <source>&amp;Group...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1402"/>
+        <location filename="../common/lc_commands.cpp" line="1395"/>
         <source>&amp;Ungroup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1409"/>
+        <location filename="../common/lc_commands.cpp" line="1402"/>
         <source>&amp;Add to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1416"/>
+        <location filename="../common/lc_commands.cpp" line="1409"/>
         <source>Re&amp;move from Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1423"/>
+        <location filename="../common/lc_commands.cpp" line="1416"/>
         <source>&amp;Edit Groups...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1430"/>
+        <location filename="../common/lc_commands.cpp" line="1423"/>
         <source>&amp;Hide Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1437"/>
+        <location filename="../common/lc_commands.cpp" line="1430"/>
         <source>Hide &amp;Unselected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1444"/>
+        <location filename="../common/lc_commands.cpp" line="1437"/>
         <source>&amp;Unhide Selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1451"/>
+        <location filename="../common/lc_commands.cpp" line="1444"/>
         <source>U&amp;nhide All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1458"/>
+        <location filename="../common/lc_commands.cpp" line="1451"/>
         <source>Show Earlier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1465"/>
+        <location filename="../common/lc_commands.cpp" line="1458"/>
         <source>Show Later</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1472"/>
+        <location filename="../common/lc_commands.cpp" line="1465"/>
         <source>New Submodel...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1479"/>
+        <location filename="../common/lc_commands.cpp" line="1472"/>
         <source>Prope&amp;rties...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1486"/>
+        <location filename="../common/lc_commands.cpp" line="1479"/>
         <source>Submodels...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1493"/>
+        <location filename="../common/lc_commands.cpp" line="1486"/>
         <source>Model 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1500"/>
+        <location filename="../common/lc_commands.cpp" line="1493"/>
         <source>Model 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1507"/>
+        <location filename="../common/lc_commands.cpp" line="1500"/>
         <source>Model 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1514"/>
+        <location filename="../common/lc_commands.cpp" line="1507"/>
         <source>Model 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1521"/>
+        <location filename="../common/lc_commands.cpp" line="1514"/>
         <source>Model 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1528"/>
+        <location filename="../common/lc_commands.cpp" line="1521"/>
         <source>Model 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1535"/>
+        <location filename="../common/lc_commands.cpp" line="1528"/>
         <source>Model 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1542"/>
+        <location filename="../common/lc_commands.cpp" line="1535"/>
         <source>Model 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1549"/>
+        <location filename="../common/lc_commands.cpp" line="1542"/>
         <source>Model 9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1556"/>
+        <location filename="../common/lc_commands.cpp" line="1549"/>
         <source>Model 10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1563"/>
+        <location filename="../common/lc_commands.cpp" line="1556"/>
         <source>Model 11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1570"/>
+        <location filename="../common/lc_commands.cpp" line="1563"/>
         <source>Model 12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1577"/>
+        <location filename="../common/lc_commands.cpp" line="1570"/>
         <source>Model 13</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1584"/>
+        <location filename="../common/lc_commands.cpp" line="1577"/>
         <source>Model 14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1591"/>
+        <location filename="../common/lc_commands.cpp" line="1584"/>
         <source>Model 15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1598"/>
+        <location filename="../common/lc_commands.cpp" line="1591"/>
         <source>Model 16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1605"/>
+        <location filename="../common/lc_commands.cpp" line="1598"/>
         <source>Model 17</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1612"/>
+        <location filename="../common/lc_commands.cpp" line="1605"/>
         <source>Model 18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1619"/>
+        <location filename="../common/lc_commands.cpp" line="1612"/>
         <source>Model 19</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1626"/>
+        <location filename="../common/lc_commands.cpp" line="1619"/>
         <source>Model 20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1633"/>
+        <location filename="../common/lc_commands.cpp" line="1626"/>
         <source>Model 21</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1640"/>
+        <location filename="../common/lc_commands.cpp" line="1633"/>
         <source>Model 22</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1647"/>
+        <location filename="../common/lc_commands.cpp" line="1640"/>
         <source>Model 23</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1654"/>
+        <location filename="../common/lc_commands.cpp" line="1647"/>
         <source>Model 24</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1661"/>
+        <location filename="../common/lc_commands.cpp" line="1654"/>
         <source>Model 25</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1668"/>
+        <location filename="../common/lc_commands.cpp" line="1661"/>
         <source>Model 26</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1675"/>
+        <location filename="../common/lc_commands.cpp" line="1668"/>
         <source>Model 27</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1682"/>
+        <location filename="../common/lc_commands.cpp" line="1675"/>
         <source>Model 28</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1689"/>
+        <location filename="../common/lc_commands.cpp" line="1682"/>
         <source>Model 29</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1696"/>
+        <location filename="../common/lc_commands.cpp" line="1689"/>
         <source>Model 30</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1703"/>
+        <location filename="../common/lc_commands.cpp" line="1696"/>
         <source>Model 31</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1710"/>
+        <location filename="../common/lc_commands.cpp" line="1703"/>
         <source>Model 32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1717"/>
+        <location filename="../common/lc_commands.cpp" line="1710"/>
         <source>Model 33</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1724"/>
+        <location filename="../common/lc_commands.cpp" line="1717"/>
         <source>Model 34</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1731"/>
+        <location filename="../common/lc_commands.cpp" line="1724"/>
         <source>Model 35</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1738"/>
+        <location filename="../common/lc_commands.cpp" line="1731"/>
         <source>Model 36</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1745"/>
+        <location filename="../common/lc_commands.cpp" line="1738"/>
         <source>Model 37</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1752"/>
+        <location filename="../common/lc_commands.cpp" line="1745"/>
         <source>Model 38</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1759"/>
+        <location filename="../common/lc_commands.cpp" line="1752"/>
         <source>Model 39</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1766"/>
+        <location filename="../common/lc_commands.cpp" line="1759"/>
         <source>Model 40</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1773"/>
+        <location filename="../common/lc_commands.cpp" line="1766"/>
         <source>LeoCAD &amp;Home Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1780"/>
+        <location filename="../common/lc_commands.cpp" line="1773"/>
         <source>Report a Bug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1787"/>
+        <location filename="../common/lc_commands.cpp" line="1780"/>
         <source>Check for &amp;Updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1794"/>
+        <location filename="../common/lc_commands.cpp" line="1787"/>
         <source>&amp;About...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1801"/>
+        <location filename="../common/lc_commands.cpp" line="1794"/>
         <source>Insert Step Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1808"/>
+        <location filename="../common/lc_commands.cpp" line="1801"/>
         <source>Insert Step After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1822"/>
+        <location filename="../common/lc_commands.cpp" line="1815"/>
         <source>Move Selection Here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1829"/>
+        <location filename="../common/lc_commands.cpp" line="1822"/>
         <source>Set Current Step</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2559,77 +2549,77 @@
 <context>
     <name>Mouse</name>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1839"/>
+        <location filename="../common/lc_commands.cpp" line="1832"/>
         <source>NewPiece</source>
         <translation>НовийБлок</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1840"/>
+        <location filename="../common/lc_commands.cpp" line="1833"/>
         <source>NewPointLight</source>
         <translation>НовеТочковеСвітло</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1841"/>
+        <location filename="../common/lc_commands.cpp" line="1834"/>
         <source>NewSpotLight</source>
         <translation>НовеПрожекторнеСвітло</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1842"/>
+        <location filename="../common/lc_commands.cpp" line="1835"/>
         <source>NewCamera</source>
         <translation>НоваКамера</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1843"/>
+        <location filename="../common/lc_commands.cpp" line="1836"/>
         <source>Select</source>
         <translation>Виділити</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1844"/>
+        <location filename="../common/lc_commands.cpp" line="1837"/>
         <source>Move</source>
         <translation>Перемістити</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1845"/>
+        <location filename="../common/lc_commands.cpp" line="1838"/>
         <source>Rotate</source>
         <translation>Покрутити</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1846"/>
+        <location filename="../common/lc_commands.cpp" line="1839"/>
         <source>Delete</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1847"/>
+        <location filename="../common/lc_commands.cpp" line="1840"/>
         <source>Paint</source>
         <translation>Фарбувати</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1848"/>
+        <location filename="../common/lc_commands.cpp" line="1841"/>
         <source>ColorPicker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1849"/>
+        <location filename="../common/lc_commands.cpp" line="1842"/>
         <source>Zoom</source>
         <translation>Масштабувати</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1850"/>
+        <location filename="../common/lc_commands.cpp" line="1843"/>
         <source>Pan</source>
         <translation>Подвинути</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1851"/>
+        <location filename="../common/lc_commands.cpp" line="1844"/>
         <source>Orbit</source>
         <translation>Прокрутити</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1852"/>
+        <location filename="../common/lc_commands.cpp" line="1845"/>
         <source>Roll</source>
         <translation>Нахилити</translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1853"/>
+        <location filename="../common/lc_commands.cpp" line="1846"/>
         <source>ZoomRegion</source>
         <translation>МасштабуватиРегіон</translation>
     </message>
@@ -2637,172 +2627,170 @@
 <context>
     <name>Project</name>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.ldr</source>
         <translation>нова_модель.ldr</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="108"/>
+        <location filename="../common/project.cpp" line="109"/>
         <source>New Model.mpd</source>
         <translation>нова_модель.mpd</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="177"/>
+        <location filename="../common/project.cpp" line="178"/>
         <source>Submodel #</source>
         <translation>підмодель_#</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="201"/>
+        <location filename="../common/project.cpp" line="202"/>
         <source>Submodel Name:</source>
         <translation>Назва підмоделі:</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>Empty Name</source>
         <translation>Порожня назва</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="208"/>
+        <location filename="../common/project.cpp" line="209"/>
         <source>The submodel name cannot be empty.</source>
         <translation>Назва підмоделі не може бути порожньою.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>Duplicate Submodel</source>
         <translation>Дублювати підмодель</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="228"/>
+        <location filename="../common/project.cpp" line="229"/>
         <source>A submodel named &apos;%1&apos; already exists, please enter a unique name.</source>
         <translation>Підмодель з назвою &apos;%1&apos; вже існує. Оберіть унікальну назву.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="245"/>
+        <location filename="../common/project.cpp" line="246"/>
         <source>New Submodel</source>
         <translation>Нова підмодель</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
-        <location filename="../common/project.cpp" line="449"/>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="378"/>
+        <location filename="../common/project.cpp" line="457"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="371"/>
+        <location filename="../common/project.cpp" line="378"/>
         <source>Error reading file &apos;%1&apos;:
 %2</source>
         <translation>Помилка читання файла &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="449"/>
+        <location filename="../common/project.cpp" line="457"/>
         <source>Error loading file &apos;%1&apos;:
 File format is not recognized.</source>
         <translation>Помилка завантаження файла &apos;%1&apos;:
 Формат файла не розпізнано.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="486"/>
-        <location filename="../common/project.cpp" line="653"/>
-        <location filename="../common/project.cpp" line="1571"/>
-        <location filename="../common/project.cpp" line="1602"/>
-        <location filename="../common/project.cpp" line="1627"/>
-        <location filename="../common/project.cpp" line="1661"/>
-        <location filename="../common/project.cpp" line="1693"/>
+        <location filename="../common/project.cpp" line="494"/>
+        <location filename="../common/project.cpp" line="661"/>
+        <location filename="../common/project.cpp" line="1536"/>
+        <location filename="../common/project.cpp" line="1567"/>
+        <location filename="../common/project.cpp" line="1592"/>
+        <location filename="../common/project.cpp" line="1626"/>
+        <location filename="../common/project.cpp" line="1658"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation>Помилка запису у файл &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="544"/>
+        <location filename="../common/project.cpp" line="552"/>
         <source>Merged </source>
         <translation>Об&apos;єднано </translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
-        <location filename="../common/project.cpp" line="2060"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
+        <location filename="../common/project.cpp" line="2025"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="695"/>
-        <location filename="../common/project.cpp" line="1139"/>
-        <location filename="../common/project.cpp" line="1200"/>
-        <location filename="../common/project.cpp" line="1475"/>
-        <location filename="../common/project.cpp" line="1741"/>
-        <location filename="../common/project.cpp" line="2060"/>
+        <location filename="../common/project.cpp" line="703"/>
+        <location filename="../common/project.cpp" line="1147"/>
+        <location filename="../common/project.cpp" line="1165"/>
+        <location filename="../common/project.cpp" line="1440"/>
+        <location filename="../common/project.cpp" line="1706"/>
+        <location filename="../common/project.cpp" line="2025"/>
         <source>Nothing to export.</source>
         <translation>Немає чого експортувати.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>Export 3D Studio</source>
         <translation>Експортувати 3D Studio</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="699"/>
+        <location filename="../common/project.cpp" line="707"/>
         <source>3DS Files (*.3ds);;All Files (*.*)</source>
         <translation>Файли 3DS (*.3ds);;Усі файли (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="708"/>
-        <location filename="../common/project.cpp" line="1153"/>
-        <location filename="../common/project.cpp" line="1213"/>
-        <location filename="../common/project.cpp" line="1489"/>
-        <location filename="../common/project.cpp" line="1754"/>
-        <location filename="../common/project.cpp" line="2074"/>
-        <location filename="../common/project.cpp" line="2091"/>
+        <location filename="../common/project.cpp" line="716"/>
+        <location filename="../common/project.cpp" line="1178"/>
+        <location filename="../common/project.cpp" line="1454"/>
+        <location filename="../common/project.cpp" line="1719"/>
+        <location filename="../common/project.cpp" line="2039"/>
+        <location filename="../common/project.cpp" line="2056"/>
         <source>Could not open file &apos;%1&apos; for writing.</source>
         <translation>Не вдалося відкрити файл &apos;%1&apos; для запису.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>Export BrickLink</source>
         <translation>Експортувати BrickLink</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1143"/>
+        <location filename="../common/project.cpp" line="1151"/>
         <source>XML Files (*.xml);;All Files (*.*)</source>
         <translation>Файли XML (*.xml);;Усі файли (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>Export COLLADA</source>
         <translation>Експортувати COLLADA</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1204"/>
+        <location filename="../common/project.cpp" line="1169"/>
         <source>COLLADA Files (*.dae);;All Files (*.*)</source>
         <translation>Файли COLLADA (*.dae);;Усі файли (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>Export CSV</source>
         <translation>Експортувати CSV</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1479"/>
+        <location filename="../common/project.cpp" line="1444"/>
         <source>CSV Files (*.csv);;All Files (*.*)</source>
         <translation>Файли CSV (*.csv);;Усі файли (*.*)</translation>
     </message>
@@ -2811,28 +2799,28 @@ File format is not recognized.</source>
         <translation type="vanished">Помилка створення зображення.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>Export POV-Ray</source>
         <translation>Експортувати POV-Ray</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1745"/>
+        <location filename="../common/project.cpp" line="1710"/>
         <source>POV-Ray Files (*.pov);;All Files (*.*)</source>
         <translation>Файли POV-Ray (*.pov);;Усі файли (*.*)</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="1793"/>
-        <location filename="../common/project.cpp" line="1839"/>
+        <location filename="../common/project.cpp" line="1758"/>
+        <location filename="../common/project.cpp" line="1804"/>
         <source>Could not find LGEO files in folder &apos;%1&apos;.</source>
         <translation>Не вдалося знайти файли LGEO у теці &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Export Wavefront</source>
         <translation>Експортувати Wavefront</translation>
     </message>
     <message>
-        <location filename="../common/project.cpp" line="2064"/>
+        <location filename="../common/project.cpp" line="2029"/>
         <source>Wavefront Files (*.obj);;All Files (*.*)</source>
         <translation>Файли Wavefront (*.obj);;Усі файли (*.*)</translation>
     </message>
@@ -2863,19 +2851,19 @@ File format is not recognized.</source>
         <translation type="vanished">Спеціальні кольори</translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="507"/>
+        <location filename="../common/lc_colors.cpp" line="318"/>
         <source>Solid</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="508"/>
+        <location filename="../common/lc_colors.cpp" line="319"/>
         <source>Translucent</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_colors.cpp" line="509"/>
+        <location filename="../common/lc_colors.cpp" line="320"/>
         <source>Special</source>
         <comment>Colors</comment>
         <translation type="unfinished"></translation>
@@ -2884,14 +2872,21 @@ File format is not recognized.</source>
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
         <source>Error</source>
-        <translation type="unfinished">Помилка</translation>
+        <translation type="obsolete">Помилка</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>LeoCAD</source>
+        <translation type="unfinished">LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="128"/>
-        <source>Failed to load &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../common/lc_bricklink.cpp" line="72"/>
+        <source>Could not open file &apos;%1&apos; for writing.</source>
+        <translation type="unfinished">Не вдалося відкрити файл &apos;%1&apos; для запису.</translation>
     </message>
 </context>
 <context>
@@ -3521,349 +3516,345 @@ File format is not recognized.</source>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="983"/>
-        <source>Reset views to their default positions</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="990"/>
         <source>Go to the first step of the model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="997"/>
+        <location filename="../common/lc_commands.cpp" line="990"/>
         <source>Go to the previous step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1004"/>
+        <location filename="../common/lc_commands.cpp" line="997"/>
         <source>Go to the next step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1004"/>
         <source>Go to the last step of the model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_commands.cpp" line="1011"/>
+        <location filename="../common/lc_commands.cpp" line="1795"/>
+        <source>Insert a new step before the current step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1018"/>
         <location filename="../common/lc_commands.cpp" line="1802"/>
-        <source>Insert a new step before the current step</source>
+        <source>Insert a new step after the current step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../common/lc_commands.cpp" line="1025"/>
         <location filename="../common/lc_commands.cpp" line="1809"/>
-        <source>Insert a new step after the current step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_commands.cpp" line="1032"/>
-        <location filename="../common/lc_commands.cpp" line="1816"/>
         <source>Remove current step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1039"/>
+        <location filename="../common/lc_commands.cpp" line="1032"/>
         <source>Toggle adding new animation keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1046"/>
+        <location filename="../common/lc_commands.cpp" line="1039"/>
         <source>Split the current view horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1053"/>
+        <location filename="../common/lc_commands.cpp" line="1046"/>
         <source>Split the current view vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1060"/>
+        <location filename="../common/lc_commands.cpp" line="1053"/>
         <source>Remove the current view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1067"/>
+        <location filename="../common/lc_commands.cpp" line="1060"/>
         <source>Reset all views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1074"/>
+        <location filename="../common/lc_commands.cpp" line="1067"/>
         <source>Toggle the Standard Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1081"/>
+        <location filename="../common/lc_commands.cpp" line="1074"/>
         <source>Toggle the Tools Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1088"/>
+        <location filename="../common/lc_commands.cpp" line="1081"/>
         <source>Toggle the Time Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1095"/>
+        <location filename="../common/lc_commands.cpp" line="1088"/>
         <source>Toggle the Parts Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1102"/>
+        <location filename="../common/lc_commands.cpp" line="1095"/>
         <source>Toggle the Colors Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1109"/>
+        <location filename="../common/lc_commands.cpp" line="1102"/>
         <source>Toggle the Properties Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1116"/>
+        <location filename="../common/lc_commands.cpp" line="1109"/>
         <source>Toggle the Timeline Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1123"/>
+        <location filename="../common/lc_commands.cpp" line="1116"/>
         <source>Toggle the Preview Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1130"/>
+        <location filename="../common/lc_commands.cpp" line="1123"/>
         <source>Toggle fullscreen mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1137"/>
+        <location filename="../common/lc_commands.cpp" line="1130"/>
         <source>Close current tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1144"/>
+        <location filename="../common/lc_commands.cpp" line="1137"/>
         <source>Display the scene as wireframe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1151"/>
+        <location filename="../common/lc_commands.cpp" line="1144"/>
         <source>Display the scene without any shading or lights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1158"/>
+        <location filename="../common/lc_commands.cpp" line="1151"/>
         <source>Display the scene with the default lights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1165"/>
+        <location filename="../common/lc_commands.cpp" line="1158"/>
         <source>Set the current camera to use a perspective projection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1172"/>
+        <location filename="../common/lc_commands.cpp" line="1165"/>
         <source>Set the current camera to use an orthographic projection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1179"/>
+        <location filename="../common/lc_commands.cpp" line="1172"/>
         <source>Toggle the view sphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1186"/>
+        <location filename="../common/lc_commands.cpp" line="1179"/>
         <source>Toggle axis icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1193"/>
+        <location filename="../common/lc_commands.cpp" line="1186"/>
         <source>Toggle grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1200"/>
+        <location filename="../common/lc_commands.cpp" line="1193"/>
         <source>Toggle fading previous model steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1207"/>
+        <location filename="../common/lc_commands.cpp" line="1200"/>
         <source>Add a new piece to the model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1214"/>
+        <location filename="../common/lc_commands.cpp" line="1207"/>
         <source>Delete selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1221"/>
+        <location filename="../common/lc_commands.cpp" line="1214"/>
         <source>Create a copy of the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1228"/>
+        <location filename="../common/lc_commands.cpp" line="1221"/>
         <source>Change the color of the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1235"/>
+        <location filename="../common/lc_commands.cpp" line="1228"/>
         <source>Reset the pivot point of the selected pieces to their origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1242"/>
+        <location filename="../common/lc_commands.cpp" line="1235"/>
         <source>Remove all key frames from the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1249"/>
+        <location filename="../common/lc_commands.cpp" line="1242"/>
         <source>Insert a new control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1256"/>
+        <location filename="../common/lc_commands.cpp" line="1249"/>
         <source>Remove the selected control point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1256"/>
         <location filename="../common/lc_commands.cpp" line="1263"/>
-        <location filename="../common/lc_commands.cpp" line="1270"/>
         <source>Move selected objects along the X axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1270"/>
         <location filename="../common/lc_commands.cpp" line="1277"/>
-        <location filename="../common/lc_commands.cpp" line="1284"/>
         <source>Move selected objects along the Y axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1284"/>
         <location filename="../common/lc_commands.cpp" line="1291"/>
-        <location filename="../common/lc_commands.cpp" line="1298"/>
         <source>Move selected objects along the Z axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1298"/>
         <location filename="../common/lc_commands.cpp" line="1305"/>
-        <location filename="../common/lc_commands.cpp" line="1312"/>
         <source>Rotate selected objects along the X axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1312"/>
         <location filename="../common/lc_commands.cpp" line="1319"/>
-        <location filename="../common/lc_commands.cpp" line="1326"/>
         <source>Rotate selected objects along the Y axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1326"/>
         <location filename="../common/lc_commands.cpp" line="1333"/>
-        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Rotate selected objects along the Z axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1347"/>
+        <location filename="../common/lc_commands.cpp" line="1340"/>
         <source>Add a new minifig to the model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1354"/>
+        <location filename="../common/lc_commands.cpp" line="1347"/>
         <source>Make copies of the selected pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1361"/>
+        <location filename="../common/lc_commands.cpp" line="1354"/>
         <source>Open the model referenced by the selected piece in a new tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1368"/>
+        <location filename="../common/lc_commands.cpp" line="1361"/>
         <source>Move the selected pieces to a new model and replace them with a reference to the model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1375"/>
+        <location filename="../common/lc_commands.cpp" line="1368"/>
         <source>Insert the contents of the selected model references into the current model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1382"/>
+        <location filename="../common/lc_commands.cpp" line="1375"/>
         <source>Edit the currently selected submodel in-place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1389"/>
+        <location filename="../common/lc_commands.cpp" line="1382"/>
         <source>End in-place submodel editing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1396"/>
+        <location filename="../common/lc_commands.cpp" line="1389"/>
         <source>Group selected pieces together</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1403"/>
+        <location filename="../common/lc_commands.cpp" line="1396"/>
         <source>Ungroup selected group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1410"/>
+        <location filename="../common/lc_commands.cpp" line="1403"/>
         <source>Add focused piece to selected group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1417"/>
+        <location filename="../common/lc_commands.cpp" line="1410"/>
         <source>Remove focused piece from group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1424"/>
+        <location filename="../common/lc_commands.cpp" line="1417"/>
         <source>Edit groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1431"/>
+        <location filename="../common/lc_commands.cpp" line="1424"/>
         <source>Hide selected objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1438"/>
+        <location filename="../common/lc_commands.cpp" line="1431"/>
         <source>Hide objects that are not selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1445"/>
+        <location filename="../common/lc_commands.cpp" line="1438"/>
         <source>Show hidden objects that are selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1452"/>
+        <location filename="../common/lc_commands.cpp" line="1445"/>
         <source>Show all hidden objects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1459"/>
+        <location filename="../common/lc_commands.cpp" line="1452"/>
         <source>Show selected pieces one step earlier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1466"/>
+        <location filename="../common/lc_commands.cpp" line="1459"/>
         <source>Show selected pieces one step later</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1473"/>
+        <location filename="../common/lc_commands.cpp" line="1466"/>
         <source>Create a new submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1480"/>
+        <location filename="../common/lc_commands.cpp" line="1473"/>
         <source>Display the properties of the current submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1487"/>
+        <location filename="../common/lc_commands.cpp" line="1480"/>
         <source>Show a list of all submodels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_commands.cpp" line="1487"/>
         <location filename="../common/lc_commands.cpp" line="1494"/>
         <location filename="../common/lc_commands.cpp" line="1501"/>
         <location filename="../common/lc_commands.cpp" line="1508"/>
@@ -3903,37 +3894,36 @@ File format is not recognized.</source>
         <location filename="../common/lc_commands.cpp" line="1746"/>
         <location filename="../common/lc_commands.cpp" line="1753"/>
         <location filename="../common/lc_commands.cpp" line="1760"/>
-        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Switch to this submodel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1774"/>
+        <location filename="../common/lc_commands.cpp" line="1767"/>
         <source>Open LeoCAD&apos;s home page on the internet using your default web browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1781"/>
+        <location filename="../common/lc_commands.cpp" line="1774"/>
         <source>Open LeoCAD&apos;s bug report form on your default web browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1788"/>
+        <location filename="../common/lc_commands.cpp" line="1781"/>
         <source>Check if a newer LeoCAD version or parts library has been released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1795"/>
+        <location filename="../common/lc_commands.cpp" line="1788"/>
         <source>Display program version number and system information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1823"/>
+        <location filename="../common/lc_commands.cpp" line="1816"/>
         <source>Move the selected parts into this step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_commands.cpp" line="1830"/>
+        <location filename="../common/lc_commands.cpp" line="1823"/>
         <source>View the model at this point in the timeline</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3974,398 +3964,398 @@ File format is not recognized.</source>
 <context>
     <name>lcApplication</name>
     <message>
-        <location filename="../common/lc_application.cpp" line="401"/>
-        <location filename="../common/lc_application.cpp" line="426"/>
-        <location filename="../common/lc_application.cpp" line="449"/>
-        <location filename="../common/lc_application.cpp" line="472"/>
-        <location filename="../common/lc_application.cpp" line="482"/>
-        <location filename="../common/lc_application.cpp" line="505"/>
-        <location filename="../common/lc_application.cpp" line="530"/>
+        <location filename="../common/lc_application.cpp" line="421"/>
+        <location filename="../common/lc_application.cpp" line="446"/>
+        <location filename="../common/lc_application.cpp" line="469"/>
+        <location filename="../common/lc_application.cpp" line="492"/>
+        <location filename="../common/lc_application.cpp" line="502"/>
+        <location filename="../common/lc_application.cpp" line="525"/>
+        <location filename="../common/lc_application.cpp" line="550"/>
         <source>Not enough parameters for the &apos;%1&apos; option.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="423"/>
-        <location filename="../common/lc_application.cpp" line="446"/>
-        <location filename="../common/lc_application.cpp" line="469"/>
-        <location filename="../common/lc_application.cpp" line="502"/>
-        <location filename="../common/lc_application.cpp" line="527"/>
-        <location filename="../common/lc_application.cpp" line="580"/>
-        <location filename="../common/lc_application.cpp" line="734"/>
-        <location filename="../common/lc_application.cpp" line="745"/>
+        <location filename="../common/lc_application.cpp" line="443"/>
+        <location filename="../common/lc_application.cpp" line="466"/>
+        <location filename="../common/lc_application.cpp" line="489"/>
+        <location filename="../common/lc_application.cpp" line="522"/>
+        <location filename="../common/lc_application.cpp" line="547"/>
+        <location filename="../common/lc_application.cpp" line="600"/>
+        <location filename="../common/lc_application.cpp" line="754"/>
+        <location filename="../common/lc_application.cpp" line="765"/>
         <source>Invalid parameter value specified for the &apos;%1&apos; option: &apos;%2&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="541"/>
+        <location filename="../common/lc_application.cpp" line="561"/>
         <source>The file &apos;%1&apos; is not readable.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="589"/>
+        <location filename="../common/lc_application.cpp" line="609"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: limits are +/- 360.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="601"/>
+        <location filename="../common/lc_application.cpp" line="621"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="620"/>
+        <location filename="../common/lc_application.cpp" line="640"/>
         <source>Invalid parameter value(s) specified for the &apos;%1&apos; option: requirements are: 1 &lt;= &lt;near&gt; &lt; &lt;far&gt;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="630"/>
-        <location filename="../common/lc_application.cpp" line="641"/>
-        <location filename="../common/lc_application.cpp" line="652"/>
-        <location filename="../common/lc_application.cpp" line="663"/>
+        <location filename="../common/lc_application.cpp" line="650"/>
+        <location filename="../common/lc_application.cpp" line="661"/>
+        <location filename="../common/lc_application.cpp" line="672"/>
+        <location filename="../common/lc_application.cpp" line="683"/>
         <source>High contrast stud style is required for the &apos;%1&apos; option but is not enabled.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="678"/>
-        <location filename="../common/lc_application.cpp" line="689"/>
+        <location filename="../common/lc_application.cpp" line="698"/>
+        <location filename="../common/lc_application.cpp" line="709"/>
         <source>Automate edge color is required for the &apos;%1&apos; option but is not enabled.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="779"/>
+        <location filename="../common/lc_application.cpp" line="799"/>
         <source>LeoCAD Continuous Build %1
 </source>
         <translation type="unfinished">LeoCAD Continuous Build %1
 </translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="781"/>
+        <location filename="../common/lc_application.cpp" line="801"/>
         <source>LeoCAD Version %1
 </source>
         <translation type="unfinished">LeoCAD Версія %1
 </translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="783"/>
+        <location filename="../common/lc_application.cpp" line="803"/>
         <source>Compiled %1
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="788"/>
+        <location filename="../common/lc_application.cpp" line="808"/>
         <source>Usage: leocad [options] [file]
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="789"/>
+        <location filename="../common/lc_application.cpp" line="809"/>
         <source>  [options] can be:
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="790"/>
+        <location filename="../common/lc_application.cpp" line="810"/>
         <source>  -l, --libpath &lt;path&gt;: Set the Parts Library location to path.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="791"/>
+        <location filename="../common/lc_application.cpp" line="811"/>
         <source>  -i, --image &lt;outfile.ext&gt;: Save a picture in the format specified by ext and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="792"/>
+        <location filename="../common/lc_application.cpp" line="812"/>
         <source>  -w, --width &lt;width&gt;: Set the picture width.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="793"/>
+        <location filename="../common/lc_application.cpp" line="813"/>
         <source>  -h, --height &lt;height&gt;: Set the picture height.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="794"/>
+        <location filename="../common/lc_application.cpp" line="814"/>
         <source>  -f, --from &lt;step&gt;: Set the first step to save pictures.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="795"/>
+        <location filename="../common/lc_application.cpp" line="815"/>
         <source>  -t, --to &lt;step&gt;: Set the last step to save pictures.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="796"/>
+        <location filename="../common/lc_application.cpp" line="816"/>
         <source>  -s, --submodel &lt;submodel&gt;: Set the active submodel.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="797"/>
+        <location filename="../common/lc_application.cpp" line="817"/>
         <source>  -c, --camera &lt;camera&gt;: Set the active camera.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="798"/>
+        <location filename="../common/lc_application.cpp" line="818"/>
         <source>  -ss, --stud-style &lt;id&gt;: Set the stud style 0=No style, 1=LDraw single wire, 2=LDraw double wire, 3=LDraw raised floating, 4=LDraw raised rounded, 5=LDraw subtle rounded, 6=LEGO no logo, 7=LEGO single wire.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="799"/>
+        <location filename="../common/lc_application.cpp" line="819"/>
         <source>  --viewpoint &lt;front|back|left|right|top|bottom|home&gt;: Set the viewpoint.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="800"/>
+        <location filename="../common/lc_application.cpp" line="820"/>
         <source>  --camera-angles &lt;latitude&gt; &lt;longitude&gt;: Set the camera angles in degrees around the model.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="801"/>
+        <location filename="../common/lc_application.cpp" line="821"/>
         <source>  --camera-position &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="802"/>
+        <location filename="../common/lc_application.cpp" line="822"/>
         <source>  --camera-position-ldraw &lt;x&gt; &lt;y&gt; &lt;z&gt; &lt;tx&gt; &lt;ty&gt; &lt;tz&gt; &lt;ux&gt; &lt;uy&gt; &lt;uz&gt;: Set the camera position, target and up vector using LDraw coordinates.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="803"/>
+        <location filename="../common/lc_application.cpp" line="823"/>
         <source>  --orthographic: Render images using an orthographic projection.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="804"/>
+        <location filename="../common/lc_application.cpp" line="824"/>
         <source>  --fov &lt;degrees&gt;: Set the vertical field of view used to render images (&lt; 180).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="805"/>
+        <location filename="../common/lc_application.cpp" line="825"/>
         <source>  --zplanes &lt;near&gt; &lt;far&gt;: Set the near and far clipping planes used to render images (1 &lt;= &lt;near&gt; &lt; &lt;far&gt;).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="806"/>
+        <location filename="../common/lc_application.cpp" line="826"/>
         <source>  --fade-steps: Render parts from prior steps faded.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="807"/>
+        <location filename="../common/lc_application.cpp" line="827"/>
         <source>  --no-fade-steps: Do not render parts from prior steps faded.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="808"/>
+        <location filename="../common/lc_application.cpp" line="828"/>
         <source>  --fade-steps-color &lt;rgba&gt;: Renderinng color for prior step parts (#AARRGGBB).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="809"/>
+        <location filename="../common/lc_application.cpp" line="829"/>
         <source>  --highlight: Highlight parts in the steps they appear.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="810"/>
+        <location filename="../common/lc_application.cpp" line="830"/>
         <source>  --no-highlight: Do not highlight parts in the steps they appear.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="811"/>
+        <location filename="../common/lc_application.cpp" line="831"/>
         <source>  --highlight-color: Renderinng color for highlighted parts (#AARRGGBB).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="812"/>
+        <location filename="../common/lc_application.cpp" line="832"/>
         <source>  --shading &lt;wireframe|flat|default|full&gt;: Select shading mode for rendering.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="813"/>
-        <source>  --line-width &lt;width&gt;: Set the with of the edge lines.
+        <location filename="../common/lc_application.cpp" line="833"/>
+        <source>  --line-width &lt;width&gt;: Set the width of the edge lines.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="814"/>
+        <location filename="../common/lc_application.cpp" line="834"/>
         <source>  --aa-samples &lt;count&gt;: AntiAliasing sample size (1, 2, 4, or 8).
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="815"/>
+        <location filename="../common/lc_application.cpp" line="835"/>
         <source>  -scc, --stud-cylinder-color &lt;#AARRGGBB&gt;: High contrast stud cylinder color.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="816"/>
+        <location filename="../common/lc_application.cpp" line="836"/>
         <source>  -ec, --edge-color &lt;#AARRGGBB&gt;: High contrast edge color.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="817"/>
+        <location filename="../common/lc_application.cpp" line="837"/>
         <source>  -bec, --black-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for black parts.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="818"/>
+        <location filename="../common/lc_application.cpp" line="838"/>
         <source>  -dec, --dark-edge-color &lt;#AARRGGBB&gt;: High contrast edge color for dark color parts.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="819"/>
+        <location filename="../common/lc_application.cpp" line="839"/>
         <source>  -aec, --automate-edge-color: Enable automatically adjusted edge colors.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="820"/>
+        <location filename="../common/lc_application.cpp" line="840"/>
         <source>  -cc, --color-contrast &lt;float&gt;: Color contrast value between 0.0 and 1.0.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="821"/>
+        <location filename="../common/lc_application.cpp" line="841"/>
         <source>  -ldv, --light-dark-value &lt;float&gt;: Light/Dark color value between 0.0 and 1.0.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="822"/>
+        <location filename="../common/lc_application.cpp" line="842"/>
         <source>  -obj, --export-wavefront &lt;outfile.obj&gt;: Export the model to Wavefront OBJ format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="823"/>
+        <location filename="../common/lc_application.cpp" line="843"/>
         <source>  -3ds, --export-3ds &lt;outfile.3ds&gt;: Export the model to 3D Studio 3DS format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="824"/>
+        <location filename="../common/lc_application.cpp" line="844"/>
         <source>  -dae, --export-collada &lt;outfile.dae&gt;: Export the model to COLLADA DAE format.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="825"/>
+        <location filename="../common/lc_application.cpp" line="845"/>
         <source>  -html, --export-html &lt;folder&gt;: Create an HTML page for the model.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="826"/>
+        <location filename="../common/lc_application.cpp" line="846"/>
         <source>  -v, --version: Output version information and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="827"/>
+        <location filename="../common/lc_application.cpp" line="847"/>
         <source>  -?, --help: Display this help message and exit.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="833"/>
+        <location filename="../common/lc_application.cpp" line="853"/>
         <source>Unknown option: &apos;%1&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="840"/>
+        <location filename="../common/lc_application.cpp" line="860"/>
         <source>High contrast stud and edge color settings are ignored when -aec or --automate-edge-color is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="846"/>
+        <location filename="../common/lc_application.cpp" line="866"/>
         <source>--viewpoint is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="849"/>
+        <location filename="../common/lc_application.cpp" line="869"/>
         <source>--orthographic is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="852"/>
+        <location filename="../common/lc_application.cpp" line="872"/>
         <source>--camera-angles is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="855"/>
+        <location filename="../common/lc_application.cpp" line="875"/>
         <source>--camera-position is ignored when --camera is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="860"/>
+        <location filename="../common/lc_application.cpp" line="880"/>
         <source>--camera-angles is ignored when --viewpoint is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="863"/>
+        <location filename="../common/lc_application.cpp" line="883"/>
         <source>--camera-position is ignored when --viewpoint is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="868"/>
+        <location filename="../common/lc_application.cpp" line="888"/>
         <source>--camera-position is ignored when --camera-angles is set.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="875"/>
+        <location filename="../common/lc_application.cpp" line="895"/>
         <source>No file name specified.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="908"/>
+        <location filename="../common/lc_application.cpp" line="928"/>
         <source>Error creating OpenGL context.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="929"/>
+        <location filename="../common/lc_application.cpp" line="949"/>
         <source>LeoCAD could not find a compatible Parts Library so only a small number of parts will be available.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
@@ -4374,7 +4364,7 @@ Please visit https://www.leocad.org for information on how to download and insta
 Відвідайте https://www.leocad.org для дізнатися як завантажити і встановити бібліотеки блоків.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="931"/>
+        <location filename="../common/lc_application.cpp" line="951"/>
         <source>LeoCAD could not load Parts Library.
 
 Please visit https://www.leocad.org for information on how to download and install a library.</source>
@@ -4383,28 +4373,28 @@ Please visit https://www.leocad.org for information on how to download and insta
 Відвідайте https://www.leocad.org для дізнатися як завантажити і встановити бібліотеки блоків.</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="934"/>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="954"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1002"/>
+        <location filename="../common/lc_application.cpp" line="1022"/>
         <source>Error: model &apos;%1&apos; does not exist.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1093"/>
-        <location filename="../common/lc_application.cpp" line="1121"/>
-        <location filename="../common/lc_application.cpp" line="1146"/>
-        <location filename="../common/lc_application.cpp" line="1171"/>
+        <location filename="../common/lc_application.cpp" line="1113"/>
+        <location filename="../common/lc_application.cpp" line="1141"/>
+        <location filename="../common/lc_application.cpp" line="1166"/>
+        <location filename="../common/lc_application.cpp" line="1191"/>
         <source>Saved &apos;%1&apos;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_application.cpp" line="1287"/>
+        <location filename="../common/lc_application.cpp" line="1298"/>
         <source>Some changes will only take effect the next time you start LeoCAD.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4454,6 +4444,26 @@ Please visit https://www.leocad.org for information on how to download and insta
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Light/Dark Value:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="48"/>
+        <source>Saturation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="54"/>
+        <source>Set to classify where color values are light or dark - e.g. Dark Bluish Gray (72) is light at 0.39.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="55"/>
+        <source>Set to specify amount of edge color tint or shade from the saturation adjusted part color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="68"/>
         <source>High Contrast</source>
         <translation type="unfinished"></translation>
@@ -4489,8 +4499,18 @@ Please visit https://www.leocad.org for information on how to download and insta
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="179"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Black parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../common/lc_edgecolordialog.cpp" line="183"/>
         <source>Select Black Edge Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_edgecolordialog.cpp" line="191"/>
+        <source>Automate edge color appears to be enabled.&lt;br&gt;Dark parts edge color will not be accessible.&lt;br&gt;Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4551,109 +4571,134 @@ Please visit https://www.leocad.org for information on how to download and insta
 <context>
     <name>lcInstructionsDialog</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="527"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="532"/>
         <source>Instructions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="542"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="547"/>
         <source>Page Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="552"/>
+        <source>Print</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="554"/>
+        <source>Vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="557"/>
+        <source>Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="571"/>
+        <source>Page %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPageListWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="174"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="179"/>
         <source>Pages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_instructionsdialog.cpp" line="189"/>
+        <source>Page Setup</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>lcInstructionsPropertiesWidget</name>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="288"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="293"/>
         <source>Properties</source>
         <translation type="unfinished">Властивості</translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="294"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="299"/>
         <source>Current Step Forward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="296"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="301"/>
         <source>Scope:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="301"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="306"/>
         <source>Preset:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="351"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="356"/>
         <source>Select Step Number Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="355"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="360"/>
         <source>Select Step Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="359"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="364"/>
         <source>Select Parts List Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="363"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="368"/>
         <source>Select Parts List Border Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="367"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="372"/>
         <source>Select Parts List Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="417"/>
-        <location filename="../common/lc_instructionsdialog.cpp" line="438"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="422"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="443"/>
         <source>Select Step Number Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="421"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="426"/>
         <source>Select Parts List Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="477"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="482"/>
         <source>Step Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="493"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="498"/>
         <source>Step Number Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_instructionsdialog.cpp" line="508"/>
+        <location filename="../common/lc_instructionsdialog.cpp" line="513"/>
         <source>Parts List Properties</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4661,225 +4706,220 @@ Please visit https://www.leocad.org for information on how to download and insta
 <context>
     <name>lcMainWindow</name>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="172"/>
+        <location filename="../common/lc_mainwindow.cpp" line="145"/>
         <source>New Model</source>
         <translation>Нова модель</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="173"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
+        <location filename="../common/lc_mainwindow.cpp" line="146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
         <source>Open Model</source>
         <translation>Відкрити модель</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="174"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2507"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2434"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save Model</source>
         <translation>Зберегти модель</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="403"/>
-        <location filename="../common/lc_mainwindow.cpp" line="606"/>
-        <location filename="../common/lc_mainwindow.cpp" line="613"/>
+        <location filename="../common/lc_mainwindow.cpp" line="376"/>
+        <location filename="../common/lc_mainwindow.cpp" line="577"/>
+        <location filename="../common/lc_mainwindow.cpp" line="584"/>
         <source>Transform</source>
         <translation>Трансформувати</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="410"/>
+        <location filename="../common/lc_mainwindow.cpp" line="383"/>
         <source>C&amp;ameras</source>
         <translation>&amp;Камери</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="419"/>
+        <location filename="../common/lc_mainwindow.cpp" line="389"/>
         <source>&amp;Viewpoints</source>
         <translation>&amp;Точки зору</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="398"/>
         <source>Projection</source>
         <translation>Проекція</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="432"/>
+        <location filename="../common/lc_mainwindow.cpp" line="402"/>
         <source>Sh&amp;ading</source>
         <translation>За&amp;тінення</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="437"/>
-        <location filename="../common/lc_mainwindow.cpp" line="674"/>
+        <location filename="../common/lc_mainwindow.cpp" line="407"/>
+        <location filename="../common/lc_mainwindow.cpp" line="645"/>
         <source>Tools</source>
         <translation>Інтструменти</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="456"/>
+        <location filename="../common/lc_mainwindow.cpp" line="426"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="464"/>
+        <location filename="../common/lc_mainwindow.cpp" line="434"/>
         <source>&amp;Import</source>
         <translation>&amp;Імпорт</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="467"/>
+        <location filename="../common/lc_mainwindow.cpp" line="437"/>
         <source>&amp;Export</source>
         <translation>&amp;Експорт</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="488"/>
+        <location filename="../common/lc_mainwindow.cpp" line="458"/>
         <source>&amp;Edit</source>
         <translation>&amp;Редагувати</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="512"/>
+        <location filename="../common/lc_mainwindow.cpp" line="482"/>
         <source>&amp;View</source>
         <translation>&amp;Вигляд</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="521"/>
+        <location filename="../common/lc_mainwindow.cpp" line="491"/>
         <source>Ste&amp;p</source>
         <translation>Кр&amp;ок</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="506"/>
         <source>T&amp;oolbars</source>
         <translation>&amp;Панелі інструментів</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="549"/>
+        <location filename="../common/lc_mainwindow.cpp" line="519"/>
         <source>&amp;Piece</source>
         <translation>&amp;Блок</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="575"/>
+        <location filename="../common/lc_mainwindow.cpp" line="546"/>
         <source>Sub&amp;model</source>
         <translation>Під&amp;модель</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="583"/>
+        <location filename="../common/lc_mainwindow.cpp" line="554"/>
         <source>&amp;Help</source>
         <translation>&amp;Довідка</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="597"/>
-        <location filename="../common/lc_mainwindow.cpp" line="601"/>
+        <location filename="../common/lc_mainwindow.cpp" line="568"/>
+        <location filename="../common/lc_mainwindow.cpp" line="572"/>
         <source>Selection Mode</source>
         <translation>Режим виділення</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="602"/>
+        <location filename="../common/lc_mainwindow.cpp" line="573"/>
         <source>Change selection mode</source>
         <translation>Змінити режим виділення</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="614"/>
+        <location filename="../common/lc_mainwindow.cpp" line="585"/>
         <source>Transform Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="618"/>
+        <location filename="../common/lc_mainwindow.cpp" line="589"/>
         <source>Snap XY</source>
         <translation>Прилипання XY</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="622"/>
+        <location filename="../common/lc_mainwindow.cpp" line="593"/>
         <source>Snap Z</source>
         <translation>Прилипання Z</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="626"/>
+        <location filename="../common/lc_mainwindow.cpp" line="597"/>
         <source>Snap Menu</source>
         <translation>Меню прилипання</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="632"/>
+        <location filename="../common/lc_mainwindow.cpp" line="603"/>
         <source>Movement Snap</source>
         <translation>Прилипання переміщення</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="633"/>
+        <location filename="../common/lc_mainwindow.cpp" line="604"/>
         <source>Snap translations to fixed intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="637"/>
+        <location filename="../common/lc_mainwindow.cpp" line="608"/>
         <source>Snap Angle Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="643"/>
+        <location filename="../common/lc_mainwindow.cpp" line="614"/>
         <source>Rotation Snap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="644"/>
+        <location filename="../common/lc_mainwindow.cpp" line="615"/>
         <source>Snap rotations to fixed intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="648"/>
+        <location filename="../common/lc_mainwindow.cpp" line="619"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="666"/>
+        <location filename="../common/lc_mainwindow.cpp" line="637"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="696"/>
+        <location filename="../common/lc_mainwindow.cpp" line="667"/>
         <source>Parts</source>
         <translation type="unfinished">Блоків</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="702"/>
+        <location filename="../common/lc_mainwindow.cpp" line="673"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="731"/>
+        <location filename="../common/lc_mainwindow.cpp" line="702"/>
         <source>Properties</source>
         <translation type="unfinished">Властивості</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="766"/>
+        <location filename="../common/lc_mainwindow.cpp" line="737"/>
         <source>Timeline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
-        <source>Part preview for &apos;%1&apos; failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_mainwindow.cpp" line="814"/>
-        <location filename="../common/lc_mainwindow.cpp" line="815"/>
+        <location filename="../common/lc_mainwindow.cpp" line="784"/>
+        <location filename="../common/lc_mainwindow.cpp" line="785"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1031"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1001"/>
         <source>Close Other Tabs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1113"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1083"/>
         <source>The file &apos;%1&apos; has been modified by another application, do you want to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="1119"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1089"/>
         <source>File Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2058"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1985"/>
         <source>%1 (ID: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../common/lc_mainwindow.cpp" line="2064"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1991"/>
         <source>%n Object(s) selected</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -4888,198 +4928,197 @@ Please visit https://www.leocad.org for information on how to download and insta
         </translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2068"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1995"/>
         <source> - %1 (ID: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2072"/>
+        <location filename="../common/lc_mainwindow.cpp" line="1999"/>
         <source> in group &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2110"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2037"/>
         <source>Step %1</source>
         <translation type="unfinished">Крок %1</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2168"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2095"/>
         <source>&amp;Undo %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2173"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2100"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2179"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2106"/>
         <source>&amp;Redo %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2184"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2111"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2384"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2311"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Supported Files (*.lcd *.ldr *.dat *.mpd);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2428"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2355"/>
         <source>Merge Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>LeoCAD</source>
         <translation type="unfinished">LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2371"/>
         <source>Merged 1 submodel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2446"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2373"/>
         <source>Merged %1 submodels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2459"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2386"/>
         <source>LEGO Diginal Designer Files (*.lxf);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.mpd);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2505"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2432"/>
         <source>Supported Files (*.ldr *.dat *.mpd);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="807"/>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Error</source>
         <translation type="unfinished">Помилка</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Rel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2146"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2073"/>
         <source>Abs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2147"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2074"/>
         <source> M: %1 %2 R: %3 %4 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2517"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2444"/>
         <source>Saving files in LCD format is no longer supported, please use the LDR or MPD formats instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.cpp" line="2536"/>
+        <location filename="../common/lc_mainwindow.cpp" line="2463"/>
         <source>Save changes to &apos;%1&apos;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>0</source>
         <translation type="unfinished">8x {0?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/20S</source>
         <translation type="unfinished">8x {1/20S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/4S</source>
         <translation type="unfinished">8x {1/4S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1F</source>
         <translation type="unfinished">8x {1F?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1/2S</source>
         <translation type="unfinished">8x {1/2S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1S</source>
         <translation type="unfinished">8x {1S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>2S</source>
         <translation type="unfinished">8x {2S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>3S</source>
         <translation type="unfinished">8x {3S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>4S</source>
         <translation type="unfinished">8x {4S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="151"/>
+        <location filename="../common/lc_mainwindow.h" line="130"/>
         <source>8S</source>
         <translation type="unfinished">8x {8S?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="152"/>
-        <location filename="../common/lc_mainwindow.h" line="158"/>
-        <location filename="../common/lc_mainwindow.h" line="163"/>
+        <location filename="../common/lc_mainwindow.h" line="131"/>
+        <location filename="../common/lc_mainwindow.h" line="137"/>
+        <location filename="../common/lc_mainwindow.h" line="142"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>1B</source>
         <translation type="unfinished">8x {1B?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>2B</source>
         <translation type="unfinished">8x {2B?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>4B</source>
         <translation type="unfinished">8x {4B?}</translation>
     </message>
     <message>
-        <location filename="../common/lc_mainwindow.h" line="157"/>
+        <location filename="../common/lc_mainwindow.h" line="136"/>
         <source>8B</source>
         <translation type="unfinished">8x {8B?}</translation>
     </message>
@@ -5192,130 +5231,130 @@ Please visit https://www.leocad.org for information on how to download and insta
 <context>
     <name>lcModel</name>
     <message>
-        <location filename="../common/lc_model.cpp" line="957"/>
-        <location filename="../common/lc_model.cpp" line="1831"/>
+        <location filename="../common/lc_model.cpp" line="954"/>
+        <location filename="../common/lc_model.cpp" line="1834"/>
         <source>Group #</source>
         <translation>Група #</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1100"/>
+        <location filename="../common/lc_model.cpp" line="1097"/>
         <source>Cutting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1146"/>
+        <location filename="../common/lc_model.cpp" line="1143"/>
         <source>Pasting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1219"/>
+        <location filename="../common/lc_model.cpp" line="1216"/>
         <source>Duplicating Pieces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="2531"/>
-        <location filename="../common/lc_model.cpp" line="4307"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>LeoCAD</source>
         <translation>LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1273"/>
-        <location filename="../common/lc_model.cpp" line="1352"/>
+        <location filename="../common/lc_model.cpp" line="1270"/>
+        <location filename="../common/lc_model.cpp" line="1349"/>
         <source>Error creating images.</source>
         <translation>Помилка створення зображення.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1539"/>
+        <location filename="../common/lc_model.cpp" line="1536"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation>Помилка запису у файл &apos;%1&apos;:
 %2</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1765"/>
+        <location filename="../common/lc_model.cpp" line="1768"/>
         <source>Inserting Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1784"/>
+        <location filename="../common/lc_model.cpp" line="1787"/>
         <source>Removing Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1827"/>
-        <location filename="../common/lc_model.cpp" line="4325"/>
+        <location filename="../common/lc_model.cpp" line="1830"/>
+        <location filename="../common/lc_model.cpp" line="4344"/>
         <source>No pieces selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1850"/>
-        <location filename="../common/lc_model.cpp" line="1916"/>
+        <location filename="../common/lc_model.cpp" line="1853"/>
+        <location filename="../common/lc_model.cpp" line="1919"/>
         <source>Grouping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1886"/>
-        <location filename="../common/lc_model.cpp" line="1931"/>
+        <location filename="../common/lc_model.cpp" line="1889"/>
+        <location filename="../common/lc_model.cpp" line="1934"/>
         <source>Ungrouping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="1977"/>
+        <location filename="../common/lc_model.cpp" line="1980"/>
         <source>Editing Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2176"/>
+        <location filename="../common/lc_model.cpp" line="2179"/>
         <source>Adding Piece</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2218"/>
+        <location filename="../common/lc_model.cpp" line="2221"/>
         <source>Resetting Cameras</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2229"/>
-        <location filename="../common/lc_model.cpp" line="4131"/>
+        <location filename="../common/lc_model.cpp" line="2232"/>
+        <location filename="../common/lc_model.cpp" line="4149"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2258"/>
+        <location filename="../common/lc_model.cpp" line="2261"/>
         <source>Removing Key Frames</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2275"/>
-        <location filename="../common/lc_model.cpp" line="2292"/>
-        <location filename="../common/lc_model.cpp" line="2334"/>
-        <location filename="../common/lc_model.cpp" line="2379"/>
-        <location filename="../common/lc_model.cpp" line="2414"/>
+        <location filename="../common/lc_model.cpp" line="2278"/>
+        <location filename="../common/lc_model.cpp" line="2295"/>
+        <location filename="../common/lc_model.cpp" line="2337"/>
+        <location filename="../common/lc_model.cpp" line="2382"/>
+        <location filename="../common/lc_model.cpp" line="2417"/>
         <source>Modifying</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2482"/>
+        <location filename="../common/lc_model.cpp" line="2485"/>
         <source>New Model</source>
         <translation type="unfinished">Нова модель</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2531"/>
+        <location filename="../common/lc_model.cpp" line="2534"/>
         <source>No models selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="2535"/>
+        <location filename="../common/lc_model.cpp" line="2538"/>
         <source>Inlining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5336,7 +5375,7 @@ Please visit https://www.leocad.org for information on how to download and insta
     </message>
     <message>
         <location filename="../common/lc_model.cpp" line="2844"/>
-        <location filename="../common/lc_model.cpp" line="4145"/>
+        <location filename="../common/lc_model.cpp" line="4163"/>
         <source>Painting</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5373,113 +5412,113 @@ Please visit https://www.leocad.org for information on how to download and insta
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3723"/>
-        <location filename="../common/lc_model.cpp" line="3746"/>
+        <location filename="../common/lc_model.cpp" line="3741"/>
+        <location filename="../common/lc_model.cpp" line="3764"/>
         <source>Hide</source>
         <translation type="unfinished">Приховати</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3769"/>
-        <location filename="../common/lc_model.cpp" line="3792"/>
+        <location filename="../common/lc_model.cpp" line="3787"/>
+        <location filename="../common/lc_model.cpp" line="3810"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3834"/>
+        <location filename="../common/lc_model.cpp" line="3852"/>
         <source>Replacing Part</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3939"/>
+        <location filename="../common/lc_model.cpp" line="3957"/>
         <source>New SpotLight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3944"/>
+        <location filename="../common/lc_model.cpp" line="3962"/>
         <source>New Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3951"/>
+        <location filename="../common/lc_model.cpp" line="3969"/>
         <source>Move</source>
         <translation type="unfinished">Перемістити</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3955"/>
+        <location filename="../common/lc_model.cpp" line="3973"/>
         <source>Rotate</source>
         <translation type="unfinished">Покрутити</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3965"/>
-        <location filename="../common/lc_model.cpp" line="4206"/>
-        <location filename="../common/lc_model.cpp" line="4266"/>
-        <location filename="../common/lc_model.cpp" line="4278"/>
+        <location filename="../common/lc_model.cpp" line="3983"/>
+        <location filename="../common/lc_model.cpp" line="4224"/>
+        <location filename="../common/lc_model.cpp" line="4284"/>
+        <location filename="../common/lc_model.cpp" line="4296"/>
         <source>Zoom</source>
         <translation type="unfinished">Масштабувати</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3970"/>
+        <location filename="../common/lc_model.cpp" line="3988"/>
         <source>Pan</source>
         <translation type="unfinished">Подвинути</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3975"/>
+        <location filename="../common/lc_model.cpp" line="3993"/>
         <source>Orbit</source>
         <translation type="unfinished">Прокрутити</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="3980"/>
+        <location filename="../common/lc_model.cpp" line="3998"/>
         <source>Roll</source>
         <translation type="unfinished">Нахилити</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4002"/>
+        <location filename="../common/lc_model.cpp" line="4020"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4012"/>
+        <location filename="../common/lc_model.cpp" line="4030"/>
         <source>New Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4229"/>
+        <location filename="../common/lc_model.cpp" line="4247"/>
         <source>Look At</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4239"/>
+        <location filename="../common/lc_model.cpp" line="4257"/>
         <source>Moving Camera</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4300"/>
+        <location filename="../common/lc_model.cpp" line="4319"/>
         <source>Changing Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4307"/>
+        <location filename="../common/lc_model.cpp" line="4326"/>
         <source>Nothing to select.</source>
         <translation>Немає чого обирати.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4336"/>
+        <location filename="../common/lc_model.cpp" line="4355"/>
         <source>Array only has 1 element or less, no pieces added.</source>
         <translatorcomment>Уточнити</translatorcomment>
         <translation>Масив містить лише 1 елемент або й менше, не додано блоків.</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4390"/>
+        <location filename="../common/lc_model.cpp" line="4409"/>
         <source>Array</source>
         <translation>Масив</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4402"/>
+        <location filename="../common/lc_model.cpp" line="4421"/>
         <source>Minifig #</source>
         <translation>Мініфігура #</translation>
     </message>
     <message>
-        <location filename="../common/lc_model.cpp" line="4424"/>
+        <location filename="../common/lc_model.cpp" line="4443"/>
         <source>Minifig</source>
         <translation>Мініфігура</translation>
     </message>
@@ -5645,17 +5684,17 @@ Please visit https://www.leocad.org for information on how to download and insta
         <translation type="vanished">Зафіксувати колір попереднього перегляду</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="524"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="551"/>
         <source>Add to Palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="535"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="562"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="539"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="566"/>
         <source>Remove from Palette</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5663,77 +5702,82 @@ Please visit https://www.leocad.org for information on how to download and insta
 <context>
     <name>lcPartSelectionWidget</name>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="719"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="746"/>
         <source>Search Parts</source>
         <translation>Пошук блоків</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="726"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="753"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="884"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="902"/>
+        <source>Edit Palettes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_partselectionwidget.cpp" line="911"/>
         <source>No Icons</source>
         <translation type="unfinished">Без іконок</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="889"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="916"/>
         <source>Small Icons</source>
         <translation type="unfinished">Малі іконки</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="894"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="921"/>
         <source>Medium Icons</source>
         <translation type="unfinished">Середні іконки</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="899"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="926"/>
         <source>Large Icons</source>
         <translation type="unfinished">Великі іконки</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="904"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="931"/>
         <source>Extra Large Icons</source>
         <translation type="unfinished">Дуже великі іконки</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="914"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="941"/>
         <source>Show Part Names</source>
         <translation type="unfinished">Показувати назви блоків</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="919"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="946"/>
         <source>Show Decorated Parts</source>
         <translation type="unfinished">Показувати декоровані блоки</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="923"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="950"/>
         <source>Show Part Aliases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="929"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="956"/>
         <source>List Mode</source>
         <translation type="unfinished">Режим списку</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="933"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="960"/>
         <source>Lock Preview Color</source>
         <translation type="unfinished">Зафіксувати колір попереднього перегляду</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="975"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1002"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1091"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1118"/>
         <source>All Parts</source>
         <translation>Усі блоки</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1097"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1124"/>
         <source>In Use</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5742,7 +5786,7 @@ Please visit https://www.leocad.org for information on how to download and insta
         <translation type="vanished">Використані блоки</translation>
     </message>
     <message>
-        <location filename="../common/lc_partselectionwidget.cpp" line="1103"/>
+        <location filename="../common/lc_partselectionwidget.cpp" line="1130"/>
         <source>Submodels</source>
         <translation>Підмоделі</translation>
     </message>
@@ -5750,12 +5794,12 @@ Please visit https://www.leocad.org for information on how to download and insta
 <context>
     <name>lcPiecesLibrary</name>
     <message>
-        <location filename="../common/lc_library.cpp" line="775"/>
+        <location filename="../common/lc_library.cpp" line="782"/>
         <source>Initializing</source>
         <translation>Ініціалізація</translation>
     </message>
     <message>
-        <location filename="../common/lc_library.cpp" line="776"/>
+        <location filename="../common/lc_library.cpp" line="783"/>
         <source>Loading Parts Library</source>
         <translation>Завантаження бібліотеки блоків</translation>
     </message>
@@ -5764,6 +5808,7 @@ Please visit https://www.leocad.org for information on how to download and insta
     <name>lcPreviewDockWidget</name>
     <message>
         <location filename="../common/lc_previewwidget.cpp" line="19"/>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
         <source>Lock Preview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5788,23 +5833,18 @@ Please visit https://www.leocad.org for information on how to download and insta
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Unlock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../common/lc_previewwidget.cpp" line="77"/>
-        <source>Lock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../common/lc_previewwidget.cpp" line="78"/>
-        <source>%1 the preview display to %2 updates</source>
+        <source>Unlock the preview display to enable updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../common/lc_previewwidget.cpp" line="80"/>
-        <source>%1 Preview</source>
+        <location filename="../common/lc_previewwidget.cpp" line="79"/>
+        <source>Lock the preview display to disable updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/lc_previewwidget.cpp" line="81"/>
+        <source>Unlock Preview</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6545,22 +6585,21 @@ GL_EXT_texture_filter_anisotropic extension: %5
         <translation>Відображення</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="359"/>
         <source>Edge lines</source>
-        <translation>Лінії контурів</translation>
+        <translation type="vanished">Лінії контурів</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="439"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
         <source>2x</source>
         <translation>2x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="444"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
         <source>4x</source>
         <translation>4x</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="449"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="454"/>
         <source>8x</source>
         <translation>8x</translation>
     </message>
@@ -6569,7 +6608,7 @@ GL_EXT_texture_filter_anisotropic extension: %5
         <translation type="vanished">Іконка вісей</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="436"/>
         <source>Anti-aliasing</source>
         <translation>Згладжування</translation>
     </message>
@@ -6578,76 +6617,76 @@ GL_EXT_texture_filter_anisotropic extension: %5
         <translation type="vanished">пікселів (ширина)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="409"/>
         <source>Shading Mode:</source>
         <translation>Режим відображення:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="546"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="347"/>
         <source>Wireframe</source>
         <translation>Арматура</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="551"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="352"/>
         <source>Flat Shading</source>
         <translation>Плоске освітлення</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="357"/>
         <source>Default Lights</source>
         <translation>Типове освітлення</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="678"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="745"/>
         <source>Base Grid</source>
         <translation>Базова сітка</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="728"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="795"/>
         <source>Draw studs</source>
         <translation>Відображати контури шипів</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="751"/>
         <source>studs</source>
         <translation>шипів</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="704"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="771"/>
         <source>Draw lines every</source>
         <translation>Відображати лінії кожні</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1111"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1052"/>
         <source>View Sphere</source>
         <translation>Сфера візуалізації</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="615"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="783"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="850"/>
         <source>Disabled</source>
         <translation>Вимкнено</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="620"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="656"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="855"/>
         <source>Small</source>
         <translation>Малий</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="625"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="793"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="661"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="860"/>
         <source>Medium</source>
         <translation>Середній</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="630"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="798"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="666"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="865"/>
         <source>Large</source>
         <translation>Великий</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1145"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1118"/>
         <source>Highlight Color:</source>
         <translation>Колір підсвічування:</translation>
     </message>
@@ -6656,18 +6695,19 @@ GL_EXT_texture_filter_anisotropic extension: %5
         <translation type="vanished">Розмір:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1117"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1058"/>
         <source>Color:</source>
         <translation>Колір:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1131"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1088"/>
         <source>Text Color:</source>
         <translation>Колір тексту:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="600"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="775"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="636"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="711"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="842"/>
         <source>Location:</source>
         <translation>Положення:</translation>
     </message>
@@ -6762,449 +6802,512 @@ GL_EXT_texture_filter_anisotropic extension: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="429"/>
         <source>Stud Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="394"/>
-        <source>Fade previous steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="476"/>
         <source>Mesh LOD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="431"/>
         <source>Highlight new parts</source>
-        <translation type="unfinished">Підсвічувати нові блоки</translation>
+        <translation type="obsolete">Підсвічувати нові блоки</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="465"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="366"/>
         <source>Plain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="470"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="371"/>
         <source>Thin Lines Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="475"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="376"/>
         <source>Outline Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="381"/>
         <source>Sharp Top Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="386"/>
         <source>Rounded Top Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="490"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="391"/>
         <source>Flattened Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="495"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="396"/>
         <source>High Contrast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="500"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="401"/>
         <source>High Contrast with Logo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="524"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
         <source>Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="531"/>
-        <source>Automate edge color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="538"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="339"/>
         <source>Contrast Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="581"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="617"/>
         <source>Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="587"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="623"/>
         <source>Model Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="593"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="744"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="629"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="811"/>
         <source>Axis Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="607"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="806"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="643"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="873"/>
         <source>View Sphere:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="639"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="752"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="675"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="819"/>
         <source>Top Left</source>
         <translation>Вгорі ліворуч</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="644"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="757"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="680"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="724"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="824"/>
         <source>Top Right</source>
         <translation>Вгорі праворуч</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="649"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="762"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="685"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="729"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="829"/>
         <source>Bottom Left</source>
         <translation>Внизу ліворуч</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="654"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="767"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="690"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="734"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="834"/>
         <source>Bottom Right</source>
         <translation>Внизу праворуч</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="721"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="788"/>
         <source>Draw origin lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="805"/>
         <source>Part Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="843"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="910"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="849"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1227"/>
         <source>Background</source>
         <translation type="unfinished">Фон</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="857"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1235"/>
         <source>Top Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="871"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1265"/>
         <source>Bottom Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="900"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
         <source>So&amp;lid Color</source>
         <translation type="unfinished">Су&amp;цільний колір</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="907"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1301"/>
         <source>&amp;Gradient</source>
         <translation type="unfinished">&amp;Градієнт</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="941"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="916"/>
         <source>Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="947"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="936"/>
         <source>Inactive View Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="961"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="978"/>
         <source>Overlay Color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="968"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1026"/>
         <source>Active View Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="989"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="950"/>
         <source>Camera Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1016"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="985"/>
         <source>Axis Icon Labels:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1030"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="922"/>
         <source>Marquee Border:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1044"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="469"/>
+        <source>Highlight New Parts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="506"/>
+        <source>Fade Previous Steps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="523"/>
+        <source>Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="536"/>
+        <source>Conditional Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="556"/>
+        <source>Line Width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="579"/>
+        <source>Edge Lines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="586"/>
+        <source>Automate Edge Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="964"/>
         <source>Marquee Fill:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1061"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1161"/>
         <source>Grid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1067"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1167"/>
         <source>Lines:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1197"/>
         <source>Studs:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1189"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1230"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1335"/>
+        <source>Objects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1341"/>
+        <source>Light:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1371"/>
+        <source>Focused:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1385"/>
+        <source>Control Point Focused:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1420"/>
+        <source>Control Point:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1427"/>
+        <source>Selected:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1434"/>
+        <source>Camera:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1458"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1499"/>
         <source>Categories</source>
         <translation>Категорії</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1195"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1464"/>
         <source>Parts Library Categories</source>
         <translation>Категорії бібліотеки блоків</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1264"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1533"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1538"/>
         <source>Number</source>
         <translation>Номер</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1280"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1408"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1541"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1549"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1677"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1810"/>
         <source>Import...</source>
         <translation>Імпортувати...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1287"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1415"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1548"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1556"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1684"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1817"/>
         <source>Export...</source>
         <translation>Експортувати...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1294"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1422"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1555"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1563"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1691"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1824"/>
         <source>Reset...</source>
         <translation>Скинути...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1319"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1588"/>
         <source>Category</source>
         <translation>Категорія</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1325"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1594"/>
         <source>New...</source>
         <translation>Нова...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1332"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1601"/>
         <source>Edit...</source>
         <translation>Редагувати...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1339"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1608"/>
         <source>Delete...</source>
         <translation>Видалити...</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1363"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1632"/>
         <source>Keyboard</source>
         <translation>Клавіатура</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1373"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1642"/>
         <source>Keyboard Shortcuts</source>
         <translation>Комбінації клавіш клавіатури</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1386"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1655"/>
         <source>Command</source>
         <translation>Команда</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1391"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1450"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1584"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1660"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1719"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1853"/>
         <source>Shortcut</source>
         <translation>Комбінація клавіш</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1399"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1668"/>
         <source>Search shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1456"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1725"/>
         <source>Key se&amp;quence:</source>
         <translation>&amp;Послідовність клавіш:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1469"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1651"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1738"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1920"/>
         <source>Assign</source>
         <translation>Встановити</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1476"/>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1658"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1745"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1927"/>
         <source>Remove</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1498"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1767"/>
         <source>Mouse</source>
         <translation>Миша</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1506"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1775"/>
         <source>Mouse Shortcuts</source>
         <translation>Комбінації клавіш миші</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1521"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1790"/>
         <source>Action</source>
         <translation>Дія</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1526"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1795"/>
         <source>Shortcut 1</source>
         <translation>Комбінація клавіш 1</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1531"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1800"/>
         <source>Shortcut 2</source>
         <translation>Комбінація клавіш 2</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1592"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1861"/>
         <source>Button:</source>
         <translation>Клавіша:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1600"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1869"/>
         <source>None</source>
         <translation>Немає</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1605"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1874"/>
         <source>Left</source>
         <translation>Вліво</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1610"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1879"/>
         <source>Middle</source>
         <translation>Середня</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1615"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1884"/>
         <source>Right</source>
         <translation>Вправо</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1623"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1892"/>
         <source>Modifiers:</source>
         <translation>Модифікатори:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1630"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1899"/>
         <source>Control</source>
         <translation>Ctrl</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1637"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1906"/>
         <source>Alt</source>
         <translation>Alt</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1644"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1913"/>
         <source>Shift</source>
         <translation>Shift</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.ui" line="1672"/>
+        <location filename="../qt/lc_qpreferencesdialog.ui" line="1941"/>
         <source>Mouse sensitivity:</source>
         <translation>Чутливість миші:</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="242"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="263"/>
         <source>Grid spacing must be greater than 0.</source>
         <translation>Розмір клітинок сітки має бути більше 0.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="331"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="354"/>
         <source>Select Parts Library Folder</source>
         <translation>Оберіть теку з бібліотекою блоків</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Select Parts Library Archive</source>
         <translation>Оберіть архів з бібліотекою блоків</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="339"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="362"/>
         <source>Supported Archives (*.zip *.bin);;All Files (*.*)</source>
         <translation>Підтримувані архіви (*.zip *.bin);;Усі файли (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Select Color Configuration File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="347"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="370"/>
         <source>Settings Files (*.ldr);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Select Minifig Settings File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="355"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="378"/>
         <source>Settings Files (*.ini);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="364"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
         <source>Executable Files (*.exe);;All Files (*.*)</source>
         <translation>Виконувані файли (*.exe);;Усі файли (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="366"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="389"/>
         <source>All Files (*.*)</source>
         <translation>Усі файли (*.*)</translation>
     </message>
@@ -7213,235 +7316,265 @@ GL_EXT_texture_filter_anisotropic extension: %5
         <translation type="vanished">Показати розташування програми POV-Ray</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="377"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="400"/>
         <source>Open LGEO Folder</source>
         <translation>Показати розташування теки LGEO</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Reset Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="387"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="410"/>
         <source>Would you like to also reset the interface colors to match the color theme?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="401"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="424"/>
         <source>Select Background Color</source>
         <translation type="unfinished">Визначте колір фону</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="406"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="429"/>
         <source>Select Gradient Top Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="411"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="434"/>
         <source>Select Gradient Bottom Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="416"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="439"/>
         <source>Select Axes Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="421"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="444"/>
         <source>Select Text Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="426"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="449"/>
         <source>Select Marquee Border Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="431"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="454"/>
         <source>Select Marquee Fill Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="437"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="460"/>
         <source>Select Overlay Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="442"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="465"/>
         <source>Select Active View Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="447"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="470"/>
         <source>Select Inactive View Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="452"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="475"/>
         <source>Select Fade Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="458"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="481"/>
         <source>Select Highlight Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="464"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="487"/>
         <source>Select Grid Stud Color</source>
         <translation>Визначте колір контурів шипів сітки</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="470"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="493"/>
         <source>Select Grid Line Color</source>
         <translation>Визначте колір ліній сітки</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="475"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="498"/>
         <source>Select View Sphere Color</source>
         <translation>Визначте колір сфери візуалізації</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="480"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="503"/>
         <source>Select View Sphere Text Color</source>
         <translation>Визначте колір тексту сфери візуалізації</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="485"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="508"/>
         <source>Select View Sphere Highlight Color</source>
         <translation>Визначте колір підсвічування сфери візуалізації</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="596"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="513"/>
+        <source>Select Object Selected Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="518"/>
+        <source>Select Object Focused Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="523"/>
+        <source>Select Camera Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="528"/>
+        <source>Select Light Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="533"/>
+        <source>Select Control Point Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="539"/>
+        <source>Select Control Point Focused Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="661"/>
         <source>Unassigned</source>
         <translation>Не встановлено</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="710"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="775"/>
         <source>Are you sure you want to delete the category &apos;%1&apos;?</source>
         <translation>Ви впевнені що хочете видалити категорію &apos;%1&apos;?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
         <source>Import Categories</source>
         <translation>Імпортувати категорії</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="723"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="788"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Text Files (*.txt);;All Files (*.*)</source>
         <translation>Текстові файли (*.txt);;Усі файли (*.*)</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="731"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="796"/>
         <source>Error loading categories file.</source>
         <translation>Помилка завантаження файла категорій.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="742"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="807"/>
         <source>Export Categories</source>
         <translation>Експортувати категорії</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="749"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="814"/>
         <source>Error saving categories file.</source>
         <translation>Помилка збереження файла категорій.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="756"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="821"/>
         <source>Are you sure you want to load the default categories?</source>
         <translation>Ви впевнені що хочете встановити типові категорії?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="957"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1022"/>
         <source>The shortcut &apos;%1&apos; is already assigned to &apos;%2&apos;. Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1012"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
         <source>Import shortcuts</source>
         <translation>Імпортувати комбінації клавіш</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1020"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1085"/>
         <source>Error loading keyboard shortcuts file.</source>
         <translation>Помилка завантаження файла комбінацій клавіш.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1032"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1097"/>
         <source>Export shortcuts</source>
         <translation>Експортувати комбінації клавіш</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1039"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1104"/>
         <source>Error saving keyboard shortcuts file.</source>
         <translation>Помилка збереження файла комбінацій клавіш.</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1046"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1111"/>
         <source>Are you sure you want to load the default keyboard shortcuts?</source>
         <translation>Ви впевнені що хочете встановити типові комбінації клавіш клавіатури?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1073"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1138"/>
         <source>Left Button</source>
         <translation>Клавіша вліво</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1077"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1142"/>
         <source>Middle Button</source>
         <translation>Середня клавіша миші</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1081"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1146"/>
         <source>Right Button</source>
         <translation>Кнопка вправо</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="959"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1024"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>Override Shortcut</source>
         <translation>Перезаписати комбінації клавіш</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="369"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="392"/>
         <source>Select POV-Ray Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1148"/>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1157"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1213"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1222"/>
         <source>This shortcut is already assigned to &apos;%1&apos;, do you want to replace it?</source>
         <translation>Ця комбінаця клавіш вже використовується для &apos;%1&apos;. Ви хочете замінити її?</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1204"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1269"/>
         <source>Import Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1212"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1277"/>
         <source>Error loading mouse shortcuts file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1225"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1290"/>
         <source>Export Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1231"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1296"/>
         <source>Error saving mouse shortcuts file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1236"/>
+        <location filename="../qt/lc_qpreferencesdialog.cpp" line="1301"/>
         <source>Are you sure you want to load the default mouse shortcuts?</source>
         <translation>Ви впевнені що хочете встановити типові комбінації клавіш миші?</translation>
     </message>
@@ -7472,6 +7605,11 @@ GL_EXT_texture_filter_anisotropic extension: %5
         <location filename="../qt/lc_qpropertiesdialog.ui" line="56"/>
         <source>Comments:</source>
         <translation>Коментарі:</translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="76"/>
+        <source>Measurements:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scene</source>
@@ -7506,7 +7644,7 @@ GL_EXT_texture_filter_anisotropic extension: %5
         <translation type="vanished">Встановити типовими властивостями для нових проектів</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.ui" line="77"/>
+        <location filename="../qt/lc_qpropertiesdialog.ui" line="91"/>
         <source>Parts Used</source>
         <translation>Використані блоки</translation>
     </message>
@@ -7516,13 +7654,20 @@ GL_EXT_texture_filter_anisotropic extension: %5
         <translation>Властивості %1</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="62"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="51"/>
+        <source>%1 x %2 x %3 cm
+%4 x %5 x %6 inches
+%7 x %8 x %9 LDU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="70"/>
         <source>Part</source>
         <translation>Блок</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="73"/>
-        <location filename="../qt/lc_qpropertiesdialog.cpp" line="110"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="81"/>
+        <location filename="../qt/lc_qpropertiesdialog.cpp" line="118"/>
         <source>Total</source>
         <translation>Усього</translation>
     </message>
@@ -7560,40 +7705,40 @@ GL_EXT_texture_filter_anisotropic extension: %5
         <translation>Значення</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="886"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1018"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="895"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1027"/>
         <source>Position</source>
         <translation>Позиція</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="887"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="892"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1019"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1024"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="888"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="893"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1020"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1025"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1029"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1039"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="889"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="894"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1021"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1026"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1031"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="903"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1030"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1040"/>
         <source>Z</source>
         <translation>Z</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="891"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
         <source>Rotation</source>
         <translation>Обертання</translation>
     </message>
@@ -7602,73 +7747,73 @@ GL_EXT_texture_filter_anisotropic extension: %5
         <translation type="vanished">Видимість</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="896"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="905"/>
         <source>Visible Steps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="897"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="906"/>
         <source>Show</source>
         <translation>Відображати</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="898"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="907"/>
         <source>Hide</source>
         <translation>Приховати</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="900"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="909"/>
         <source>Appearance</source>
         <translation>Зовнішній вигляд</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="901"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="910"/>
         <source>Color</source>
         <translation>Колір</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="902"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="911"/>
         <source>Part</source>
         <translation>Блок</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1023"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1032"/>
         <source>Target</source>
         <translation>Ціль</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1028"/>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1033"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1042"/>
         <source>Up</source>
         <translation>Верх</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1034"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1043"/>
         <source>Orthographic</source>
         <translation>Ортографічна</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1035"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1044"/>
         <source>FOV</source>
         <translation>Фокусна відстань</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1036"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1045"/>
         <source>Near</source>
         <translation>Мінімум</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1037"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1046"/>
         <source>Far</source>
         <translation>Максимум</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1038"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1047"/>
         <source>Name</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location filename="../qt/lc_qpropertiestree.cpp" line="1118"/>
+        <location filename="../qt/lc_qpropertiestree.cpp" line="1127"/>
         <source>Multiple Objects Selected</source>
         <translation>Обрано кілька об&apos;єктів</translation>
     </message>
@@ -7960,22 +8105,22 @@ GL_EXT_texture_filter_anisotropic extension: %5
 <context>
     <name>lcView</name>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>LeoCAD</source>
         <translation type="unfinished">LeoCAD</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="755"/>
+        <location filename="../common/lc_view.cpp" line="665"/>
         <source>Error creating images.</source>
         <translation type="unfinished">Помилка створення зображення.</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error</source>
         <translation type="unfinished">Помилка</translation>
     </message>
     <message>
-        <location filename="../common/lc_view.cpp" line="800"/>
+        <location filename="../common/lc_view.cpp" line="710"/>
         <source>Error writing to file &apos;%1&apos;:
 %2</source>
         <translation type="unfinished">Помилка запису у файл &apos;%1&apos;:


### PR DESCRIPTION
Hi!

I started to use LeoCAD some days ago and I noticed that the spanish translation had missing, wrong or just non-sense translations. I respected most of them while tried to sound natural and preserve the coherence when reading those translations in spanish.

This PR mainly

- makes remaining strings in the code localizable: 60281248ade3329d372af38594f3cb7e3c37e955
- improves the ES translation: 88bbeefba2fc7f923ef06abbe313ad84e3a85842
- updates the TS files for the rest of languages: 176e3006aba7302dccac1e375552e0f95d545007