### PR TITLE
Enable HTTP redirection on lcHttpManager requests

### DIFF
--- a/common/lc_http.cpp
+++ b/common/lc_http.cpp
@@ -22,10 +22,12 @@ void lcHttpReply::run()
 	static_assert(sizeof(wchar_t) == sizeof(QChar), "Character size mismatch");
 
 	Session = InternetOpen(L"LeoCAD", INTERNET_OPEN_TYPE_PRECONFIG, NULL, NULL, 0);
+
 	if (!Session)
 		return;
 
-	Request = InternetOpenUrl(Session, (WCHAR*)mURL.data(), NULL, 0, 0, 0);
+	Request = InternetOpenUrl(Session, (WCHAR*)mURL.data(), NULL, 0, INTERNET_FLAG_IGNORE_REDIRECT_TO_HTTP, 0);
+
 	if (!Request)
 	{
 		InternetCloseHandle(Session);
@@ -81,10 +83,17 @@ lcHttpManager::lcHttpManager(QObject* Owner)
 
 lcHttpReply* lcHttpManager::lcHttpManager::DownloadFile(const QString& Url)
 {
-    QNetworkRequest req = QNetworkRequest(QUrl(Url));
-    req.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+	QNetworkRequest Request = QNetworkRequest(QUrl(Url));
 
-	return (lcHttpReply*)get(req);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0)) // default changed in Qt6
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 9, 0))
+	Request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+#elif (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+	Request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+#endif
+#endif
+
+	return (lcHttpReply*)get(Request);
 }
 
 void lcHttpManager::Finished(QNetworkReply* Reply)

--- a/common/lc_http.cpp
+++ b/common/lc_http.cpp
@@ -81,7 +81,10 @@ lcHttpManager::lcHttpManager(QObject* Owner)
 
 lcHttpReply* lcHttpManager::lcHttpManager::DownloadFile(const QString& Url)
 {
-	return (lcHttpReply*)get(QNetworkRequest(QUrl(Url)));
+    QNetworkRequest req = QNetworkRequest(QUrl(Url));
+    req.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+
+	return (lcHttpReply*)get(req);
 }
 
 void lcHttpManager::Finished(QNetworkReply* Reply)


### PR DESCRIPTION
This is a modification to class lcHttpManager, so it follows redirections.

Were debugging the blender integration (Blender LDraw Addon #865), which I think is very exiting, and came to see that  the blender integration could not get file: LDrawBlenderRenderAddons.zip, which have two 302 redirects before it gets to the right URL. So enabled HTTP redirection on QNetworkRequest. 

Now the the files can be downloaded, but now there is an python error.
