### PR TITLE
Set desktop file name for the application

### DIFF
--- a/qt/qtmain.cpp
+++ b/qt/qtmain.cpp
@@ -142,6 +142,7 @@ int main(int argc, char *argv[])
 	QCoreApplication::setOrganizationName(QLatin1String("LeoCAD Software"));
 	QCoreApplication::setApplicationName(QLatin1String("LeoCAD"));
 	QCoreApplication::setApplicationVersion(QLatin1String(LC_VERSION_TEXT));
+	QGuiApplication::setDesktopFileName(QLatin1String("leocad"));
 
 	lcInitializeSurfaceFormat(argc, argv);
 


### PR DESCRIPTION
This ensures that the XDG toplevel app ID matches with the desktop file name, so Wayland compositors could match the window with the application and show the appropriate icon for them.

Without this change, the app ID is `org.leocad.leocad`, but the desktop file is called as [`leocad`](https://github.com/leozide/leocad/blob/9dd9208067d4b25107e6e00ca097a0d7ba42ddbe/qt/leocad.desktop).

References:
- https://github.com/qt/qtbase/blob/bf1ae5862807ec2b9a411506d59ccd566937a4c7/src/plugins/platforms/wayland/qwaylandwindow.cpp#L152C20-L177
- https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id