### PR TITLE
Blender addon - create addon folder if it does not exist. Fixes #878

### DIFF
--- a/common/lc_blenderpreferences.cpp
+++ b/common/lc_blenderpreferences.cpp
@@ -1513,6 +1513,10 @@ int lcBlenderPreferences::GetBlenderAddon(const QString& BlenderDir)
 				ShowMessage(tr("Failed to rename existing Blender addon archive %1.").arg(BlenderAddonFile));
 		}
 
+		QDir Dir(BlenderDir);
+		if(!Dir.exists())
+			Dir.mkpath(".");
+
 		QString ArchiveFileName, OldArchiveFileName = QFileInfo(OldBlenderAddonFile).fileName();
 		QFile File(BlenderAddonFile);
 		if (File.open(QIODevice::WriteOnly))


### PR DESCRIPTION
This update will create the user Blender folder at /home/\<user\>/.local/share/LeoCAD Software/LeoCAD/Blender if it does not exist.

Cheers,