### PR TITLE
Added json cofiguration feature for Train Track system

### DIFF
--- a/common/lc_traintrack.cpp
+++ b/common/lc_traintrack.cpp
@@ -5,7 +5,6 @@
 #include "piece.h"
 #include "lc_application.h"
 
-#include <iostream>
 // todo:
 // auto replace cross when going over a straight section
 // redo gizmo

--- a/common/lc_traintrack.h
+++ b/common/lc_traintrack.h
@@ -28,7 +28,7 @@ public:
         return relatedPieces[index];
     }
 
-    int Size()
+    size_t Size()
     {
         return relatedPieces.size();
     }

--- a/common/lc_traintrack.h
+++ b/common/lc_traintrack.h
@@ -4,28 +4,51 @@
 
 class lcPiece;
 class lcPiecesLibrary;
+class lcTrainTrackInfo;
+class lcRelatedPiecesGroup;
 
 struct lcTrainTrackConnection
 {
 	lcMatrix44 Transform;
+    lcRelatedPiecesGroup *relatedPiecesGroup;
 };
 
-enum class lcTrainTrackType
+
+class lcRelatedPiecesGroup
 {
-	Straight,
-	Left,
-	Right,
-	BranchLeft,
-	BranchRight,
-	Count
+public:
+
+    void AddRelatedPieceName(PieceInfo* info)
+    {
+        relatedPieces.push_back(info);
+    }
+
+    PieceInfo* GetIndex(int index)
+    {
+        return relatedPieces[index];
+    }
+
+    int Size()
+    {
+        return relatedPieces.size();
+    }
+
+protected:
+    std::vector<PieceInfo*> relatedPieces;
 };
+
 
 class lcTrainTrackInfo
 {
 public:
 	lcTrainTrackInfo() = default;
 
-	std::pair<PieceInfo*, lcMatrix44> GetPieceInsertTransform(lcPiece* Piece, quint32 ConnectionIndex, lcTrainTrackType TrainTrackType) const;
+    lcTrainTrackInfo(PieceInfo* pieceInfo)
+    {
+        mPieceInfo = pieceInfo;
+    }
+
+	std::pair<PieceInfo*, lcMatrix44> GetPieceInsertTransform(lcPiece* Piece, quint32 ConnectionIndex, int relatedPieceIdx) const;
 	static std::optional<lcMatrix44> GetPieceInsertTransform(lcPiece* CurrentPiece, PieceInfo* Info);
 	static std::optional<lcMatrix44> GetConnectionTransform(lcPiece* CurrentPiece, quint32 CurrentConnectionIndex, PieceInfo* Info, quint32 NewConnectionIndex);
 	static int GetPieceConnectionIndex(const lcPiece* Piece1, int ConnectionIndex1, const lcPiece* Piece2);
@@ -40,7 +63,13 @@ public:
 		return mConnections;
 	}
 
+    PieceInfo* GetPieceInfo() {
+        return mPieceInfo;
+    }
+
 protected:
+
+    PieceInfo* mPieceInfo = nullptr;
 	std::vector<lcTrainTrackConnection> mConnections;
 };
 

