### PR TITLE
Fix deprecated code

### DIFF
--- a/common/lc_blenderpreferences.cpp
+++ b/common/lc_blenderpreferences.cpp
@@ -455,7 +455,12 @@ lcBlenderPreferences::lcBlenderPreferences(int Width, int Height, double Scale, 
 
 	QCheckBox* AddonVersionCheck = new QCheckBox(tr("Prompt to download new addon version when available"), BlenderAddonVersionBox);
 	AddonVersionCheck->setChecked(lcGetProfileInt(LC_PROFILE_BLENDER_ADDON_VERSION_CHECK));
+	
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+	QObject::connect(AddonVersionCheck, &QCheckBox::checkStateChanged, [](int State)
+#else
 	QObject::connect(AddonVersionCheck, &QCheckBox::stateChanged, [](int State)
+#endif
 	{
 		 const bool VersionCheck = static_cast<Qt::CheckState>(State) == Qt::CheckState::Checked;
 		 lcSetProfileInt(LC_PROFILE_BLENDER_ADDON_VERSION_CHECK, (int)VersionCheck);
@@ -1583,7 +1588,11 @@ int lcBlenderPreferences::GetBlenderAddon(const QString& BlenderDir)
 				while (ReadSize > 0 && (BytesRead = File.read(Buf, ReadSize)) > 0)
 				{
 					DataSize -= BytesRead;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+					Sha256Hash.addData(QByteArrayView(Buf, BytesRead));
+#else
 					Sha256Hash.addData(Buf, BytesRead);
+#endif
 					ReadSize = qMin(DataSize, BufferSize);
 				}
 				File.close();
@@ -3646,7 +3655,12 @@ int lcBlenderPreferences::ShowMessage(QWidget* Parent, const QString& Header,  c
 	{
 		QCheckBox* AddonVersionCheck = new QCheckBox(tr("Do not show download new addon version message again."));
 		Box.setCheckBox(AddonVersionCheck);
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+		QObject::connect(AddonVersionCheck, &QCheckBox::checkStateChanged, [](int State)
+#else
 		QObject::connect(AddonVersionCheck, &QCheckBox::stateChanged, [](int State)
+#endif
 		{
 			bool VersionCheck = true;
 			if (static_cast<Qt::CheckState>(State) == Qt::CheckState::Checked)

--- a/common/lc_propertieswidget.cpp
+++ b/common/lc_propertieswidget.cpp
@@ -151,7 +151,11 @@ void lcPropertiesWidget::AddKeyFrameWidget(lcObjectPropertyId PropertyId)
 	lcKeyFrameWidget* Widget = new lcKeyFrameWidget(this);
 	Widget->setToolTip(tr("Toggle Key Frame"));
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+	connect(Widget, &QCheckBox::checkStateChanged, this, &lcPropertiesWidget::KeyFrameChanged);
+#else
 	connect(Widget, &QCheckBox::stateChanged, this, &lcPropertiesWidget::KeyFrameChanged);
+#endif
 
 	mLayout->addWidget(Widget, mLayoutRow, 3);
 
@@ -234,7 +238,11 @@ void lcPropertiesWidget::AddBoolProperty(lcObjectPropertyId PropertyId, const QS
 	QCheckBox* Widget = new QCheckBox(this);
 	Widget->setToolTip(ToolTip);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+	connect(Widget, &QCheckBox::checkStateChanged, this, &lcPropertiesWidget::BoolChanged);
+#else
 	connect(Widget, &QCheckBox::stateChanged, this, &lcPropertiesWidget::BoolChanged);
+#endif
 
 	mLayout->addWidget(Widget, mLayoutRow, 2);
 

--- a/common/lc_shortcuts.cpp
+++ b/common/lc_shortcuts.cpp
@@ -256,9 +256,15 @@ bool lcMouseShortcuts::Load(const QStringList& FullShortcuts)
 			if (KeySequence.isEmpty())
 				continue;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+			QKeyCombination ShortcutKey = KeySequence[0];
+			Qt::KeyboardModifiers Modifiers = ShortcutKey.keyboardModifiers();
+			Qt::MouseButton Button = (Qt::MouseButton)(1 << (ShortcutKey.key() - Qt::Key_0 - 1));
+#else
 			int ShortcutKey = KeySequence[0];
 			Qt::KeyboardModifiers Modifiers = (Qt::KeyboardModifier)(ShortcutKey & Qt::KeyboardModifierMask);
 			Qt::MouseButton Button = (Qt::MouseButton)(1 << ((ShortcutKey & ~Qt::KeyboardModifierMask) - Qt::Key_0 - 1));
+#endif
 
 			if (!AddedShortcut)
 			{

--- a/common/lc_timelinewidget.cpp
+++ b/common/lc_timelinewidget.cpp
@@ -561,7 +561,11 @@ void lcTimelineWidget::ItemSelectionChanged()
 
 void lcTimelineWidget::dropEvent(QDropEvent* Event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	QTreeWidgetItem* DropItem = itemAt(Event->position().toPoint());
+#else
 	QTreeWidgetItem* DropItem = itemAt(Event->pos());
+#endif
 
 	if (!DropItem)
 		return;

--- a/common/lc_viewwidget.cpp
+++ b/common/lc_viewwidget.cpp
@@ -132,7 +132,12 @@ void lcViewWidget::mousePressEvent(QMouseEvent* MouseEvent)
 {
 	float DeviceScale = GetDeviceScale();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+	mView->SetMousePosition(MouseEvent->position().x() * DeviceScale, mView->GetHeight() - MouseEvent->position().y() * DeviceScale - 1);
+#else
 	mView->SetMousePosition(MouseEvent->x() * DeviceScale, mView->GetHeight() - MouseEvent->y() * DeviceScale - 1);
+#endif
+
 	mView->SetMouseModifiers(MouseEvent->modifiers());
 
 	switch (MouseEvent->button())
@@ -166,7 +171,12 @@ void lcViewWidget::mouseReleaseEvent(QMouseEvent* MouseEvent)
 {
 	float DeviceScale = GetDeviceScale();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+	mView->SetMousePosition(MouseEvent->position().x() * DeviceScale, mView->GetHeight() - MouseEvent->position().y() * DeviceScale - 1);
+#else
 	mView->SetMousePosition(MouseEvent->x() * DeviceScale, mView->GetHeight() - MouseEvent->y() * DeviceScale - 1);
+#endif
+
 	mView->SetMouseModifiers(MouseEvent->modifiers());
 
 	switch (MouseEvent->button())
@@ -200,7 +210,12 @@ void lcViewWidget::mouseDoubleClickEvent(QMouseEvent* MouseEvent)
 {
 	float DeviceScale = GetDeviceScale();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+	mView->SetMousePosition(MouseEvent->position().x() * DeviceScale, mView->GetHeight() - MouseEvent->position().y() * DeviceScale - 1);
+#else
 	mView->SetMousePosition(MouseEvent->x() * DeviceScale, mView->GetHeight() - MouseEvent->y() * DeviceScale - 1);
+#endif
+
 	mView->SetMouseModifiers(MouseEvent->modifiers());
 
 	switch (MouseEvent->button())
@@ -218,7 +233,12 @@ void lcViewWidget::mouseMoveEvent(QMouseEvent* MouseEvent)
 {
 	float DeviceScale = GetDeviceScale();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+	mView->SetMousePosition(MouseEvent->position().x() * DeviceScale, mView->GetHeight() - MouseEvent->position().y() * DeviceScale - 1);
+#else
 	mView->SetMousePosition(MouseEvent->x() * DeviceScale, mView->GetHeight() - MouseEvent->y() * DeviceScale - 1);
+#endif
+
 	mView->SetMouseModifiers(MouseEvent->modifiers());
 
 	mView->OnMouseMove();
@@ -314,8 +334,13 @@ void lcViewWidget::dragMoveEvent(QDragMoveEvent* DragMoveEvent)
 	{
 		float DeviceScale = GetDeviceScale();
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+		mView->SetMousePosition(DragMoveEvent->position().x() * DeviceScale, mView->GetHeight() - DragMoveEvent->position().y() * DeviceScale - 1);
+		mView->SetMouseModifiers(DragMoveEvent->modifiers());
+#else
 		mView->SetMousePosition(DragMoveEvent->pos().x() * DeviceScale, mView->GetHeight() - DragMoveEvent->pos().y() * DeviceScale - 1);
 		mView->SetMouseModifiers(DragMoveEvent->keyboardModifiers());
+#endif
 
 		mView->OnMouseMove();
 

--- a/qt/lc_qutils.cpp
+++ b/qt/lc_qutils.cpp
@@ -8,7 +8,6 @@
 #include "lc_mainwindow.h"
 
 #ifdef Q_OS_WIN
-#include <windows.h>
 #include <TlHelp32.h>
 #endif
 

--- a/qt/lc_qutils.h
+++ b/qt/lc_qutils.h
@@ -2,6 +2,10 @@
 
 #include <QObject>
 
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
 class lcPartSelectionWidget;
 class lcPartSelectionListView;
 struct lcTrainTrackConnectionType;

--- a/qt/qtmain.cpp
+++ b/qt/qtmain.cpp
@@ -156,7 +156,11 @@ int main(int argc, char *argv[])
 		Locale = QLocale(Language);
 
 	QTranslator QtTranslator;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	if (QtTranslator.load(Locale, "qt", "_", QLibraryInfo::path(QLibraryInfo::TranslationsPath)))
+#else
 	if (QtTranslator.load(Locale, "qt", "_", QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
+#endif
 		Application.installTranslator(&QtTranslator);
 #ifdef Q_OS_WIN
 	else if (QtTranslator.load(Locale, "qt", "_", qApp->applicationDirPath() + "/translations"))
@@ -164,7 +168,11 @@ int main(int argc, char *argv[])
 #endif
 
 	QTranslator QtBaseTranslator;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	if (QtBaseTranslator.load("qtbase_" + Locale.name(), QLibraryInfo::path(QLibraryInfo::TranslationsPath)))
+#else
 	if (QtBaseTranslator.load("qtbase_" + Locale.name(), QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
+#endif
 		Application.installTranslator(&QtBaseTranslator);
 #ifdef Q_OS_WIN
 	else if (QtBaseTranslator.load("qtbase_" + Locale.name(), qApp->applicationDirPath() + "/translations"))


### PR DESCRIPTION
Moved all deprecated code into #if...#endif QT_VERSION_CHECK blocks.

* Qt 6.7:
  - QCheckBox: stateChanged() -> checkStateChanged()

* Qt 6.3:
  - QCryptographicHash: addData(const char *data, qsizetype length) -> addData(QByteArrayView bytes)

* Qt 6.0:
  - QDropEvent: pos() -> position() keyboardModifiers() -> modifiers()

  - QKeyCombination (new)

  - QKeySequence: int operator[] -> QKeyCombination operator[]

  - QMouseEvent: x() -> position().x() y() -> position().y()