### PR TITLE
Remove unused QOpenGLFunctions_3_2_Core include

### DIFF
--- a/common/lc_context.cpp
+++ b/common/lc_context.cpp
@@ -12,7 +12,6 @@
 #include "lc_viewmanipulator.h"
 #include "lc_stringcache.h"
 #include "lc_partselectionwidget.h"
-#include <QOpenGLFunctions_3_2_Core>
 
 #ifdef LC_OPENGLES
 #define glEnableClientState(...)

--- a/common/lc_glextensions.cpp
+++ b/common/lc_glextensions.cpp
@@ -1,6 +1,5 @@
 #include "lc_global.h"
 #include "lc_glextensions.h"
-#include <QOpenGLFunctions_3_2_Core>
 
 bool gSupportsShaderObjects;
 bool gSupportsVertexBufferObject;


### PR DESCRIPTION
This fixes compilation when OpenGL ES is used instead.

Ref https://doc.qt.io/qt-6/qopenglwidget.html#opengl-function-calls-headers-and-qopenglfunctions