### PR TITLE
chore: bump library in github continuous workflow

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -34,11 +34,11 @@ jobs:
       id: cache-library
       with:
         path: library.bin
-        key: library-20.03
+        key: library-23.01
     - name: Download Library
       if: steps.cache-library.outputs.cache-hit != 'true'
       run: |
-        wget https://github.com/leozide/leocad/releases/download/v19.07.1/Library-20.03.zip -O library.zip
+        wget https://github.com/leozide/leocad/releases/download/v23.03/Library-23.01.zip -O library.zip
         unzip library.zip
     - name: Cache POV-Ray
       uses: actions/cache@v3


### PR DESCRIPTION
Just noticed this was updated in appveyor, but not github actions.

Interesting (to me); is that there are so many CI systems

- travis
- appveyor
- github

Do they all have a dedicated purpose?
Is it documented anywhere?