### PR TITLE
Improve shortcuts dialog interactive  resize

### DIFF
--- a/qt/lc_qutils.cpp
+++ b/qt/lc_qutils.cpp
@@ -47,40 +47,48 @@ float lcParseValueLocalized(const QString& Value)
 
 // Resize all columns to content except for one stretching column. (taken from QT creator)
 lcQTreeWidgetColumnStretcher::lcQTreeWidgetColumnStretcher(QTreeWidget *treeWidget, int columnToStretch)
-	: QObject(treeWidget->header()), m_columnToStretch(columnToStretch)
+	: QObject(treeWidget->header()), m_columnToStretch(columnToStretch), m_stretchWidth(0)
 {
 	parent()->installEventFilter(this);
+	connect(treeWidget->header(), SIGNAL(sectionResized(int, int, int)), SLOT(sectionResized(int, int, int)));
 	QHideEvent fake;
 	lcQTreeWidgetColumnStretcher::eventFilter(parent(), &fake);
+}
+
+void lcQTreeWidgetColumnStretcher::sectionResized(int LogicalIndex, int OldSize, int NewSize)
+{
+	Q_UNUSED(OldSize)
+
+	if (LogicalIndex == m_columnToStretch)
+		m_stretchWidth = NewSize;
 }
 
 bool lcQTreeWidgetColumnStretcher::eventFilter(QObject* Object, QEvent* Event)
 {
 	if (Object == parent())
 	{
+		QHeaderView* HeaderView = qobject_cast<QHeaderView*>(Object);
+
 		if (Event->type() == QEvent::Show)
 		{
-			QHeaderView* HeaderView = qobject_cast<QHeaderView*>(Object);
-
 			for (int i = 0; i < HeaderView->count(); ++i)
 				HeaderView->setSectionResizeMode(i, QHeaderView::Interactive);
+
+			m_stretchWidth = HeaderView->sectionSize(m_columnToStretch);
+
 		}
 		else if (Event->type() == QEvent::Hide)
 		{
-			QHeaderView* HeaderView = qobject_cast<QHeaderView*>(Object);
-
 			for (int i = 0; i < HeaderView->count(); ++i)
 				HeaderView->setSectionResizeMode(i, i == m_columnToStretch ? QHeaderView::Stretch : QHeaderView::ResizeToContents);
 		}
 		else if (Event->type() == QEvent::Resize)
 		{
-			QHeaderView* HeaderView = qobject_cast<QHeaderView*>(Object);
+			if (HeaderView->sectionResizeMode(m_columnToStretch) == QHeaderView::Interactive) {
 
-			if (HeaderView->sectionResizeMode(m_columnToStretch) == QHeaderView::Interactive)
-			{
-				const QResizeEvent* ResizeEvent = reinterpret_cast<QResizeEvent*>(Event);
-				const int Diff = ResizeEvent->size().width() - ResizeEvent->oldSize().width() ;
-				HeaderView->resizeSection(m_columnToStretch, qMax(32, HeaderView->sectionSize(1) + Diff));
+				const int StretchWidth = HeaderView->isVisible() ? m_stretchWidth : 32;
+
+				HeaderView->resizeSection(m_columnToStretch, StretchWidth);
 			}
 		}
 	}

--- a/qt/lc_qutils.h
+++ b/qt/lc_qutils.h
@@ -20,6 +20,7 @@ private slots:
 
 private:
 	const int m_columnToStretch;
+	bool m_interactiveResize;
 	int m_stretchWidth;
 };
 

--- a/qt/lc_qutils.h
+++ b/qt/lc_qutils.h
@@ -15,7 +15,12 @@ public:
 
 	bool eventFilter(QObject* Object, QEvent* Event) override;
 
+private slots:
+	void sectionResized(int LogicalIndex, int OldSize, int NewSize);
+
+private:
 	const int m_columnToStretch;
+	int m_stretchWidth;
 };
 
 class lcSmallLineEdit : public QLineEdit


### PR DESCRIPTION
This is a small user experience improvement that treats the jumpy column display when interactively resizing the keyboard shortcuts management dialog.

![Screenshot - 07_09_2022 , 17_54_56](https://user-images.githubusercontent.com/13388970/188926082-492d82da-8161-4903-bdd1-1690e52a2b82.png)

Cheers,