--- a/common/lc_view.cpp
+++ b/common/lc_view.cpp
@@ -435,9 +435,9 @@ void lcView::UpdatePiecePreview()
 		if (TrainTrackInfo)
 		{
 			quint32 ConnectionIndex = mTrackToolSection & 0xff;
-			lcTrainTrackType TrainTrackType = static_cast<lcTrainTrackType>((mTrackToolSection >> 8) & 0xff);
+			int relatedPieceIdx = (mTrackToolSection >> 8) & 0xff;
 
-			std::tie(PreviewInfo, mPiecePreviewTransform) = TrainTrackInfo->GetPieceInsertTransform(Piece, ConnectionIndex, TrainTrackType);
+			std::tie(PreviewInfo, mPiecePreviewTransform) = TrainTrackInfo->GetPieceInsertTransform(Piece, ConnectionIndex, relatedPieceIdx);
 
 			if (GetActiveModel() != mModel)
 				mPiecePreviewTransform = lcMul(mPiecePreviewTransform, mActiveSubmodelTransform);

--- a/common/lc_viewmanipulator.cpp
+++ b/common/lc_viewmanipulator.cpp
@@ -370,7 +370,8 @@ void lcViewManipulator::DrawSelectMove(lcTrackButton TrackButton, lcTrackTool Tr
 
 void lcViewManipulator::DrawTrainTrack(lcPiece* Piece, lcContext* Context, float OverlayScale)
 {
-	const lcTrainTrackInfo* TrainTrackInfo = Piece->mPieceInfo->GetTrainTrackInfo();
+    lcTrainTrackInfo* TrainTrackInfo = Piece->mPieceInfo->GetTrainTrackInfo();
+
 	const std::vector<lcTrainTrackConnection>& Connections = TrainTrackInfo->GetConnections();
 
 	for (quint32 ConnectionIndex = 0; ConnectionIndex < Connections.size(); ConnectionIndex++)
@@ -380,23 +381,23 @@ void lcViewManipulator::DrawTrainTrack(lcPiece* Piece, lcContext* Context, float
 
 		const lcMatrix44& Transform = Connections[ConnectionIndex].Transform;
 
-		lcVector3 Verts[static_cast<int>(lcTrainTrackType::Count) * 2];
+        lcRelatedPiecesGroup* releatedPieces = Connections[ConnectionIndex].relatedPiecesGroup;
+
+        int noOfPieces = releatedPieces->Size();
+        lcVector3 Verts[noOfPieces * 2];
+
 		int NumVerts = 0;
 
-		Verts[NumVerts++] = Transform.GetTranslation() / OverlayScale;
-		Verts[NumVerts++] = (Transform.GetTranslation() + lcVector3(Transform[0]) * 100) / OverlayScale;
+        int degreeStep = 0;
 
-		Verts[NumVerts++] = Transform.GetTranslation() / OverlayScale;
-		Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * 60)) * 100) / OverlayScale;
+        if(noOfPieces > 1) {
+            degreeStep = 120 / (noOfPieces - 1);
+        }
 
-		Verts[NumVerts++] = Transform.GetTranslation() / OverlayScale;
-		Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * -60)) * 100) / OverlayScale;
-
-		Verts[NumVerts++] = Transform.GetTranslation() / OverlayScale;
-		Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * 30)) * 100) / OverlayScale;
-
-		Verts[NumVerts++] = Transform.GetTranslation() / OverlayScale;
-		Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * -30)) * 100) / OverlayScale;
+        for(int pieceNo = 0; pieceNo < noOfPieces; pieceNo++) {
+		    Verts[NumVerts++] = Transform.GetTranslation() / OverlayScale;
+		    Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * (-60 + (degreeStep * pieceNo) ))) * 100) / OverlayScale;
+        }
 
 		Context->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 
