### PR TITLE
Fix font selection error in manual page.

### DIFF
--- a/docs/leocad.1
+++ b/docs/leocad.1
@@ -162,12 +162,12 @@ High contrast edge color for dark color parts.
 Enable automatically adjusted edge colors.\
 
 .TP
-\fB\-cc \fIfloat\fR,\ \fB\-\-color\-contrast\ \ffloat
+\fB\-cc \fIfloat\fR,\ \fB\-\-color\-contrast\ \fIfloat
 .br
 Set the near and far clipping planes used to render images (1 <= \fInear\fR < \fIfar\fR).
 
 .TP
-\fB\-ldv \fIfloat\fR,\ \fB\-\-light\-dark\-value\ \ffloat
+\fB\-ldv \fIfloat\fR,\ \fB\-\-light\-dark\-value\ \fIfloat
 .br
 Set the value to indicate a light or dark color.
 


### PR DESCRIPTION
Can be seen using:

    man -l docs/leocad.1 > /dev/null

The \f is missing the I, and the f of float is interpreted as the font.