### PR TITLE
Fix AppImage SSL/TLS certificate issue

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,10 +89,46 @@ for:
       - chmod a+x linuxdeployqt*.AppImage 
       - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
       - export VERSION=$(git rev-parse --short HEAD)
-      - ./linuxdeployqt*.AppImage ./AppDir/usr/share/applications/*.desktop -bundle-non-qt-libs
-      - ./linuxdeployqt*.AppImage --appimage-extract
-      - export PATH=$(readlink -f ./squashfs-root/usr/bin/):$PATH
-      - ./squashfs-root/usr/bin/appimagetool AppDir/
+      ### NEW AppImage config ###
+      - |
+        cat > AppDir/AppRun <<EOF
+        #!/bin/bash -e
+
+        this_dir="\$(readlink -f "\$(dirname "\$0")")"
+        export XDG_DATA_DIRS="\${this_dir}/usr/share:\${XDG_DATA_DIRS}:/usr/share:/usr/local/share"
+        export QT_QPA_PLATFORMTHEME=gtk3
+        unset QT_STYLE_OVERRIDE
+
+        # Find the system certificates location
+        # https://gitlab.com/probono/platformissues/blob/master/README.md#certificates
+        possible_locations=(
+          "/etc/ssl/certs/ca-certificates.crt"                # Debian/Ubuntu/Gentoo etc.
+          "/etc/pki/tls/certs/ca-bundle.crt"                  # Fedora/RHEL
+          "/etc/ssl/ca-bundle.pem"                            # OpenSUSE
+          "/etc/pki/tls/cacert.pem"                           # OpenELEC
+          "/etc/ssl/certs"                                    # SLES10/SLES11, https://golang.org/issue/12139
+          "/usr/share/ca-certs/.prebuilt-store/"              # Clear Linux OS; https://github.com/knapsu/plex-media-player-appimage/issues/17#issuecomment-437710032
+          "/system/etc/security/cacerts"                      # Android
+          "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" # CentOS/RHEL 7
+          "/etc/ssl/cert.pem"                                 # Alpine Linux
+        )
+
+        for location in "\${possible_locations[@]}"; do
+          if [ -r "\${location}" ]; then
+            export SSL_CERT_FILE="\${location}"
+            break
+          fi
+        done
+
+        exec "\${this_dir}/usr/bin/leocad" "\$@"
+        EOF
+      - ./linuxdeployqt*.AppImage ./AppDir/usr/share/applications/*.desktop -appimage -always-overwrite -extra-plugins=tls -no-copy-copyright-files
+      ### OLD AppImage config ###
+      #- ./linuxdeployqt*.AppImage ./AppDir/usr/share/applications/*.desktop -bundle-non-qt-libs
+      #- ./linuxdeployqt*.AppImage --appimage-extract
+      #- export PATH=$(readlink -f ./squashfs-root/usr/bin/):$PATH
+      #- ./squashfs-root/usr/bin/appimagetool AppDir/
+      ### END ###
       - mv ./LeoCAD-$VERSION-x86_64.AppImage ./LeoCAD-Linux-$VERSION-x86_64.AppImage 
       - 'curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/leozide/leocad/commits/master -o repo.txt'
       - 'export REMOTE=$(grep -Po ''(?<=: \")(([a-z0-9])\w+)(?=\")'' -m 1 repo.txt)'


### PR DESCRIPTION
This is a fix for #899 and #835 issues.

Reference:

- https://github.com/probonopd/linuxdeployqt/issues/621#issuecomment-2448965568
  > Key points:
  >
  > - generate your own AppRun instead of default soft link to add some environment variables to make better compatibility
  > - `linuxdeployqt` can generate AppImage directly, so just use `-appimage` is enough. The most important is append `-extra-plugins=tls` to bundle qt `TLS` plugin to support https