### PR TITLE
Fixes 'Crash when dropping a new train track piece'

### DIFF
--- a/common/lc_model.cpp
+++ b/common/lc_model.cpp
@@ -4436,8 +4436,11 @@ void lcModel::InsertPieceToolClicked(PieceInfo* Info, const lcMatrix44& WorldMat
 	Piece->UpdatePosition(mCurrentStep);
 	AddPiece(Piece);
 
+
 	gMainWindow->UpdateTimeline(false, false);
 	ClearSelectionAndSetFocus(Piece, LC_PIECE_SECTION_POSITION, false);
+
+	UpdateTrainTrackConnections(Piece);
 
 	SaveCheckpoint(tr("Insert"));
 }


### PR DESCRIPTION
**lcPiece::IsTrainTrackConnected()**, is used before **mTrainTrackConnections** array is set, so **mTrainTrackConnections** array is  accessed outside its bounds.

To fix the probem, **mTrainTrackConnections** is updated, just after the piece is dropped and before it is used.

Compiled with: GNU dialect of g++, C++17
Qt version: Qt 5.15.15 
Ubuntu 24.10

