### PR TITLE
Fix compiler warning type-limits

### DIFF
--- a/common/lc_library.cpp
+++ b/common/lc_library.cpp
@@ -1087,7 +1087,7 @@ bool lcPiecesLibrary::LoadCacheIndex(const QString& FileName)
 		PieceInfo* Info = PieceIt.second;
 		quint8 Length;
 
-		if (IndexFile.ReadBuffer((char*)&Length, sizeof(Length)) == 0 || Length >= sizeof(Info->m_strDescription))
+		if (IndexFile.ReadBuffer((char*)&Length, sizeof(Length)) == 0)
 			return false;
 
 		if (IndexFile.ReadBuffer((char*)Info->m_strDescription, Length) == 0)


### PR DESCRIPTION
PieceInfo->m_strDescription is 256 bytes long; it can correctly be access for any value of Length (represented by a quint8).

Fix the following compiler warning:

common/lc_library.cpp: In member function ‘bool lcPiecesLibrary::LoadCacheIndex(const QString&)’: common/lc_library.cpp:1090:89: warning: comparison is always false due to limited range of data type [-Wtype-limits]
 1090 |                 if (IndexFile.ReadBuffer((char*)&Length, sizeof(Length)) == 0 || Length >= sizeof(Info->m_strDescription))
      |                                                                                  ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~