### PR TITLE
Undo/redo preserve selected step

### DIFF
--- a/common/lc_model.cpp
+++ b/common/lc_model.cpp
@@ -1751,6 +1751,22 @@ void lcModel::LoadCheckPoint(lcModelHistoryEntry* CheckPoint)
 	// Remember the current step
 	const lcStep CurrentStep = mCurrentStep;
 
+	// Remember the camera names
+	std::vector<QString> CameraNames;
+	if (gMainWindow)
+	{
+		std::vector<lcView*> Views = lcView::GetModelViews(this);
+		CameraNames.resize( Views.size() );
+		for (unsigned int i = 0; i < Views.size(); i++)
+		{
+			lcCamera* Camera = Views[i]->GetCamera();
+			if (!Camera->IsSimple() && mCameras.FindIndex(Camera) != -1)
+				CameraNames[i] = Camera->GetName();
+			else
+				CameraNames[i] = "";
+		}
+	}
+
 	DeleteModel();
 
 	QBuffer Buffer(&CheckPoint->File);
@@ -1760,6 +1776,17 @@ void lcModel::LoadCheckPoint(lcModelHistoryEntry* CheckPoint)
 	// Reset the current step
 	mCurrentStep = CurrentStep;
 	CalculateStep(CurrentStep);
+
+	// Reset the cameras
+	if (gMainWindow)
+	{
+		std::vector<lcView*> Views = lcView::GetModelViews(this);
+		for (unsigned int i = 0; i < CameraNames.size(); i++)
+		{
+			if (CameraNames[i] != "")
+				Views[i]->SetCamera(CameraNames[i]);
+		}
+	}
 
 	gMainWindow->UpdateTimeline(true, false);
 	gMainWindow->UpdateCameraMenu();

--- a/common/lc_model.cpp
+++ b/common/lc_model.cpp
@@ -1748,11 +1748,18 @@ void lcModel::LoadCheckPoint(lcModelHistoryEntry* CheckPoint)
 		LoadedInfos.push_back(Info);
 	}
 
+	// Remember the current step
+	const lcStep CurrentStep = mCurrentStep;
+
 	DeleteModel();
 
 	QBuffer Buffer(&CheckPoint->File);
 	Buffer.open(QIODevice::ReadOnly);
 	LoadLDraw(Buffer, lcGetActiveProject());
+
+	// Reset the current step
+	mCurrentStep = CurrentStep;
+	CalculateStep(CurrentStep);
 
 	gMainWindow->UpdateTimeline(true, false);
 	gMainWindow->UpdateCameraMenu();


### PR DESCRIPTION
This fixes an annoying bug, which resets the selected step after undo/redo.

I am not sure whether this is the nicest way for the implementation. Alternatively, one could add a new parameter (desired step) to `LoadLDraw`. I am also not using `SetCurrentStep`, since this would call some update routines twice.

Fixes leozide/leocad#788