### PR TITLE
use std::vector inside lcArray class

### DIFF
--- a/common/lc_array.h
+++ b/common/lc_array.h
@@ -4,201 +4,98 @@ template <class T>
 class lcArray
 {
 public:
-	lcArray(int Size = 0, int Grow = 16)
+	lcArray(int Size = 0)
 	{
-		mData = nullptr;
-		mLength = 0;
-		mAlloc = 0;
-		mGrow = Grow;
-
-		if (Size != 0)
-			AllocGrow(Size);
-	}
-
-	lcArray(const lcArray<T>& Array)
-	{
-		mData = nullptr;
-		*this = Array;
-	}
-
-	~lcArray()
-	{
-		delete[] mData;
-	}
-
-	lcArray<T>& operator=(const lcArray<T>& Array)
-	{
-		mLength = Array.mLength;
-		mAlloc = Array.mAlloc;
-		mGrow = Array.mGrow;
-
-		delete[] mData;
-		mData = new T[mAlloc];
-
-		for (int i = 0; i < mLength; i++)
-			mData[i] = Array.mData[i];
-
-		return *this;
-	}
-
-	lcArray(lcArray<T>&& Array)
-	{
-		mData = nullptr;
-		*this = std::move(Array);
-	}
-
-	lcArray<T>& operator=(lcArray<T>&& Array)
-	{
-		delete[] mData;
-
-		mData = Array.mData;
-		Array.mData = nullptr;
-		mLength = Array.mLength;
-		Array.mLength = 0;
-		mAlloc = Array.mAlloc;
-		Array.mAlloc = 0;
-		mGrow = Array.mGrow;
-		Array.mGrow = 16;
-
-		return *this;
+		if (Size > 0)
+			elements.reserve(Size);
 	}
 
 	const T& operator[](int Index) const
 	{
-		return mData[Index];
+		return elements[Index];
 	}
 
 	T& operator[](int Index)
 	{
-		return mData[Index];
+		return elements[Index];
 	}
 
 	bool operator==(const lcArray<T>& Array) const
 	{
-		if (mLength != Array.mLength)
-			return false;
-
-		for (int i = 0; i < mLength; i++)
-			if (mData[i] != Array.mData[i])
-				return false;
-
-		return true;
+		return elements == Array;
 	}
 
-	T* begin()
+	typename std::vector<T>::iterator begin()
 	{
-		return &mData[0];
+		return elements.begin();
 	}
 
-	T* end()
+	typename std::vector<T>::iterator end()
 	{
-		return &mData[0] + mLength;
+		return elements.end();
 	}
 
-	const T* begin() const
+	typename std::vector<T>::const_iterator begin() const
 	{
-		return &mData[0];
+		return elements.begin();
 	}
 
-	const T* end() const
+	typename std::vector<T>::const_iterator end() const
 	{
-		return &mData[0] + mLength;
+		return elements.end();
 	}
 
 	bool IsEmpty() const
 	{
-		return mLength == 0;
+		return elements.empty();
 	}
 
 	int GetSize() const
 	{
-		return mLength;
+		return elements.size();
 	}
 
 	void SetSize(size_t NewSize)
 	{
-		if (NewSize > mAlloc)
-			AllocGrow(NewSize - mLength);
-
-		mLength = (int)NewSize;
-	}
-
-	void SetGrow(int Grow)
-	{
-		if (Grow)
-			mGrow = Grow;
+		elements.resize(NewSize);
 	}
 
 	void AllocGrow(size_t Grow)
 	{
-		if ((mLength + Grow) > mAlloc)
-		{
-			const size_t NewSize = ((mLength + Grow + mGrow - 1) / mGrow) * mGrow;
-			T* NewData = new T[NewSize];
-
-			for (int i = 0; i < mLength; i++)
-				NewData[i] = mData[i];
-
-			delete[] mData;
-			mData = NewData;
-			mAlloc = NewSize;
-		}
+		elements.reserve(elements.size() + Grow);
 	}
 
 	void Add(const T& NewItem)
 	{
-		AllocGrow(1);
-		mData[mLength++] = NewItem;
+		elements.push_back(NewItem);
 	}
 
 	T& Add()
 	{
-		AllocGrow(1);
-		mData[mLength++] = T();
-		return mData[mLength - 1];
+		elements.push_back(T());
+		return elements.back();
 	}
 
 	T& InsertAt(int Index)
 	{
-		if (Index >= mLength)
-			AllocGrow(Index - mLength + 1);
-		else
-			AllocGrow(1);
-
-		mLength++;
-		for (int i = mLength - 1; i > Index; i--)
-			mData[i] = mData[i - 1];
-
-		return mData[Index];
+		return elements.insert(Index, T());
 	}
 
 	void InsertAt(int Index, const T& NewItem)
 	{
-		if (Index >= mLength)
-			AllocGrow(Index - mLength + 1);
-		else
-			AllocGrow(1);
-
-		mLength++;
-		for (int i = mLength - 1; i > Index; i--)
-			mData[i] = mData[i - 1];
-
-		mData[Index] = NewItem;
+		elements.insert(elements.begin() + Index, NewItem);
 	}
 
 	void RemoveIndex(int Index)
 	{
-		mLength--;
-
-		for (int i = Index; i < mLength; i++)
-			mData[i] = mData[i + 1];
+		elements.erase(elements.begin() + Index);
 	}
 
 	void Remove(const T& Item)
 	{
-		for (int i = 0; i < mLength; i++)
+		for (size_t i = 0; i < elements.size(); i++)
 		{
-			if (mData[i] == Item)
+			if (elements[i] == Item)
 			{
 				RemoveIndex(i);
 				return;
@@ -208,30 +105,27 @@ public:
 
 	void RemoveAll()
 	{
-		mLength = 0;
+		elements.clear();
 	}
 
 	void DeleteAll()
 	{
-		for (int i = 0; i < mLength; i++)
-			delete mData[i];
+		for (size_t i = 0; i < elements.size(); i++)
+			delete elements[i];
 
-		mLength = 0;
+		elements.clear();
 	}
 
 	int FindIndex(const T& Item) const
 	{
-		for (int i = 0; i < mLength; i++)
-			if (mData[i] == Item)
+		for (size_t i = 0; i < elements.size(); i++)
+			if (elements[i] == Item)
 				return i;
 
 		return -1;
 	}
 
 protected:
-	T* mData;
-	int mLength;
-	size_t mAlloc;
-	int mGrow;
+	std::vector<T> elements;
 };
 

--- a/common/lc_meshloader.cpp
+++ b/common/lc_meshloader.cpp
@@ -417,7 +417,6 @@ void lcMeshLoaderTypeData::AddMeshDataNoDuplicateCheck(const lcMeshLoaderTypeDat
 
 	BaseIndex = mVertices.GetSize();
 
-	mVertices.SetGrow(lcMin(mVertices.GetSize(), 8 * 1024 * 1024));
 	mVertices.AllocGrow(DataVertices.GetSize());
 
 	for (int SrcVertexIdx = 0; SrcVertexIdx < DataVertices.GetSize(); SrcVertexIdx++)
@@ -470,7 +469,6 @@ void lcMeshLoaderTypeData::AddMeshDataNoDuplicateCheck(const lcMeshLoaderTypeDat
 			DstSection = AddSection(PrimitiveType, mMeshData->GetMaterial(ColorCode));
 		}
 
-		DstSection->mIndices.SetGrow(lcMin(DstSection->mIndices.GetSize(), 8 * 1024 * 1024));
 		DstSection->mIndices.AllocGrow(SrcSection->mIndices.GetSize());
 
 		if (PrimitiveType == LC_MESH_CONDITIONAL_LINES)

--- a/common/lc_meshloader.h
+++ b/common/lc_meshloader.h
@@ -55,7 +55,7 @@ class lcMeshLoaderSection
 {
 public:
 	lcMeshLoaderSection(lcMeshPrimitiveType PrimitiveType, lcMeshLoaderMaterial* Material)
-		: mMaterial(Material), mPrimitiveType(PrimitiveType), mIndices(1024, 1024)
+		: mMaterial(Material), mPrimitiveType(PrimitiveType), mIndices(1024)
 	{
 	}
 
@@ -98,8 +98,7 @@ class lcMeshLoaderTypeData
 public:
 	lcMeshLoaderTypeData()
 	{
-		mVertices.SetGrow(1024);
-		mConditionalVertices.SetGrow(1024);
+
 	}
 
 	lcMeshLoaderTypeData(const lcMeshLoaderTypeData&) = delete;

--- a/common/lc_scene.cpp
+++ b/common/lc_scene.cpp
@@ -8,7 +8,7 @@
 #include "object.h"
 
 lcScene::lcScene()
-	: mRenderMeshes(0, 1024), mOpaqueMeshes(0, 1024), mTranslucentMeshes(0, 1024), mInterfaceObjects(0, 1024)
+	: mRenderMeshes(0), mOpaqueMeshes(0), mTranslucentMeshes(0), mInterfaceObjects(0)
 {
 	mActiveSubmodelInstance = nullptr;
 	mDrawInterface = false;


### PR DESCRIPTION
This replaces the custom dynamic allocation logic for `lcArray` with `std::vector`. The standard library vector grows by some factor when resizing to make the insertion cost average out to be roughly constant. The old implementation for `lcArray` appeared to be resizing every N elements for some user configurable N. When loading a large model with roughly 58000 pieces, `Project::load` takes about 3000ms on my machine for the old `lcArray` and 2800ms for the new implementation with `std::vector` when profiling in Visual Studio. Application memory usage in task manager seems to be identical for both versions. Removing `lcArray` entirely is more involved, so I preserved most of the existing API. 