### PR TITLE
Unofficial project part

### DIFF
--- a/common/lc_library.cpp
+++ b/common/lc_library.cpp
@@ -164,7 +164,7 @@ PieceInfo* lcPiecesLibrary::FindPiece(const char* PieceName, Project* CurrentPro
 	{
 		PieceInfo* Info = PieceIt->second;
 
-		if ((!CurrentProject || !Info->IsModel() || CurrentProject->GetModels().FindIndex(Info->GetModel()) != -1) && (!ProjectPath.isEmpty() || !Info->IsProject()))
+		if ((!CurrentProject || !Info->IsModel() || CurrentProject->GetModels().FindIndex(Info->GetModel()) != -1) && (!ProjectPath.isEmpty() || !Info->IsProject() || Info->IsProjectPiece()))
 			return Info;
 	}
 

--- a/common/lc_partselectionwidget.cpp
+++ b/common/lc_partselectionwidget.cpp
@@ -266,7 +266,7 @@ void lcPartSelectionListModel::SetFilter(const QString& Filter)
 		PieceInfo* Info = mParts[PartIdx].first;
 		bool Visible;
 
-		if (!mShowDecoratedParts && Info->IsPatterned())
+		if (!mShowDecoratedParts && Info->IsPatterned() && !Info->IsProjectPiece())
 			Visible = false;
 		else if (!mShowPartAliases && Info->m_strDescription[0] == '=')
 			Visible = false;

--- a/common/lc_previewwidget.cpp
+++ b/common/lc_previewwidget.cpp
@@ -93,7 +93,8 @@ lcPreview::lcPreview()
 bool lcPreview::SetCurrentPiece(const QString& PartType, int ColorCode)
 {
 	lcPiecesLibrary* Library = lcGetPiecesLibrary();
-	PieceInfo* Info = Library->FindPiece(PartType.toLatin1().constData(), nullptr, false, false);
+	Project* CurrentProject = lcGetActiveProject();
+	PieceInfo* Info = Library->FindPiece(PartType.toLatin1().constData(), CurrentProject, false, true);
 
 	if (Info)
 	{

--- a/common/lc_previewwidget.cpp
+++ b/common/lc_previewwidget.cpp
@@ -93,8 +93,7 @@ lcPreview::lcPreview()
 bool lcPreview::SetCurrentPiece(const QString& PartType, int ColorCode)
 {
 	lcPiecesLibrary* Library = lcGetPiecesLibrary();
-	Project* CurrentProject = lcGetActiveProject();
-	PieceInfo* Info = Library->FindPiece(PartType.toLatin1().constData(), CurrentProject, false, true);
+	PieceInfo* Info = Library->FindPiece(PartType.toLatin1().constData(), nullptr, false, false);
 
 	if (Info)
 	{

--- a/common/pieceinf.cpp
+++ b/common/pieceinf.cpp
@@ -112,6 +112,13 @@ void PieceInfo::CreateProject(Project* Project, const char* PieceName)
 	m_strDescription[sizeof(m_strDescription) - 1] = 0;
 }
 
+bool PieceInfo::IsProjectPiece() const
+{
+	if (mProject)
+		return !strcmp(m_strDescription, mProject->GetFileName().toLatin1().data());
+	return false;
+}
+
 bool PieceInfo::GetPieceWorldMatrix(lcPiece* Piece, lcMatrix44& WorldMatrix) const
 {
 	if (IsModel())
@@ -346,7 +353,7 @@ void PieceInfo::GetPartsList(int DefaultColorIndex, bool ScanSubModels, bool Add
 		if (AddSubModels)
 			PartsList[this][DefaultColorIndex]++;
 	}
-	else if (IsProject())
+	else if (IsProject() && !IsProjectPiece())
 	{
 		const lcModel* const Model = mProject->GetMainModel();
 		if (Model)

--- a/common/pieceinf.h
+++ b/common/pieceinf.h
@@ -158,6 +158,7 @@ public:
 		return (m_strDescription[0] == '~');
 	}
 
+	bool IsProjectPiece() const;
 	void ZoomExtents(float FoV, float AspectRatio, lcMatrix44& ProjectionMatrix, lcMatrix44& ViewMatrix) const;
 	void AddRenderMesh(lcScene& Scene);
 	void AddRenderMeshes(lcScene* Scene, const lcMatrix44& WorldMatrix, int ColorIndex, lcRenderMeshState RenderMeshState, bool ParentActive) const;


### PR DESCRIPTION
This update improves the display of project parts.

A project part is defined as a part file residing in the project folder that does not contain the `0 FILE...` LDraw header meta command. Typically, this type of file will have an extension of `.dat` or `.ldr`. 

A model file collection in this configuration will successfully load into LeoCAD with some limitations.

Currently, LeoCAD will not display this type of file in the preview dialogue because the _FindPiece_ lookup routine will ignore _project_ parts unless the search project folder flag is set to true. As the part is already in the library, the search project folder flag is not set to true when looking up preview items.

Secondly, _project_ parts will only display in the _all parts_ category, because instead of being added to the part selection list, its constituent parts will be processed and added instead. Basically, the parent is ignored as it is a _project_ and only the children are added to the part selection list. This behaviour is inconsistent because while the constitutent parts are displayed in the part selection dialogue, those parts are not indvidually selectable within the loaded model. As the model is treated as a single part, the part selection dialogue should reflect this configuration and display the project part.

Lastly, because project parts may not respect the LDraw part naming convention, a part with letters in the name will not display in the _in use_ category, or any category for that matter, unless the _show decorated parts_ context menu setting is checked.

This PR treats these limitations.

Example:

To reproduce this behaviour, copy and paste the file content below into their respective files and place them together at your designated location. Next, open the model file in LeoCAD and observe the demo part display.

Model file: project_part_demo.ldr

```
0 FILE project_part_demo.ldr
0 project_part_demo
0 Name: project_part_demo.ldr
0 Author: LPub3D [LP3D]
0 !LDRAW_ORG Unofficial_Model
0 ROTATION CENTER 0 0 0 1 "Custom" 
0 ROTATION CONFIG 0 0
1 15 0 0 0 1 0 0 0 1 0 0 0 1 64782.dat
0 STEP
1 15 0 -200 -80 1 0 0 0 1 0 0 0 1 demo_part.dat
0 NOFILE
```

Project part file: demo_part.dat

```
0 demo_part
0 Name: demo_part.dat
0 Author: LPub3D [LP3D]
0 !LDRAW_ORG Unofficial_Part
0 !LICENSE Redistributable under CCAL version 2.0 : see CAreadme.txt

0 BFC CERTIFY CCW

0 !HISTORY 2022-07-05 [LP3D] Initial version

0 ROTATION CENTER 0 0 0 1 "Custom" 
0 ROTATION CONFIG 0 0
1 0 0 -20 0 1 0 0 0 1 0 0 0 1 71709.dat
1 0 80 -20 -20 0 -1 0 1 0 0 0 0 1 32140.dat
1 0 -80 -20 -20 0 -1 0 1 0 0 0 0 1 32140.dat
1 0 100 -20 0 0 1 0 -1 0 0 0 0 1 32316.dat
1 0 -100 -20 0 0 1 0 -1 0 0 0 0 1 32316.dat
1 0 60 80 40 0 1 0 0 0 1 1 0 0 32525.dat
1 0 -60 80 40 0 1 0 0 0 1 1 0 0 32525.dat
1 0 -45 180 40 0 -1 0 -1 0 0 0 0 -1 32056.dat
1 0 -35 180 40 0 -1 0 -1 0 0 0 0 -1 32056.dat
1 0 45 180 40 0 -1 0 -1 0 0 0 0 -1 32056.dat
1 0 35 180 40 0 -1 0 -1 0 0 0 0 -1 32056.dat
0
```

Current display:

Note the demo_part's constitutent parts are displayed for the _in use_ category and the preview is not displayed when the part is selected.

![Screenshot - 06_07_2022 , 13_43_19](https://user-images.githubusercontent.com/13388970/177581913-9455bc73-f427-4d6c-a3e4-87716d53ad48.png)

Corrected display:

![Screenshot - 06_07_2022 , 13_13_34](https://user-images.githubusercontent.com/13388970/177582027-a0e0eba6-3cd3-4dab-a180-eb1b1758dfb7.png)

Cheers,






