### PR TITLE
Fix freeze for find/replace

### DIFF
--- a/common/lc_model.cpp
+++ b/common/lc_model.cpp
@@ -4192,10 +4192,7 @@ void lcModel::FindReplacePiece(bool SearchForward, bool FindAll)
 
 		lcPiece* Current = mPieces[CurrentIdx];
 
-		if (!Current->IsVisible(mCurrentStep))
-			continue;
-
-		if (PieceMatches(Current))
+		if (Current->IsVisible(mCurrentStep) && PieceMatches(Current))
 		{
 			if (FindAll)
 				Selection.Add(Current);


### PR DESCRIPTION
The loop was not terminated properly if pieces were invisible.

Fixes leozide/leocad#901