@@ -961,7 +962,7 @@ std::pair<lcTrackTool, quint32> lcViewManipulator::UpdateSelectMove()
 	if (Focus && Focus->IsPiece())
 	{
 		lcPiece* Piece = (lcPiece*)Focus;
-		const lcTrainTrackInfo* TrainTrackInfo = Piece->mPieceInfo->GetTrainTrackInfo();
+        lcTrainTrackInfo* TrainTrackInfo = Piece->mPieceInfo->GetTrainTrackInfo();
 
 		if (TrainTrackInfo)
 		{
@@ -975,14 +976,23 @@ std::pair<lcTrackTool, quint32> lcViewManipulator::UpdateSelectMove()
 					continue;
 
 				const lcMatrix44& Transform = Connections[ConnectionIndex].Transform;
-				lcVector3 Verts[static_cast<int>(lcTrainTrackType::Count)];
+
+                lcRelatedPiecesGroup* releatedPieces = Connections[ConnectionIndex].relatedPiecesGroup;
+                int noOfPieces = releatedPieces->Size();
+
+                lcVector3 Verts[noOfPieces];
+
 				int NumVerts = 0;
 
-				Verts[NumVerts++] = (Transform.GetTranslation() + lcVector3(Transform[0]) * 100) / 1;
-				Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * 60)) * 100) / 1;
-				Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * -60)) * 100) / 1;
-				Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * 30)) * 100) / 1;
-				Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * -30)) * 100) / 1;
+                int degreeStep = 0;
+
+                if(noOfPieces > 1) {
+                    degreeStep = 120 / (noOfPieces - 1);
+                }
+
+                for(int pieceNo = 0; pieceNo < noOfPieces; pieceNo++) {
+                    Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * (-60 + (degreeStep * pieceNo) ))) * 100) / 1;
+                }
 
 				for (int VertexIndex = 0; VertexIndex < NumVerts; VertexIndex++)
 				{

--- a/common/lc_viewmanipulator.cpp
+++ b/common/lc_viewmanipulator.cpp
@@ -384,9 +384,10 @@ void lcViewManipulator::DrawTrainTrack(lcPiece* Piece, lcContext* Context, float
         lcRelatedPiecesGroup* releatedPieces = Connections[ConnectionIndex].relatedPiecesGroup;
 
         int noOfPieces = releatedPieces->Size();
-        lcVector3 Verts[noOfPieces * 2];
+        int NumVerts = noOfPieces * 2;
 
-		int NumVerts = 0;
+        std::vector<lcVector3> Verts;
+        Verts.resize(NumVerts);
 
         int degreeStep = 0;
 
@@ -394,14 +395,15 @@ void lcViewManipulator::DrawTrainTrack(lcPiece* Piece, lcContext* Context, float
             degreeStep = 120 / (noOfPieces - 1);
         }
 
+        int VertsIdx = 0;
         for(int pieceNo = 0; pieceNo < noOfPieces; pieceNo++) {
-		    Verts[NumVerts++] = Transform.GetTranslation() / OverlayScale;
-		    Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * (-60 + (degreeStep * pieceNo) ))) * 100) / OverlayScale;
+		    Verts[VertsIdx++] = Transform.GetTranslation() / OverlayScale;
+		    Verts[VertsIdx++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * (-60 + (degreeStep * pieceNo) ))) * 100) / OverlayScale;
         }
 
 		Context->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 
-		Context->SetVertexBufferPointer(Verts);
+		Context->SetVertexBufferPointer(Verts.data());
 		Context->ClearIndexBuffer();
 		Context->SetVertexFormatPosition(3);
 
@@ -978,11 +980,12 @@ std::pair<lcTrackTool, quint32> lcViewManipulator::UpdateSelectMove()
 				const lcMatrix44& Transform = Connections[ConnectionIndex].Transform;
 
                 lcRelatedPiecesGroup* releatedPieces = Connections[ConnectionIndex].relatedPiecesGroup;
+
                 int noOfPieces = releatedPieces->Size();
+				int NumVerts = noOfPieces;
 
-                lcVector3 Verts[noOfPieces];
-
-				int NumVerts = 0;
+                std::vector<lcVector3> Verts;
+                Verts.resize(NumVerts);
 
                 int degreeStep = 0;
 
@@ -990,8 +993,8 @@ std::pair<lcTrackTool, quint32> lcViewManipulator::UpdateSelectMove()
                     degreeStep = 120 / (noOfPieces - 1);
                 }
 
-                for(int pieceNo = 0; pieceNo < noOfPieces; pieceNo++) {
-                    Verts[NumVerts++] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * (-60 + (degreeStep * pieceNo) ))) * 100) / 1;
+                for(int VertexIndex = 0; VertexIndex < noOfPieces; VertexIndex++) {
+                    Verts[VertexIndex] = (Transform.GetTranslation() + lcMul31(lcVector3(Transform[0]), lcMatrix44RotationZ(LC_DTOR * (-60 + (degreeStep * VertexIndex) ))) * 100) / 1;
                 }
 
 				for (int VertexIndex = 0; VertexIndex < NumVerts; VertexIndex++)

--- a/leocad.qrc
+++ b/leocad.qrc
@@ -149,5 +149,6 @@
         <file>resources/part_flexible.png</file>
         <file>resources/part_traintrack.png</file>
         <file>resources/gear_in.png</file>
+        <file>resources/train_track_editor.json</file>
     </qresource>
 </RCC>

