### PR TITLE
Switch to the Select tool when Escape is pressed in a view

### DIFF
--- a/common/lc_viewwidget.cpp
+++ b/common/lc_viewwidget.cpp
@@ -134,6 +134,14 @@ void lcViewWidget::keyPressEvent(QKeyEvent* KeyEvent)
 		mView->SetMouseModifiers(KeyEvent->modifiers());
 		mView->UpdateCursor();
 	}
+	else if (KeyEvent->key() == Qt::Key_Escape && mView->GetViewType() == lcViewType::View)
+	{
+		if (gMainWindow)
+			gMainWindow->SetTool(lcTool::Select);
+
+		KeyEvent->accept();
+		return;
+	}
 
 	QOpenGLWidget::keyPressEvent(KeyEvent);
 }


### PR DESCRIPTION
## What

Pressing <kbd>Esc</kbd> while a model view has focus now switches back to the default Select tool. This gives a quick keyboard way to exit the Insert, Eraser, or other active tools without reaching for the toolbar.

## Why

<kbd>Esc</kbd> to return to the default/neutral state is a near-universal convention in editing tools, and there is currently no keyboard way to leave a tool such as Insert or Eraser once it is active.

## Why not just an assignable shortcut?

I first tried doing this purely through the existing Preferences keyboard-shortcut system (binding <kbd>Esc</kbd> to `Edit.Tool.Select`), since the project generally prefers user-assignable shortcuts. That did not work: when the OpenGL view (`lcViewWidget`) has focus it receives the key event first, so the `QAction` shortcut (default `WindowShortcut` context) never fires for keys pressed over the 3D view.

Handling <kbd>Esc</kbd> directly in `lcViewWidget::keyPressEvent` is the reliable fix, and a fixed Escape binding is consistent with the universal "escape returns to the default state" convention.

## Implementation

- Handles `Qt::Key_Escape` in `lcViewWidget::keyPressEvent` and calls `gMainWindow->SetTool(lcTool::Select)`.
- Limited to the main model view (`lcViewType::View`) so it does not affect preview widgets.
- Null-checks `gMainWindow`, accepts the event, and falls through to the default handler for every other key, leaving existing Ctrl/Shift handling untouched.
- Intentionally scoped to *only* switching tools: it does not clear the selection or cancel in-progress tracking, to keep the behavior predictable and the change minimal.