### PR TITLE
Ignore invalid drop in timeline

### DIFF
--- a/common/lc_timelinewidget.cpp
+++ b/common/lc_timelinewidget.cpp
@@ -567,14 +567,14 @@ void lcTimelineWidget::dropEvent(QDropEvent* Event)
 	QList<QTreeWidgetItem*> SelectedItems = selectedItems();
 	clearSelection();
 
-	if (DropItem)
-	{
-		QTreeWidgetItem* ParentItem = DropItem->parent();
-		lcStep Step = indexOfTopLevelItem(ParentItem ? ParentItem : DropItem) + 1;
+	if (!DropItem)
+		return;
 
-		if (Step > Model->GetCurrentStep())
-			Model->SetCurrentStep(Step);
-	}
+	QTreeWidgetItem* ParentItem = DropItem->parent();
+	lcStep Step = indexOfTopLevelItem(ParentItem ? ParentItem : DropItem) + 1;
+
+	if (Step > Model->GetCurrentStep())
+		Model->SetCurrentStep(Step);
 
 	auto SortItems = [this](QTreeWidgetItem* Item1, QTreeWidgetItem* Item2)
 	{

--- a/common/lc_timelinewidget.cpp
+++ b/common/lc_timelinewidget.cpp
@@ -562,16 +562,16 @@ void lcTimelineWidget::ItemSelectionChanged()
 void lcTimelineWidget::dropEvent(QDropEvent* Event)
 {
 	QTreeWidgetItem* DropItem = itemAt(Event->pos());
-	lcModel* Model = gMainWindow->GetActiveModel();
-
-	QList<QTreeWidgetItem*> SelectedItems = selectedItems();
-	clearSelection();
 
 	if (!DropItem)
 		return;
 
+	QList<QTreeWidgetItem*> SelectedItems = selectedItems();
+	clearSelection();
+
 	QTreeWidgetItem* ParentItem = DropItem->parent();
 	lcStep Step = indexOfTopLevelItem(ParentItem ? ParentItem : DropItem) + 1;
+	lcModel* Model = gMainWindow->GetActiveModel();
 
 	if (Step > Model->GetCurrentStep())
 		Model->SetCurrentStep(Step);


### PR DESCRIPTION
Fixes #972

In the timeline widget, if a piece is dropped beyond the last step, it will disappear from the model. Ignore these invalid drag and drops.