--- a/resources/train_track_editor.json
+++ b/resources/train_track_editor.json
@@ -1,0 +1,365 @@
+{
+    "releated_pieces_groups": [
+        {
+            "name": "TrainTrackSections9v",
+            "filenames": [
+                "2861c04.dat",
+                "32087.dat",
+                "74746.dat",
+                "74747.dat",
+                "2859c04.dat"
+            ]
+        },
+        {
+            "name": "TrainTrackSections12v",
+            "filenames": [
+                "73697ac03.dat",                
+                "3241ac01.dat",
+                "73698.dat",
+                "3240bc02.dat",
+                "73696ac04.dat"                
+            ]
+        },
+        {
+            "name": "TrainTrackSections12vSleeper",
+            "filenames": [
+                "4166a.dat"
+            ]
+        }
+    ],
+
+    "pieces": [
+        {
+            "filename": "2861c04.dat",
+            "connections": [
+                {                    
+                    "transform_x": 320,
+                    "transform_y": 0,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections9v"
+                },
+                {
+                    "transform_x": 333.85324096679688,
+                    "transform_y": 259.10357666015625,
+                    "rotate_z": 22.5,
+                    "connect_group": "TrainTrackSections9v"
+                },
+                {                    
+                    "transform_x": -320,
+                    "transform_y": 0,
+                    "rotate_z": 180,
+                    "connect_group": "TrainTrackSections9v"
+                }
+            ]
+        },
+        {
+            "filename": "32087.dat",
+            "connections": [
+                {                    
+                    "transform_x": 160,
+                    "transform_y": 0,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections9v"
+                },
+                {                    
+                    "transform_x": 0,
+                    "transform_y": 160,
+                    "rotate_z": 90,
+                    "connect_group": "TrainTrackSections9v"
+                },
+                {                    
+                    "transform_x": -160,
+                    "transform_y": 0,
+                    "rotate_z": 180,
+                    "connect_group": "TrainTrackSections9v"
+                },
+                {                    
+                    "transform_x": 0,
+                    "transform_y": -160,
+                    "rotate_z": -90,
+                    "connect_group": "TrainTrackSections9v"
+                }
+            ]
+        },
+        {
+            "filename": "74746.dat",
+            "connections": [
+                {                    
+                    "transform_x": 160,
+                    "transform_y": 0,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections9v"
+                },
+                {
+                    "transform_x": -160,
+                    "transform_y": 0,
+                    "rotate_z": -180,
+                    "connect_group": "TrainTrackSections9v"
+                }
+            ]
+        },
+        {
+            "filename": "74747.dat",
+            "connections": [
+                {                    
+                    "transform_x": 156.072265625,
+                    "transform_y": -15.371826171875,
+                    "rotate_z": -11.25,
+                    "connect_group": "TrainTrackSections9v"
+                },
+                {
+                    "transform_x": -156.072265625,
+                    "transform_y": -15.371826171875,
+                    "rotate_z": -168.75,
+                    "connect_group": "TrainTrackSections9v"
+                }
+            ]
+        },            
+        {
+            "filename": "2859c04.dat",
+            "connections": [
+                {                    
+                    "transform_x": 320,
+                    "transform_y": 0,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections9v"
+                },
+                {
+                    "transform_x": 333.85324096679688,
+                    "transform_y": -259.10357666015625,
+                    "rotate_z": -22.5,
+                    "connect_group": "TrainTrackSections9v"
+                },
+                {                    
+                    "transform_x": -320,
+                    "transform_y": 0,
+                    "rotate_z": 180,
+                    "connect_group": "TrainTrackSections9v"
+                }
+            ]
+        },
+        {
+            "filename": "3241ac01.dat",
+            "connections": [
+                {                    
+                    "transform_x": 156.072265625,
+                    "transform_y": -15.371826171875,
+                    "rotate_z": -11.25,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {
+                    "transform_x": -156.072265625,
+                    "transform_y": -15.371826171875,
+                    "rotate_z": -168.75,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {                    
+                    "transform_x": 156.072265625,
+                    "transform_y": -15.371826171875,
+                    "rotate_z": -11.25,
+                    "transform_z": -8,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                },
+                {
+                    "transform_x": -156.072265625,
+                    "transform_y": -15.371826171875,
+                    "rotate_z": -168.75,
+                    "transform_z": -8,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                }
+
+            ]
+        },
+        {
+            "filename": "3240bc02.dat",
+            "connections": [
+                {                    
+                    "transform_x": 160,
+                    "transform_y": 0,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {
+                    "transform_x": -160,
+                    "transform_y": 0,
+                    "rotate_z": -180,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {
+                    "transform_x": 160,
+                    "transform_y": 0,
+                    "transform_z": -8,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                },
+                {
+                    "transform_x": -160,
+                    "transform_y": 0,
+                    "transform_z": -8,
+                    "rotate_z": 180,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                }
+
+            ]
+        },
+        {
+            "filename": "73697ac03.dat",
+            "connections": [
+                {                    
+                    "transform_x": 320,
+                    "transform_y": 0,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {                    
+                    "transform_x": 320,
+                    "transform_y": 160,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {                    
+                    "transform_x": -320,
+                    "transform_y": 0,
+                    "rotate_z": 180,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {                    
+                    "transform_x": 320,
+                    "transform_y": 0,
+                    "transform_z": -8,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                },
+                {                    
+                    "transform_x": 320,
+                    "transform_y": 160,
+                    "transform_z": -8,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                },
+                {                    
+                    "transform_x": -320,
+                    "transform_y": 0,
+                    "transform_z": -8,
+                    "rotate_z": 180,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                }
+            ]
+        },
+        {
+            "filename": "73696ac04.dat",
+            "connections": [
+                {                    
+                    "transform_x": 320,
+                    "transform_y": 0,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {                    
+                    "transform_x": 320,
+                    "transform_y": -160,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {                    
+                    "transform_x": -320,
+                    "transform_y": 0,
+                    "rotate_z": 180,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {                    
+                    "transform_x": 320,
+                    "transform_y": 0,
+                    "transform_z": -8,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                },
+                {                    
+                    "transform_x": 320,
+                    "transform_y": -160,
+                    "transform_z": -8,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                },
+                {                    
+                    "transform_x": -320,
+                    "transform_y": 0,
+                    "transform_z": -8,
+                    "rotate_z": 180,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                }
+            ]
+        }, 
+        {
+            "filename": "73698.dat",
+            "connections": [
+                {                    
+                    "transform_x": 160,
+                    "transform_y": 0,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {                    
+                    "transform_x": 0,
+                    "transform_y": 160,
+                    "rotate_z": 90,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {                    
+                    "transform_x": -160,
+                    "transform_y": 0,
+                    "rotate_z": 180,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {                    
+                    "transform_x": 0,
+                    "transform_y": -160,
+                    "rotate_z": -90,
+                    "connect_group": "TrainTrackSections12v"
+                },
+                {                    
+                    "transform_x": 160,
+                    "transform_y": 0,
+                    "transform_z": -8,
+                    "rotate_z": 0,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                },
+                {                    
+                    "transform_x": 0,
+                    "transform_y": 160,
+                    "transform_z": -8,
+                    "rotate_z": 90,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                },
+                {                    
+                    "transform_x": -160,
+                    "transform_y": 0,
+                    "transform_z": -8,
+                    "rotate_z": 180,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                },
+                {                    
+                    "transform_x": 0,
+                    "transform_y": -160,
+                    "transform_z": -8,
+                    "rotate_z": -90,
+                    "connect_group": "TrainTrackSections12vSleeper"
+                }
+
+            ]
+        },
+        {
+            "filename": "4166a.dat",
+            "connections": [
+                {                    
+                    "transform_x": 0,
+                    "transform_y": 0,
+                    "transform_z": 8,
+                    "rotate_z": 90
+                    
+                }
+            ]
+        }
+    ]
+    
+}


### PR DESCRIPTION
This feature add **configuration** for **connection points** in the **train track system**.

The json file, can specify **connection points** for any **part type**.

For each **part type**, an arbitrary number of **connection points** can be specified.

Each **connection point** consist of a **position** and **direction**, and a **group of related pieces**, which can be connected to this **connection point**.

**Related pieces groups**, is specified with a **name** and a **list of parts names**.

**Related pieces group** can be related to a **connection point** by **related pieces group name**

The json file is read at startup and the related pieceinfos is updated accordingly.

The json file, now configures the 9 Volt and 12 Volt train track sections, as an example, can easily be expanded.

Kind regards